### PR TITLE
fix(claude): use relative paths in hooks settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /home/anthony/Documents/perso/projects/chrysa/shared-standards/.claude/hooks/secret-scanner.cjs"
+            "command": "node .claude/hooks/secret-scanner.cjs"
           },
           {
             "type": "command",
-            "command": "node /home/anthony/Documents/perso/projects/chrysa/shared-standards/.claude/hooks/circuit-breaker.cjs"
+            "command": "node .claude/hooks/circuit-breaker.cjs"
           }
         ]
       }
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /home/anthony/Documents/perso/projects/chrysa/shared-standards/.claude/hooks/verifiable-thresholds.cjs"
+            "command": "node .claude/hooks/verifiable-thresholds.cjs"
           }
         ]
       }
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node /home/anthony/Documents/perso/projects/chrysa/shared-standards/.claude/hooks/frustration-detection.cjs"
+            "command": "node .claude/hooks/frustration-detection.cjs"
           }
         ]
       }


### PR DESCRIPTION
## Problem

The `.claude/settings.json` file used absolute paths for hook commands:
```
node /home/anthony/Documents/perso/projects/chrysa/shared-standards/.claude/hooks/...
```

These paths only work on one specific machine, making the configuration non-portable.

## Fix

Replaced all absolute paths with relative paths:
```
node .claude/hooks/secret-scanner.cjs
node .claude/hooks/circuit-breaker.cjs
node .claude/hooks/verifiable-thresholds.cjs
node .claude/hooks/frustration-detection.cjs
```

Claude runs hooks from the project root directory, so relative paths resolve correctly regardless of where the project is cloned.

Closes #3