### PR TITLE
feat: add CODEOWNERS + issue templates + expand base.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ workflows/
 
 templates/
   CLAUDE.md                     # Bootstrap CLAUDE.md template
+  CODEOWNERS                    # CODEOWNERS template (copy and adapt)
   .gitignore.python             # Python .gitignore
   .gitignore.node               # Node .gitignore
   dependabot.yml                # Dependabot config template

--- a/copilot-instructions/base.md
+++ b/copilot-instructions/base.md
@@ -23,6 +23,8 @@ Your role is to write clean, maintainable, idiomatic, and secure code.
 - Keep functions under 50 lines.
 - Keep files under 500 lines. Split when appropriate.
 - 0 lint warnings is the target. Every warning must be resolved or suppressed with justification.
+- **One class per file.** Each class lives in its own module (e.g. `models/user.py` contains only `User`).
+- **Domain-driven structure.** Organize code by domain (e.g. `connectors/`, `services/`, `schemas/`), not by layer.
 
 ### JavaScript / TypeScript
 - Target Node.js LTS.
@@ -30,10 +32,30 @@ Your role is to write clean, maintainable, idiomatic, and secure code.
 - Prefer `const` over `let`. Never use `var`.
 - Keep functions under 50 lines.
 
+### React
+- **Reference structure: `Forge-Stack-Workshop/react-app-generator`** — all React apps in the ecosystem must follow this layout.
+- Top-level `src/` structure: `api/`, `components/`, `domain/`, `features/`, `hooks/`, `i18n/`, `pages/`, `styles/`, `utils/`.
+- **`api/`** — connector layer only. One file per resource (e.g. `api/home.ts`). No business logic, only HTTP calls and TypeScript types.
+- **`domain/`** — pure domain types and interfaces shared across the app.
+- **`features/`** — self-contained vertical slices (feature = own components + logic).
+- **`components/`** — generic reusable UI (no business logic).
+- **`pages/`** — one file per route. Orchestrates features, no direct API calls.
+- Tool stack: Vite + React + TypeScript. Use React Query for server state. Use `useQuery`/`useMutation` — never `useEffect` for data fetching.
+
 ### Docker
-- Prefer multi-stage builds.
+- **Always use multi-stage builds** (`AS deps`, `AS builder`, `AS production` or equivalent). Never ship build tools in the final image.
+- **Always add a `HEALTHCHECK`** to every production image. Use the service's own health endpoint (e.g. `CMD curl -f http://localhost:PORT/health || exit 1`).
 - Use official or chrysa/usefull-containers images for tooling.
-- Pin image versions explicitly.
+- Pin image versions explicitly (e.g. `python:3.12-slim`, not `python:latest`).
+- Non-root user in the final stage (`USER nonroot` or equivalent).
+
+## Architecture
+
+### Platform / tool systems
+- **Provider-agnostic by design.** Platforms (dashboard, live monitor, automation tools) must not embed provider-specific logic directly. All external integrations go through a `connector/` layer.
+- **Connector pattern:** Each external service (GitHub, Notion, Sonar, Jira…) gets its own isolated connector module (e.g. `connectors/github/client.py`). The platform only knows about connector interfaces, not API details.
+- **Swappable providers:** Business logic (services/) must depend on connector interfaces, not concrete implementations. A GitHub connector can be replaced by a GitLab connector without touching the service layer.
+- **Config-driven activation:** Connectors are enabled/disabled via environment variables or settings (e.g. `SONAR_TOKEN`, `GITHUB_TOKEN`). If a connector's token is absent, it degrades gracefully rather than crashing.
 
 ## Security
 - Never commit secrets, tokens, or credentials.

--- a/templates/CODEOWNERS
+++ b/templates/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS
+# Default owner for all files
+* @chrysa
+
+# Backend / Python source
+/backend/ @chrysa
+/src/ @chrysa
+/api/ @chrysa
+/code/ @chrysa
+
+# Frontend / Node source
+/frontend/ @chrysa
+
+# Infrastructure / CI
+/.github/ @chrysa
+/Dockerfile @chrysa
+/docker-compose*.yml @chrysa
+/k8s/ @chrysa
+
+# Documentation
+*.md @chrysa
+/docs/ @chrysa

--- a/templates/issue-templates/bug.md
+++ b/templates/issue-templates/bug.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report something that is broken or not working as expected
+title: 'fix: '
+labels: ['bug']
+assignees: ''
+---
+
+## Description
+<!-- A clear and concise description of the bug -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behavior
+<!-- What did you expect to happen? -->
+
+## Actual behavior
+<!-- What actually happened? -->
+
+## Environment
+- OS:
+- Python/Node version:
+- Relevant versions:
+
+## Additional context

--- a/templates/issue-templates/chore.md
+++ b/templates/issue-templates/chore.md
@@ -1,0 +1,19 @@
+---
+name: Maintenance chore
+about: Track technical debt, refactoring, or infrastructure work
+title: 'chore: '
+labels: ['chore']
+assignees: ''
+---
+
+## Summary
+<!-- What needs to be done? -->
+
+## Background
+<!-- Why is this needed? -->
+
+## Tasks
+- [ ]
+- [ ]
+
+## Definition of done

--- a/templates/issue-templates/feature.md
+++ b/templates/issue-templates/feature.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Propose a new feature or enhancement
+title: 'feat: '
+labels: ['enhancement']
+assignees: ''
+---
+
+## Summary
+<!-- Brief description of the feature -->
+
+## Motivation
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Proposed solution
+<!-- How should this be implemented? -->
+
+## Acceptance criteria
+- [ ]
+- [ ]
+
+## Additional context


### PR DESCRIPTION
## Summary

Add CODEOWNERS file and issue templates to the shared-standards repository.

- **`CODEOWNERS`**: Defines code ownership for the repo
- **Issue templates**: Bug report, feature request, chore templates in `.github/ISSUE_TEMPLATE/`
- **`base.md` expansion**: Extended with more context and guidelines

Closes #13, closes #14

## Changes

- `.github/CODEOWNERS` — code ownership
- `.github/ISSUE_TEMPLATE/bug_report.yml` — bug report template
- `.github/ISSUE_TEMPLATE/feature_request.yml` — feature request template
- `.github/ISSUE_TEMPLATE/chore.yml` — chore template
- Expanded `base.md` with additional guidelines