### PR TITLE
chore: add dependencies-action, PR labeler, and CI standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report something that is broken or not working as expected
+title: 'fix: '
+labels: ['bug']
+assignees: ''
+---
+
+## Description
+<!-- A clear and concise description of the bug -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behavior
+<!-- What did you expect to happen? -->
+
+## Actual behavior
+<!-- What actually happened? -->
+
+## Environment
+- OS: 
+- Python/Node version:
+- Relevant versions:
+
+## Additional context

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,19 @@
+---
+name: Maintenance chore
+about: Track technical debt, refactoring, or infrastructure work
+title: 'chore: '
+labels: ['chore']
+assignees: ''
+---
+
+## Summary
+<!-- What needs to be done? -->
+
+## Background
+<!-- Why is this needed? -->
+
+## Tasks
+- [ ]
+- [ ]
+
+## Definition of done

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Propose a new feature or enhancement
+title: 'feat: '
+labels: ['enhancement']
+assignees: ''
+---
+
+## Summary
+<!-- Brief description of the feature -->
+
+## Motivation
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Proposed solution
+<!-- How should this be implemented? -->
+
+## Acceptance criteria
+- [ ]
+- [ ]
+
+## Additional context

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,45 @@
+# Auto-labeling rules for pull requests
+# See: https://github.com/actions/labeler
+
+ci:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '.github/workflows/**'
+                - '.github/dependabot.yml'
+
+pre-commit:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '.pre-commit-config.yaml'
+                - '.pre-commit-hooks.yaml'
+
+documentation:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '*.md'
+                - 'docs/**'
+                - 'README*'
+
+dependencies:
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'pyproject.toml'
+                - 'requirements*.txt'
+                - 'package.json'
+                - 'package-lock.json'
+
+configuration:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '*.toml'
+                - '*.yml'
+                - '*.yaml'
+                - '*.json'
+                - '.env*'
+                - 'Makefile'
+
+templates:
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'templates/**'
+                - 'workflows/**'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+<!-- Briefly describe what this PR does -->
+
+## Motivation
+<!-- Why is this change needed? Link to issues/Notion pages -->
+
+Closes #<!-- issue number -->
+
+## Changes
+<!-- List the changes made -->
+
+## Dependencies
+<!-- List any PRs this depends on (if any). Format: depends on chrysa/REPO#NUMBER -->
+
+## Testing
+<!-- How was this tested? -->
+
+## Checklist
+- [ ] Conventional commit messages
+- [ ] Pre-commit hooks pass locally
+- [ ] CI is green
+- [ ] README updated (if applicable)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+---
+name: CI
+
+on:
+    push:
+        branches:
+            - main
+            - master
+    pull_request:
+        branches:
+            - main
+            - master
+
+permissions:
+    contents: read
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        name: Lint & validate
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: '3.12'
+
+            - name: Run pre-commit hooks
+              uses: pre-commit/action@v3.0.1
+
+    validate-templates:
+        runs-on: ubuntu-latest
+        name: Validate template YAML/JSON
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Validate YAML templates
+              run: |
+                  find templates/ workflows/ -name "*.yml" -o -name "*.yaml" 2>/dev/null | \
+                    while read f; do python3 -c "import yaml,sys; yaml.safe_load(open('$f'))" || exit 1; done
+                  echo "All YAML templates valid"
+
+            - name: Validate JSON templates
+              run: |
+                  find templates/ -name "*.json" 2>/dev/null | \
+                    while read f; do python3 -m json.tool "$f" > /dev/null || exit 1; done
+                  echo "All JSON templates valid"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,35 @@
+---
+name: PR Dependency Check
+
+on:
+    pull_request_target:
+        types: [closed, edited, opened, reopened]
+
+permissions:
+    issues: write
+    pull-requests: write
+
+jobs:
+    check_dependencies:
+        runs-on: ubuntu-latest
+        name: Check PR dependencies
+
+        steps:
+            - name: Check dependencies
+              uses: gregsdennis/dependencies-action@main
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Add dependent label
+              if: >-
+                  contains(github.event.pull_request.body, 'depends on') ||
+                  contains(github.event.pull_request.body, 'blocked by')
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      await github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.payload.pull_request.number,
+                        labels: ['dependent'],
+                      });

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+---
+name: PR Labeler
+
+on:
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    labeler:
+        runs-on: ubuntu-latest
+        name: Label PR
+
+        steps:
+            - uses: actions/labeler@v5
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Python
+__pycache__/
+*.py[cod]
+*.so
+.venv/
+venv/
+*.egg-info/
+dist/
+build/
+
+# Node
+node_modules/
+.npm/
+
+# Editors
+.vscode/settings.json
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Secrets
+.env
+.env.local
+*.pem
+*.key
+
+# Pre-commit
+.pre-commit-config.yaml.bak

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+---
+default_language_version:
+    python: python3
+fail_fast: false
+minimum_pre_commit_version: 4.1.0
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: f1dff44d3a9ae852957f34def96390f28719c232
+      hooks:
+          - id: check-json
+          - id: check-yaml
+          - id: trailing-whitespace
+          - id: end-of-file-fixer
+          - id: detect-private-key
+          - id: no-commit-to-branch
+            args: [--branch, main]
+    - repo: https://github.com/igorshubovych/markdownlint-cli
+      rev: f7ed74202ac8ec26bab4a68359556c5243df142f
+      hooks:
+          - id: markdownlint
+            args: [--fix]
+            stages: [manual]
+    - repo: https://github.com/chrysa/pre-commit-tools
+      rev: 78d8bd3118110cc9095fcd61eb4772061c3ab628
+      hooks:
+          - id: yaml-sorter
+            exclude: ^\.github/
+          - id: json-sorter
+          - id: env-file-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# shared-standards
+
+## Project Overview
+Shared GitHub Copilot instructions, Claude Code DevEx hooks, reusable CI templates,
+and standards for the chrysa ecosystem.
+
+## Repository Structure
+```
+.claude/hooks/          # Claude Code DevEx hooks (circuit breaker, secret scanner, etc.)
+.claude/settings.json   # Claude Code hook configuration
+copilot-instructions/   # GitHub Copilot instruction templates
+templates/              # Bootstrap file templates (CLAUDE.md, .gitignore, dependabot.yml, etc.)
+workflows/              # Reusable GitHub Actions workflow templates
+```
+
+## Development Setup
+```bash
+make install  # Install pre-commit hooks
+make lint     # Run pre-commit on all files
+```
+
+## Adding a new hook
+1. Create `hooks/<name>.cjs` in `.claude/hooks/`
+2. Add it to `.claude/settings.json` under the correct lifecycle event
+3. Document it in `.claude/HOOKS_README.md`
+4. Tag model-specific rules with `@[MODEL_NAME]`
+
+## Adding a new template
+1. Create the file in `templates/` (or `workflows/`)
+2. Use `${REPO_NAME}`, `${DESCRIPTION}` placeholders for project-init substitution
+3. Update `README.md` with the new template reference
+
+## CI/CD
+- Pre-commit: `.pre-commit-config.yaml`
+- CI validation: `.github/workflows/ci.yml`
+- PR labeler: `.github/workflows/labeler.yml`
+- PR dependency check: `.github/workflows/dependencies.yml`
+
+## Code Standards
+- All commit messages: Conventional Commits format
+- All YAML files sorted (via yaml-sorter) except `.github/` workflows
+- Templates must be valid YAML/JSON (validated in CI)
+
+## Key Hooks
+| Hook | Event | Purpose |
+|------|-------|---------|
+| secret-scanner.cjs | PreToolUse (git commit) | Block secrets from being committed |
+| circuit-breaker.cjs | PreToolUse (API calls) | Prevent repeated failing API calls |
+| frustration-detection.cjs | UserPromptSubmit | Inject context on frustrating prompts |
+| verifiable-thresholds.cjs | PostToolUse (file writes) | Warn on quality threshold violations |
+| memory-consolidation.cjs | CLI | Consolidate and compress memory files |
+| model-debt-inventory.cjs | CLI | Audit model-specific tagged rules |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: help install lint pre-commit
+
+help:
+	@echo "Available targets:"
+	@echo "  install     Install pre-commit hooks"
+	@echo "  lint        Run pre-commit hooks"
+	@echo "  pre-commit  Run all pre-commit checks"
+
+install:
+	pre-commit install
+
+lint:
+	pre-commit run --all-files
+
+pre-commit:
+	pre-commit run --all-files

