### PR TITLE
feat: add labeler, pr-size, pages reusable workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ workflows/
   ci-python.yml                 # Reusable CI workflow for Python projects
   ci-node.yml                   # Reusable CI workflow for Node/React projects
   sonar.yml                     # SonarQube analysis workflow
-  release.yml                   # Semantic release workflow
+  release.yml                   # Semantic release workflow (softprops/action-gh-release)
+  labeler.yml                   # PR auto-labeler workflow (actions/labeler@v6)
+  pr-size.yml                   # PR size label workflow (codelytv/pr-size-labeler)
+  pages.yml                     # GitHub Pages deploy (peaceiris or official actions/deploy-pages)
 
 templates/
   CLAUDE.md                     # Bootstrap CLAUDE.md template

--- a/templates/labeler.yml
+++ b/templates/labeler.yml
@@ -1,0 +1,77 @@
+---
+# Labeler configuration template for chrysa ecosystem repos
+# Copy this file to .github/labeler.yml in your repository.
+# Used by actions/labeler@v6 (see workflows/labeler.yml).
+#
+# Each key is a label name. The value defines which changed files trigger it.
+# See full syntax: https://github.com/actions/labeler
+
+# ── CI / Infrastructure ────────────────────────────────────────────────────
+ci:
+    - changed-files:
+          - any-glob-to-any-file:
+                - .github/**
+                - Dockerfile*
+                - docker-compose*.yml
+                - .dockerignore
+                - Makefile
+
+dependencies:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '**/pyproject.toml'
+                - '**/requirements*.txt'
+                - '**/package.json'
+                - '**/package-lock.json'
+                - '**/yarn.lock'
+                - .pre-commit-config.yaml
+
+# ── Backend (Python) ───────────────────────────────────────────────────────
+backend:
+    - changed-files:
+          - any-glob-to-any-file:
+                - backend/**
+                - '**/src/**/*.py'
+
+api:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '**/api/**'
+                - '**/routers/**'
+                - '**/endpoints/**'
+
+# ── Frontend (Node/React) ──────────────────────────────────────────────────
+frontend:
+    - changed-files:
+          - any-glob-to-any-file:
+                - frontend/**
+                - app/**
+                - '**/src/**/*.ts'
+                - '**/src/**/*.tsx'
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+tests:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '**/tests/**'
+                - '**/*.test.*'
+                - '**/*.spec.*'
+                - '**/conftest.py'
+
+# ── Documentation ──────────────────────────────────────────────────────────
+documentation:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '*.md'
+                - docs/**
+                - '**/README.md'
+
+# ── Configuration ──────────────────────────────────────────────────────────
+config:
+    - changed-files:
+          - any-glob-to-any-file:
+                - '**/config/**'
+                - '**/settings.py'
+                - '*.toml'
+                - '*.cfg'
+                - '*.ini'

--- a/workflows/labeler.yml
+++ b/workflows/labeler.yml
@@ -1,0 +1,55 @@
+---
+# Reusable PR auto-labeler workflow (chrysa ecosystem)
+# Applies labels to pull requests based on changed files using .github/labeler.yml config.
+#
+# Uses: actions/labeler@v6
+# Marketplace: https://github.com/marketplace/actions/auto-labeler
+#
+# Usage in your repo's .github/workflows/labeler.yml:
+#
+#   on:
+#     pull_request_target:
+#       types: [opened, reopened, synchronize]
+#   jobs:
+#     labels:
+#       uses: chrysa/shared-standards/.github/workflows/labeler.yml@main
+#       secrets: inherit
+#
+# Requires a .github/labeler.yml config file in your repo.
+# See templates/labeler.yml for a starter config.
+#
+# Note: pull_request_target is used (not pull_request) to allow label
+# writes on PRs from forks without granting unnecessary write permissions.
+
+name: PR Auto-Labeler
+
+on:
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+    workflow_call:
+        inputs:
+            sync-labels:
+                description: Remove labels that no longer match after a force push
+                required: false
+                type: boolean
+                default: true
+            dot:
+                description: Include dot files (hidden files) when matching globs
+                required: false
+                type: boolean
+                default: false
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    labeler:
+        runs-on: ubuntu-latest
+        name: Apply labels on PR
+        steps:
+            - uses: actions/labeler@v6
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  sync-labels: ${{ inputs.sync-labels != '' && inputs.sync-labels || true }}
+                  dot: ${{ inputs.dot || false }}

