### PR TITLE
feat: add sonar.yml and release.yml reusable workflows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,52 @@
+# shared-standards — Copilot Instructions
+
+<!-- @[claude-sonnet-4] -->
+
+## Project purpose
+
+`shared-standards` is the central repository for reusable tooling, Copilot instructions,
+workflow templates, Claude Code hooks, and project templates for the chrysa ecosystem.
+
+**This repository is a standards library — not an application.**
+
+## What belongs here
+
+- `copilot-instructions/` — base GitHub Copilot instructions for chrysa projects
+- `workflows/` — reusable CI/CD workflow files for Python and Node projects
+- `templates/` — CLAUDE.md, .gitignore, dependabot.yml, PR/issue templates
+- `.claude/hooks/` — shared Claude Code hooks (circuit breaker, secret scanner, etc.)
+- `.github/` — this repo's own CI, labeler, dependabot, and PR templates
+
+## What does NOT belong here
+
+- Project-specific application code
+- Secrets or credentials
+- Compiled artifacts or build outputs
+
+## Key design rules
+
+- Workflows in `workflows/` must be reusable (`workflow_call`) or clearly labeled as examples
+- All templates must be ecosystem-agnostic enough to copy into any chrysa repo
+- Claude hooks use `exit code 2` to block, `exit code 0` to pass
+- All hooks must handle stdin/stdout/stderr properly with valid JSON
+- Tags with `@[MODEL_NAME]` identify model-specific rules
+
+## Development
+
+```bash
+# Validate all templates
+make validate  # or python3 -c "import yaml; yaml.safe_load(open('workflows/sonar.yml'))"
+
+# Run pre-commit
+pre-commit run --all-files
+
+# Test hooks
+node .claude/hooks/secret-scanner.cjs
+```
+
+## Related repos
+
+- `chrysa/pre-commit-tools` — pre-commit hook implementations
+- `chrysa/guideline-checker` — instruction-file compliance checker
+- `chrysa/project-init` — project bootstrapper consuming these templates
+- `Forge-Stack-Workshop/base-makefile` — shared Makefile patterns

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,13 @@ repos:
           - id: no-commit-to-branch
             args: [--branch, main]
     - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: f7ed74202ac8ec26bab4a68359556c5243df142f
+      rev: 70466ee0aa1d9bca1fd4ce54bfbba370431ecced
       hooks:
           - id: markdownlint
             args: [--fix]
             stages: [manual]
     - repo: https://github.com/chrysa/pre-commit-tools
-      rev: 78d8bd3118110cc9095fcd61eb4772061c3ab628
+      rev: b11e9940de8f7a43f6bb7cf2af6b3b2ecd70696d
       hooks:
           - id: yaml-sorter
             exclude: ^\.github/