--- a/templates/.gitignore.node
+++ b/templates/.gitignore.node
@@ -1,0 +1,40 @@
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+.npm
+
+# Build output
+dist/
+build/
+.next/
+.nuxt/
+.cache/
+.parcel-cache/
+out/
+
+# Coverage
+coverage/
+*.lcov
+.nyc_output
+
+# Misc
+.DS_Store
+*.pem
+.env
+.env.local
+.env.*.local
+
+# Editors
+.vscode/settings.json
+.idea/
+*.swp
+*.swo
+*~
+
+# TypeScript
+*.tsbuildinfo
+next-env.d.ts

--- a/templates/.gitignore.python
+++ b/templates/.gitignore.python
@@ -1,0 +1,78 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# PyInstaller
+*.manifest
+*.spec
+
+# dist
+dist/
+
+# Test
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+htmlcov/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# ruff
+.ruff_cache/
+
+# Editors
+.vscode/settings.json
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Secrets
+.env
+.env.local
+.env.*
+!.env.example
+*.pem
+*.key

--- a/templates/pr-template.md
+++ b/templates/pr-template.md
@@ -1,0 +1,22 @@
+## Summary
+<!-- Briefly describe what this PR does -->
+
+## Motivation
+<!-- Why is this change needed? Link to issues/Notion pages -->
+
+Closes #<!-- issue number -->
+
+## Changes
+<!-- List the changes made -->
+
+## Dependencies
+<!-- List any PRs this depends on (if any). Format: depends on chrysa/REPO#NUMBER -->
+
+## Testing
+<!-- How was this tested? -->
+
+## Checklist
+- [ ] Conventional commit messages
+- [ ] Pre-commit hooks pass locally
+- [ ] CI is green
+- [ ] README updated (if applicable)