--- a/workflows/pages.yml
+++ b/workflows/pages.yml
@@ -1,0 +1,149 @@
+---
+# Reusable GitHub Pages deploy workflow (chrysa ecosystem)
+# Supports two modes:
+#   - peaceiris (default): Push directly to gh-pages branch (simpler, widely used)
+#   - official: GitHub's native pages deploy via actions/upload-pages-artifact +
+#               actions/deploy-pages (OIDC, no token stored, recommended for new setups)
+#
+# Marketplace references:
+#   - https://github.com/marketplace/actions/github-pages-action (peaceiris)
+#   - https://github.com/marketplace/actions/deploy-github-pages-site (official)
+#
+# Usage example (MkDocs project):
+#
+#   on:
+#     push:
+#       branches: [main]
+#       paths: [docs/**]
+#   jobs:
+#     pages:
+#       uses: chrysa/shared-standards/.github/workflows/pages.yml@main
+#       with:
+#         build-command: 'pip install mkdocs-material && mkdocs build'
+#         publish-dir: site
+#       secrets: inherit
+#
+# Required repo settings (official mode):
+#   Settings → Pages → Source: "GitHub Actions"
+
+name: Deploy GitHub Pages
+
+on:
+    push:
+        branches: [main, master]
+    workflow_call:
+        inputs:
+            mode:
+                description: >
+                    Deploy mode: "peaceiris" (push to gh-pages branch) or
+                    "official" (GitHub native OIDC deploy).
+                required: false
+                type: string
+                default: peaceiris
+            build-command:
+                description: Shell command to build the static site (e.g. 'mkdocs build')
+                required: false
+                type: string
+                default: ''
+            publish-dir:
+                description: Directory containing the built static files
+                required: false
+                type: string
+                default: site
+            python-version:
+                description: Python version to use when build-command uses Python
+                required: false
+                type: string
+                default: '3.12'
+            node-version:
+                description: Node version to use when build-command uses Node
+                required: false
+                type: string
+                default: '22'
+
+permissions:
+    contents: write
+    pages: write
+    id-token: write
+
+jobs:
+    # ──────────────────────────────────────────────
+    # Mode A: peaceiris/actions-gh-pages@v4
+    # Push built site directly to the gh-pages branch.
+    # Simpler setup; compatible with existing repos already using gh-pages.
+    # ──────────────────────────────────────────────
+    deploy-peaceiris:
+        if: ${{ inputs.mode == 'peaceiris' || inputs.mode == '' }}
+        runs-on: ubuntu-latest
+        name: Deploy (peaceiris)
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Python
+              if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'pip') }}
+              uses: actions/setup-python@v5
+              with:
+                  python-version: ${{ inputs.python-version }}
+
+            - name: Set up Node
+              if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'npm') }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+
+            - name: Build site
+              if: ${{ inputs.build-command != '' }}
+              run: ${{ inputs.build-command }}
+
+            - name: Deploy to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v4
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ${{ inputs.publish-dir || 'site' }}
+
+    # ──────────────────────────────────────────────
+    # Mode B: Official GitHub Pages deploy
+    # Uses actions/upload-pages-artifact + actions/deploy-pages@v4
+    # OIDC-based — no long-lived token required.
+    # Requires Pages source set to "GitHub Actions" in repo settings.
+    # ──────────────────────────────────────────────
+    build-official:
+        if: ${{ inputs.mode == 'official' }}
+        runs-on: ubuntu-latest
+        name: Build site (official)
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Python
+              if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'pip') }}
+              uses: actions/setup-python@v5
+              with:
+                  python-version: ${{ inputs.python-version }}
+
+            - name: Set up Node
+              if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'npm') }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+
+            - name: Build site
+              if: ${{ inputs.build-command != '' }}
+              run: ${{ inputs.build-command }}
+
+            - name: Upload pages artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: ${{ inputs.publish-dir || 'site' }}
+
+    deploy-official:
+        if: ${{ inputs.mode == 'official' }}
+        needs: build-official
+        runs-on: ubuntu-latest
+        name: Deploy (official)
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/workflows/pr-size.yml
+++ b/workflows/pr-size.yml
@@ -1,0 +1,69 @@
+---
+# Reusable PR size label workflow (chrysa ecosystem)
+# Adds a size label (XS/S/M/L/XL) to pull requests based on diff size.
+#
+# Uses: codelytv/pr-size-labeler@v1
+# Marketplace: https://github.com/marketplace/actions/pr-size
+#
+# Usage in your repo's .github/workflows/pull-request-size.yml:
+#
+#   on: pull_request
+#   jobs:
+#     size:
+#       uses: chrysa/shared-standards/.github/workflows/pr-size.yml@main
+#       secrets: inherit
+#
+# Or standalone (copy this file and remove workflow_call trigger):
+#   on: pull_request
+
+name: PR Size Label
+
+on:
+    pull_request:
+        types: [opened, reopened, synchronize]
+    workflow_call:
+        inputs:
+            xs-max-size:
+                description: Max lines for XS label
+                required: false
+                type: number
+                default: 20
+            s-max-size:
+                description: Max lines for S label
+                required: false
+                type: number
+                default: 50
+            m-max-size:
+                description: Max lines for M label
+                required: false
+                type: number
+                default: 200
+            l-max-size:
+                description: Max lines for L label (above = XL)
+                required: false
+                type: number
+                default: 800
+            fail-if-xl:
+                description: Fail the workflow if PR is XL
+                required: false
+                type: boolean
+                default: false
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    pr-size:
+        runs-on: ubuntu-latest
+        name: Label PR by size
+        steps:
+            - name: Label pull request by size
+              uses: codelytv/pr-size-labeler@v1
+              with:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  xs_max_size: ${{ inputs.xs-max-size || 20 }}
+                  s_max_size: ${{ inputs.s-max-size || 50 }}
+                  m_max_size: ${{ inputs.m-max-size || 200 }}
+                  l_max_size: ${{ inputs.l-max-size || 800 }}
+                  fail_if_xl: ${{ inputs.fail-if-xl || false }}


### PR DESCRIPTION
## Summary

Add three new reusable workflows for the chrysa ecosystem (session 15):

- **`labeler.yml`**: Reusable PR auto-labeler workflow using `actions/labeler@v6` — supports `workflow_call` + `pull_request_target`, configurable sync-labels
- **`pr-size.yml`**: Reusable PR size labeler using `codelytv/pr-size-labeler@v1` — assigns XS/S/M/L/XL/XXL labels based on configurable line thresholds
- **`pages.yml`**: Reusable GitHub Pages deployment workflow — supports `peaceiris` mode (push to `gh-pages` branch) and `official` mode (OIDC deploy via `actions/deploy-pages@v4`)

Also adds a **`templates/labeler.yml`** starter config with chrysa-ecosystem label conventions (ci, dependencies, backend, api, frontend, tests, documentation, config).

## Changes

- `.github/workflows/labeler.yml` — new reusable labeler workflow
- `.github/workflows/pr-size.yml` — new reusable PR size workflow
- `.github/workflows/pages.yml` — new reusable GitHub Pages workflow
- `templates/labeler.yml` — starter labeler config template