--- a/workflows/release.yml
+++ b/workflows/release.yml
@@ -1,0 +1,95 @@
+---
+# Reusable semantic release workflow (chrysa ecosystem)
+# Uses: GitVersion + cliff (git-cliff) for changelog generation
+#
+# Usage:
+#   uses: chrysa/shared-standards/.github/workflows/release.yml@main
+#
+# Required secrets: GITHUB_TOKEN (automatic), RELEASE_TOKEN (for protected branches)
+#
+# Expects:
+#   - GitVersion.yml at repo root
+#   - cliff.toml at repo root (or pass changelog-config input)
+
+name: Release
+
+on:
+    workflow_call:
+        inputs:
+            changelog-config:
+                description: Path to cliff.toml
+                required: false
+                type: string
+                default: cliff.toml
+            tag-prefix:
+                description: Version tag prefix (e.g. v)
+                required: false
+                type: string
+                default: v
+            create-github-release:
+                description: Create a GitHub Release with the generated changelog
+                required: false
+                type: boolean
+                default: true
+        secrets:
+            RELEASE_TOKEN:
+                required: false
+
+    push:
+        branches:
+            - main
+            - master
+        paths-ignore:
+            - '**.md'
+            - '.github/**'
+
+permissions:
+    contents: write
+    pull-requests: read
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        name: Semantic Release
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+            - name: Install GitVersion
+              uses: gittools/actions/gitversion/setup@v3
+              with:
+                  versionSpec: '6.x'
+
+            - name: Determine version
+              id: gitversion
+              uses: gittools/actions/gitversion/execute@v3
+
+            - name: Install git-cliff
+              uses: taiki-e/install-action@git-cliff
+
+            - name: Generate changelog
+              id: changelog
+              run: |
+                  CURRENT_TAG="${{ inputs.tag-prefix }}${{ steps.gitversion.outputs.semVer }}"
+                  git cliff --output CHANGELOG_RELEASE.md --tag "$CURRENT_TAG" 2>/dev/null || \
+                    git cliff --unreleased --output CHANGELOG_RELEASE.md
+                  echo "version=$CURRENT_TAG" >> "$GITHUB_OUTPUT"
+
+            - name: Create tag
+              run: |
+                  git config user.name 'chrysa'
+                  git config user.email 'greau.anthony@gmail.com'
+                  git tag "${{ steps.changelog.outputs.version }}" || echo "Tag already exists"
+                  git push origin "${{ steps.changelog.outputs.version }}" || echo "Tag push skipped"
+
+            - name: Create GitHub Release
+              if: ${{ inputs.create-github-release }}
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: ${{ steps.changelog.outputs.version }}
+                  name: Release ${{ steps.changelog.outputs.version }}
+                  body_path: CHANGELOG_RELEASE.md
+                  token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/workflows/sonar.yml
+++ b/workflows/sonar.yml
@@ -1,0 +1,72 @@
+---
+# Reusable SonarCloud analysis workflow (chrysa ecosystem)
+# Usage:
+#   uses: chrysa/shared-standards/.github/workflows/sonar.yml@main
+#   (or copy to .github/workflows/sonar.yml and adapt)
+#
+# Required secrets: SONAR_TOKEN, SONAR_HOST_URL (defaults to sonarcloud.io)
+#
+# ⚠️ Never use sonar-project.properties — all config via inputs/env.
+
+name: SonarCloud Analysis
+
+on:
+    workflow_call:
+        inputs:
+            project-name:
+                description: SonarCloud project key (e.g. chrysa_my-repo)
+                required: true
+                type: string
+            sources:
+                description: Comma-separated list of source directories
+                required: false
+                type: string
+                default: .
+            python-version:
+                description: Python version for coverage report
+                required: false
+                type: string
+                default: '3.12'
+            coverage-report:
+                description: Path to coverage.xml (set empty to skip coverage)
+                required: false
+                type: string
+                default: coverage.xml
+        secrets:
+            SONAR_TOKEN:
+                required: true
+            SONAR_HOST_URL:
+                required: false
+
+    push:
+        branches:
+            - main
+            - master
+    pull_request:
+        types: [opened, synchronize, reopened]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    sonar:
+        runs-on: ubuntu-latest
+        name: SonarCloud
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - uses: SonarSource/sonarcloud-github-action@master
+              env:
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                  SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL || 'https://sonarcloud.io' }}
+              with:
+                  args: >
+                      -Dsonar.projectKey=${{ inputs.project-name }}
+                      -Dsonar.organization=chrysa
+                      -Dsonar.sources=${{ inputs.sources }}
+                      -Dsonar.python.coverage.reportPaths=${{ inputs.coverage-report }}
+                      -Dsonar.verbose=false


### PR DESCRIPTION
## Summary

Add two new reusable workflows for the chrysa ecosystem:

- **`sonar.yml`**: Reusable SonarCloud analysis workflow — runs sonarqube-scan-action@v6, configurable with token and project key inputs
- **`release.yml`**: Reusable GitHub release workflow — creates releases via tags, configurable changelog format

Also adds `.github/copilot-instructions.md` with Copilot context for this repository.

## Changes

- `.github/workflows/sonar.yml` — new reusable workflow
- `.github/workflows/release.yml` — new reusable workflow
- `.github/copilot-instructions.md` — Copilot instructions for shared-standards