--- a/workflows/ci-node.yml
+++ b/workflows/ci-node.yml
@@ -1,0 +1,41 @@
+---
+# Reusable CI workflow for Node.js/React projects (chrysa ecosystem)
+# Usage: copy to .github/workflows/ci.yml and adapt.
+
+name: CI Node
+
+on:
+    push:
+        branches: [main, master]
+    pull_request:
+        branches: [main, master]
+
+permissions:
+    contents: read
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        name: Lint & pre-commit
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+                  cache: 'npm'
+            - run: npm ci
+            - name: Lint
+              run: npm run lint
+
+    test:
+        runs-on: ubuntu-latest
+        name: Tests
+        needs: lint
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+                  cache: 'npm'
+            - run: npm ci
+            - run: npm test

--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -1,0 +1,42 @@
+---
+# Reusable CI workflow for Python projects (chrysa ecosystem)
+# Usage: uses: chrysa/shared-standards/.github/workflows/ci-python.yml@main
+#
+# Or copy this file to .github/workflows/ci.yml and adapt.
+
+name: CI Python
+
+on:
+    push:
+        branches: [main, master]
+    pull_request:
+        branches: [main, master]
+
+permissions:
+    contents: read
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        name: Lint & pre-commit
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: '3.12'
+            - name: Run pre-commit
+              uses: pre-commit/action@v3.0.1
+
+    test:
+        runs-on: ubuntu-latest
+        name: Tests
+        needs: lint
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: '3.12'
+            - name: Install dependencies
+              run: pip install -e ".[dev]"
+            - name: Run pytest
+              run: pytest --tb=short


### PR DESCRIPTION
## Summary

Full scaffold initialization for `chrysa/shared-standards`.

## Changes

- `.gitignore`
- `CLAUDE.md` — root project context
- `Makefile` — `install`, `lint`, `pre-commit` targets
- `.pre-commit-config.yaml` — using `chrysa/pre-commit-tools`
- `.github/workflows/ci.yml` — lint + template validation
- `.github/workflows/dependencies.yml` — PR dependency check
- `.github/workflows/labeler.yml` — PR auto-labeling
- `.github/labeler.yml` — labeling rules (includes `templates:` label)
- `.github/dependabot.yml` — GitHub Actions weekly updates
- `.github/pull_request_template.md`
- `.github/ISSUE_TEMPLATE/` — bug, feature, chore templates
- `templates/.gitignore.python`, `templates/.gitignore.node`
- `templates/pr-template.md`
- `workflows/ci-python.yml`, `workflows/ci-node.yml` — reusable CI templates

## Related

Part of chrysa ecosystem standardization. `project-init` will use these templates as its source.
