### PR TITLE
chore: upgrade workflow templates to checkout@v6, setup-python@v6, node 22

### DIFF
--- a/workflows/ci-node.yml
+++ b/workflows/ci-node.yml
@@ -18,10 +18,10 @@ jobs:
         runs-on: ubuntu-latest
         name: Lint & pre-commit
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '22'
                   cache: 'npm'
             - run: npm ci
             - name: Lint
@@ -32,10 +32,10 @@ jobs:
         name: Tests
         needs: lint
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '22'
                   cache: 'npm'
             - run: npm ci
             - run: npm test

--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -20,8 +20,8 @@ jobs:
         runs-on: ubuntu-latest
         name: Lint & pre-commit
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
               with:
                   python-version: '3.12'
             - name: Run pre-commit
@@ -32,8 +32,8 @@ jobs:
         name: Tests
         needs: lint
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
               with:
                   python-version: '3.12'
             - name: Install dependencies


### PR DESCRIPTION
## Changements

Met à jour les templates de workflows réutilisables pour Node.js 22 runtime (deadline : septembre 2026) :

### `workflows/ci-python.yml`
- `actions/checkout@v4 → @v6`
- `actions/setup-python@v5 → @v6`

### `workflows/ci-node.yml`
- `actions/checkout@v4 → @v6`
- `node-version: '20' → '22'`

## Closes

Closes #4