### PR TITLE
feat: copilot-instructions templates for project types

### DIFF
--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -1,0 +1,20 @@
+name: Enforce Feature Branch Policy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  branch-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR source branch naming
+        shell: bash
+        run: |
+          branch="${{ github.head_ref }}"
+          pattern='^(feature|fix|chore|docs|refactor|test|ci|build|perf|hotfix)/[a-z0-9._-]+$'
+          if [[ ! "$branch" =~ $pattern ]]; then
+            echo "Invalid branch name: $branch"
+            echo "Expected: type/short-description (e.g. feature/add-auth-flow)"
+            exit 1
+          fi

--- a/copilot-instructions/fastapi.md
+++ b/copilot-instructions/fastapi.md
@@ -1,0 +1,74 @@
+# GitHub Copilot Instructions — FastAPI
+
+<!-- @[claude-sonnet-4] -->
+
+Extends [base.md](base.md). Read base rules first; rules here take precedence where they conflict.
+
+## Project layout
+
+```
+app/
+  api/          # routers, grouped by resource
+  core/         # settings, security, startup
+  db/           # session, base model, migrations
+  models/       # SQLAlchemy ORM models
+  schemas/      # Pydantic request/response schemas
+  services/     # business logic (no HTTP or ORM imports)
+  dependencies/ # FastAPI Depends() factories
+  constants.py  # app-wide constants (Final)
+tests/
+  unit/
+  integration/
+  conftest.py
+```
+
+## Architecture rules
+
+- Routers own HTTP concerns only (request parsing, response serialisation, status codes).
+- Services own business logic — they must not import FastAPI, Request, or Response.
+- ORM models and Pydantic schemas are separate classes; never share them.
+- Use `Depends()` for DB sessions, auth, pagination — never pass them as plain args.
+- Settings come from `pydantic_settings.BaseSettings`; never use `os.environ` directly.
+
+## API design
+
+- All paths use kebab-case: `/user-profiles/{id}`.
+- Version prefix: `/api/v1/`.
+- HTTP semantics: `POST` creates, `PUT` replaces, `PATCH` updates partial, `DELETE` removes.
+- Always return typed Pydantic response models, not raw dicts.
+- Use `status.HTTP_*` constants, not magic integers.
+- Validate path and query params with Annotated types and field constraints.
+
+## Database
+
+- Use SQLAlchemy 2.x async (`AsyncSession`).
+- One session per request via `Depends(get_db)`.
+- Migrations with Alembic — always generate migration files, never `create_all()` in production.
+- Keep queries in service layer, not in routers.
+
+## Error handling
+
+- Use `HTTPException` for client errors (4xx).
+- Use a global exception handler for unexpected server errors (5xx) — log and return a safe message.
+- Never expose stack traces or internal DB errors to the client.
+
+## Security
+
+- Authenticate via JWT (`python-jose` or `python-jose[cryptography]`). Validate `aud`, `iss`, `exp`.
+- Hash passwords with `passlib[bcrypt]` — never store plaintext.
+- CORS: whitelist explicit origins, never `allow_origins=["*"]` in production.
+- Rate-limit sensitive endpoints (login, register) with `slowapi` or a middleware.
+- Sanitise user input — use Pydantic validators; never interpolate input into SQL.
+
+## Testing
+
+- Use `pytest` + `httpx.AsyncClient` + `pytest-asyncio`.
+- Integration tests hit a real test DB (Postgres in Docker).
+- At minimum: happy path, validation error (422), auth failure (401/403) per endpoint.
+- Coverage target: 80%+ lines on services layer.
+
+## Dependencies
+
+- Pin versions in `pyproject.toml` under `[project.dependencies]`.
+- Use `uv` or `pip-tools` to manage lock files.
+- Dev extras: `ruff`, `mypy`, `pytest`, `pytest-asyncio`, `httpx`, `factory-boy`.

--- a/copilot-instructions/gas.md
+++ b/copilot-instructions/gas.md
@@ -1,0 +1,59 @@
+# GitHub Copilot Instructions — Google Apps Script (GAS)
+
+<!-- @[claude-sonnet-4] -->
+
+Extends [base.md](base.md). Read base rules first; rules here take precedence where they conflict.
+
+## Layout
+
+```
+<domain>/
+  appsscript.json   # GAS manifest (scopes, timezone, runtimeVersion)
+  .clasp.json       # clasp project config (scriptId, rootDir)
+  helpers.gs        # shared utilities local to this domain
+  <feature>.gs      # one file per logical feature or script
+src/                # legacy flat structure (kept for backward compat if needed)
+shared/             # cross-domain helpers (sync'd via clasp or copy-paste)
+```
+
+## Language
+
+- Use ES2020 features: arrow functions, `const`/`let`, template literals, destructuring, optional chaining.
+- No `var`. No CommonJS `require()` — GAS does not support modules.
+- Globals provided by the GAS runtime (e.g. `SpreadsheetApp`, `GmailApp`) are available globally; declare them as globals in ESLint config.
+
+## Script design
+
+- Each `.gs` file must define a `CONFIG_<SCRIPT_NAME>` object at the top with all constants.
+- Never inline magic strings or numbers — put them in `CONFIG_*`.
+- Functions must be ≤ 50 lines. Extract helpers freely.
+- Do not store secrets in source code — use `PropertiesService.getScriptProperties()`.
+
+## Triggers
+
+- All time-based triggers are documented in the script's `CONFIG_*` object under a `TRIGGERS` key.
+- Trigger re-registration is manual (GAS dashboard) — document required triggers in the `README.md`.
+- Use `LockService` for scripts that must not run concurrently.
+
+## Error handling
+
+- Wrap top-level trigger functions in `try/catch`; log errors with `console.error` or `Logger.log`.
+- Send alert emails on critical failures using `MailApp.sendEmail` to a configurable address from `PropertiesService`.
+
+## Deployment
+
+- Deploy via `clasp push --force` (CI handles this automatically).
+- CI only deploys changed domain folders (detected via `git diff`).
+- Never push directly from local without running `make lint` first.
+
+## Testing
+
+- Unit tests use Jest with a GAS globals mock file (`__tests__/setup/gas-globals.js`).
+- Test pure functions and transformation logic; do not test GAS API calls directly.
+- Mock `PropertiesService`, `MailApp`, etc. in tests.
+
+## Security
+
+- Use `ScriptApp.getOAuthToken()` only when making authenticated API calls within GAS.
+- All external API keys must be stored in Script Properties, never in `.gs` files.
+- Validate all external webhook/request inputs before processing.

--- a/copilot-instructions/monorepo.md
+++ b/copilot-instructions/monorepo.md
@@ -1,0 +1,59 @@
+# GitHub Copilot Instructions — Monorepo
+
+<!-- @[claude-sonnet-4] -->
+
+Extends [base.md](base.md). Read base rules first; rules here take precedence where they conflict.
+
+## Tooling
+
+- Package manager: `pnpm` with workspaces.
+- Build orchestration: `turborepo` (or `nx` for large repos).
+- Versioning: `changesets` for independent package versioning.
+- Root `package.json` is the workspace root — never install app deps there.
+
+## Layout
+
+```
+apps/
+  web/          # React frontend
+  api/          # FastAPI / Express backend
+  docs/         # documentation site
+packages/
+  ui/           # shared design system
+  utils/        # shared utility functions
+  types/        # shared TypeScript types / Pydantic models
+  config/       # shared tooling config (eslint, tsconfig, ruff)
+```
+
+## Rules
+
+- Each `packages/*` package must be independently publishable (`package.json` with `name`, `version`, `exports`).
+- Cross-package imports use the package name, never relative `../../packages/...` paths.
+- `apps/*` must not import from each other.
+- `packages/*` must not import from `apps/*`.
+- Shared configuration (ESLint, TypeScript, Ruff) lives in `packages/config` and is extended, not duplicated.
+
+## CI
+
+- All CI jobs use `--filter` to only run affected packages.
+- Cache `pnpm store` and Turborepo cache in CI.
+- Release is automated via `changesets/action` on merge to `main`.
+
+## Makefiles
+
+- Root `Makefile` extends `Forge-Stack-Workshop/base-makefile`.
+- Targets delegate to Turborepo: `make dev` → `turbo run dev`, `make test` → `turbo run test`.
+- Never duplicate per-package targets in root — use filters instead.
+
+## Versioning
+
+- Each package has its own semver version managed by `changesets`.
+- Add a changeset for every user-facing change: `pnpm changeset`.
+- `CHANGELOG.md` per package is auto-generated on release.
+- Breaking changes bump major; new features bump minor; fixes bump patch.
+
+## Dependency management
+
+- Hoist common devDependencies to workspace root (`pnpm add -Dw`).
+- Pin workspace deps with `workspace:*` protocol in `package.json`.
+- Renovate or Dependabot must be configured for workspace-wide updates.

--- a/copilot-instructions/python-library.md
+++ b/copilot-instructions/python-library.md
@@ -1,0 +1,70 @@
+# GitHub Copilot Instructions — Python Library
+
+<!-- @[claude-sonnet-4] -->
+
+Extends [base.md](base.md). Read base rules first; rules here take precedence where they conflict.
+
+## Layout
+
+```
+src/
+  <package_name>/
+    __init__.py       # public API surface — explicit re-exports only
+    _internal/        # private implementation (not part of public API)
+    py.typed          # marker file for PEP 561
+    constants.py      # library-wide constants (Final)
+tests/
+  unit/
+  integration/        # optional — only if the lib has external dependencies
+  conftest.py
+pyproject.toml        # single source of truth for metadata, deps, tooling
+```
+
+## Package design
+
+- Expose the public API in `__init__.py` using explicit `__all__`.
+- Prefix internal modules with `_` to signal they are not part of the public API.
+- Do not import private modules in `__init__.py` — only public symbols.
+- Follow semantic versioning. Maintain a `CHANGELOG.md` (auto-generated via git-cliff).
+- Support the Python versions declared in `python_requires` — test with tox or GitHub Actions matrix.
+
+## Typing
+
+- Full type annotations on all public functions and methods.
+- `py.typed` marker must be present for PEP 561 compliance.
+- `mypy --strict` must pass with zero errors.
+- Use `typing.Protocol` for structural typing rather than inheritance where it makes sense.
+- Avoid `Any` — use `TypeVar`, `Generic`, or `Protocol` instead.
+
+## API stability
+
+- Public API changes that break backward compatibility require a major version bump.
+- Mark unstable APIs with `@typing.experimental` or a clear deprecation warning.
+- Use `warnings.warn(DeprecationWarning)` when removing a deprecated function.
+
+## Dependencies
+
+- Keep `[project.dependencies]` minimal — prefer stdlib.
+- All heavy deps belong in optional extras (`[project.optional-dependencies]`).
+- Never pin transitive deps in the library itself — only in lock files for apps.
+
+## Testing
+
+- Use `pytest` with `pytest-cov`.
+- Test every public function with: happy path, edge cases, type boundary, error cases.
+- Use `pytest.mark.parametrize` for data-driven tests.
+- Coverage target: 90%+ on public API.
+- Mutation testing recommended (`mutmut`) for critical logic.
+
+## Distribution
+
+- Build with `flit` or `hatchling` (configured in `pyproject.toml`).
+- Publish to PyPI via CI on git tag matching `v*.*.*`.
+- Include `CHANGELOG.md`, `LICENSE`, and `README.md` in sdist (`[tool.hatch.build]`).
+- Generate CHANGELOG with `git-cliff` (`generate-changelog` pre-commit hook, stage: manual).
+
+## Documentation
+
+- Docstrings on all public symbols (Google style).
+- Public API docs auto-generated with `mkdocs` + `mkdocstrings-python`.
+- Code examples in docstrings must be runnable as doctests.

--- a/copilot-instructions/react19.md
+++ b/copilot-instructions/react19.md
@@ -1,0 +1,86 @@
+# GitHub Copilot Instructions — React 19
+
+<!-- @[claude-sonnet-4] -->
+
+Extends [base.md](base.md). Read base rules first; rules here take precedence where they conflict.
+
+## Bootstrap
+
+All React apps **must** be bootstrapped from `Forge-Stack-Workshop/react-app-generator`.
+Never scaffold from `create-react-app`, `vite` directly, or from scratch.
+
+## Project layout
+
+```
+src/
+  api/          # typed API clients (axios/fetch wrappers, no business logic)
+  components/   # shared UI components (pure presentational, no data fetching)
+  features/     # feature slices: components + hooks + slice + types colocated
+  hooks/        # global custom hooks
+  pages/        # route-level components — thin wrappers over features
+  store/        # Redux Toolkit store + root reducer
+  constants.ts  # app-wide constants (as const)
+  types/        # shared TypeScript types
+  utils/        # pure utility functions
+```
+
+## React 19 specifics
+
+- Use React Compiler if enabled — avoid manual `useMemo`/`useCallback` unless profiling proves need.
+- Prefer React 19 `use()` hook for promise resolution over manual `useState`/`useEffect` combos.
+- Server Actions: use for form mutations when using Next.js; keep pure for reusability.
+- Avoid legacy patterns: class components, `React.FC`, `defaultProps`, string refs.
+
+## State management
+
+- Global server state: React Query (`@tanstack/react-query`). No Redux for server data.
+- Global UI state: Redux Toolkit. Use `createSlice`; no hand-written reducers.
+- Local state: `useState`/`useReducer`. Prefer local unless clearly needed elsewhere.
+- Never put server responses directly in Redux — let React Query own them.
+
+## Component rules
+
+- Prefer function components with explicit `interface Props {}`.
+- One component per file; filename matches export name (PascalCase).
+- Keep components under 100 lines. Split presentational and container logic.
+- Co-locate stories (`.stories.tsx`) and tests (`.test.tsx`) next to the component.
+- No business logic in components — delegate to custom hooks or services.
+
+## TypeScript
+
+- `strict: true` — no `any`, no `@ts-ignore` without justification comment.
+- Prefer `interface` for objects, `type` for unions/aliases.
+- Never use `as` casts at runtime boundaries — use Zod or type guards instead.
+- Validate all API responses with a Zod schema before use.
+
+## API integration
+
+- All fetch calls live in `src/api/`; never call `fetch` directly from components.
+- Use React Query's `useQuery`/`useMutation` for data fetching — no `useEffect` + `fetch`.
+- Handle loading, error, and empty states explicitly in every data-driven component.
+
+## Routing
+
+- Use React Router v6+ with `createBrowserRouter`.
+- Route definitions in one file; components loaded lazily with `React.lazy`.
+- Guard protected routes with an `AuthGuard` wrapper.
+
+## Styling
+
+- Prefer Tailwind CSS utility classes.
+- No inline `style` props except for dynamic computed values.
+- Component-scoped CSS modules are acceptable for complex animations.
+
+## Security
+
+- Sanitise all user-generated HTML before rendering (use DOMPurify).
+- Never store tokens in `localStorage` — prefer `httpOnly` cookies.
+- Validate and encode URL parameters; never interpolate user input into URLs.
+
+## Testing
+
+- Vitest + React Testing Library.
+- Test user behaviour, not implementation details.
+- Mock API calls with MSW (`@mswjs/msw`).
+- At minimum: renders without crash, key user interactions, accessibility check (jest-axe).
+- Coverage target: 70%+ on feature slices.

--- a/docs/session-report-20260422-1636.md
+++ b/docs/session-report-20260422-1636.md
@@ -1,0 +1,173 @@
+# Session report chrysa · 2026-04-22T17:05:22+02:00
+
+**Durée** : 1738s · **Log** : `/home/anthony/Documents/perso/projects/chrysa/.chrysa-master-20260422-1636.log`
+**Flags** : dry=false · parallel=true · retry=2 · cron=false · apply-notion=true · seed-backlog=true · bootstrap=true · sched=true · issue-83=true · auto-fix-push=true
+
+## Résultats
+
+| Stage | Statut | Durée | Exit | Tries |
+|-------|--------|-------|------|-------|
+| 0-preflight | ✓ OK | 3s | 0 | 1 |
+| 1-fix-terminal | ✓ OK | 0s | 0 | 1 |
+| 2-fix-all | ⚠ SKIPPED | 0s | skip | 0 |
+| 3-apply-standards | ⚠ SKIPPED | 0s | skip | 0 |
+| 4-cross-project | ✓ OK | 18s | 0 | 1 |
+| 5-audit-issues | ⚠ SKIPPED | 0s | skip | 0 |
+| 6-manual | ⚠ SKIPPED | 0s | na | 0 |
+| 8-notion-wizard | ✓ OK | 0s | 0 | 1 |
+| 7-cleanup | ✓ OK | 0s | 0 | 1 |
+| 9-notion-apply | ✓ OK | 1s | 0 | 1 |
+| 10-seed-backlog | ✓ OK | 19s | 0 | 1 |
+| 11-bootstrap-projects | ✓ OK | 0s | 0 | 1 |
+| 12-sched-cleanup | ✓ OK | 0s | 0 | 1 |
+| 13-issue-83-patch | ✓ OK | 11s | 0 | 1 |
+| 14-auto-fix-push | ✓ OK | 190s | 0 | 1 |
+| 15-init-secrets | ✓ OK | 1s | 0 | 1 |
+| 16-resolve-conflicts | ✓ OK | 129s | 0 | 1 |
+| 17-push-sync-prs | ✓ OK | 421s | 0 | 1 |
+| 18-gen-reminders | ✓ OK | 1s | 0 | 1 |
+| 19-sched-to-gcal | ✓ OK | 1s | 0 | 1 |
+| 20-debian-fix | ✗ FAILED | 845s | 1 | 1 |
+| 21-dependabot-merge | ✓ OK | 98s | 0 | 1 |
+
+## Synthèse
+
+- ✓ OK : 17
+- ✗ Failed : 1
+- ⚠ Skipped : 4
+
+## Reprio 2026-04-20 (ordre)
+
+1. **server Socle P0** (infra · backup DB · Let's Encrypt · stack monitoring · Tailscale keys)
+2. **chrysa-lib Socle P1** (auth — débloque 8+ projets aval)
+3. **dev-nexus Actif P0** (multiplicateur · scaffold sans auth)
+4. **ai-aggregator Actif P1** (Ollama · sans auth)
+5. Actifs P2 : doc-gen · my-fridge · lifeos
+
+## Alertes critiques restantes
+
+- 🔴 doc-gen PR #1 python-jose → joserfc · BLOQUANT
+- 🔴 chrysa-lib Sprint 1 @chrysa/auth · non démarré
+- 🟠 pre-commit-tools Issue #83 · release workflow à patcher
+- 🟠 Désactiver scheduled task `github-state-sync` (obsolète)
+- 🟠 Docker Desktop → Docker Engine (~156€/an)
+- 🟡 GitHub MCP à configurer (PAT requis)
+
+## Achats hardware pending
+
+| Item | Coût | Priorité | Débloque |
+|------|------|----------|----------|
+| TP-Link Deco mesh | ~120€ | P0 | Travaux maison |
+| Shelly 1 Plus × 3 | ~75€ | P1 | Portail auto (vs Somfy 200€) |
+| Raspberry Pi 5 | ~80€ | P2 | ntfy.sh self-host |
+
+## Split SAT (2026-04-20) — 2 projets Opportunistes P2
+
+- **satisfactory-factory-manager** (SAT v2) · scope Satisfactory-only · rename repo + PRD scope (save parser + layout 3D + optimizer + blueprints + API REST)
+- **game-solver-platform** (nouveau) · plateforme IA platinage multi-jeux · leaderboard social · partage amis · hint system 3 niveaux · stack FastAPI + React 19 + LangGraph + Claude API
+
+Seeds : `chrysa/shared-standards/seeds/{satisfactory-factory-manager,game-solver-platform}/`
+Dépendance commune : chrysa-lib/auth (Sprint 1)
+
+## Breakdown par domaine
+
+### 💻 Dev (priorité dégressive)
+
+1. server (infra P0) · chrysa-lib (auth P1) · dev-nexus (Actif P0) · ai-aggregator (Actif P1)
+2. doc-gen · my-fridge · lifeos (Actifs P2)
+3. shared-standards · skills · project-init · pre-commit-tools · guideline-checker (Socles/outils)
+4. SAT v2 · game-solver-platform · PO-GO-DEX · D-D · FabForge (Opportunistes P2-P3)
+
+### 🏠 Maison
+
+- Travaux P0 : TP-Link Deco mesh (~120€) · bloqueur démarrage travaux
+- Domotique P1 : Shelly 1 Plus × 3 (~75€) · portail + volets (vs Somfy 200€+)
+- Self-host P2 : Raspberry Pi 5 (~80€) · ntfy.sh + Home Assistant
+
+### 🎮 Jeux (Opportunistes)
+
+- SAT v2 → satisfactory-factory-manager (Satisfactory uniquement)
+- game-solver-platform → nouveau repo · platinage multi-jeux
+- D-D · FabForge · PO-GO-DEX (stables V1)
+- Discordium V3 · coach (Opportunistes V0)
+
+## Liens Notion
+
+- 🔸 INDEX : https://www.notion.so/34859293e35e81839c77d381a2db7a16
+- 🎯 Reprio : https://www.notion.so/34859293e35e81f9b015db5d9307877d
+- ⚡ Ops Tasks : https://www.notion.so/0fa827fa2ef7496aa1292860a401d8ac
+- 🏗️ Restructuration Teamspace : voir wizard YAML + plan d'exécution
+
+## Sous-catégories Notion (Ops Tasks DB)
+
+Le stage 10 `--seed-backlog` crée les tâches avec **3 propriétés structurantes** pour filtrer/grouper facilement :
+
+| Property | Valeurs |
+|----------|---------|
+| **Category** | Dev · Maison · Jeux · Infra · Ops · Achat |
+| **Project** | chrysa-lib · dev-nexus · doc-gen · server · ai-aggregator · pre-commit-tools · satisfactory-factory-manager · game-solver-platform · chrysa-workstation · my-resume · travaux · domotique · notion · chrysa-master |
+| **Type** | Bug · Feature · Tech-debt · Purchase · Admin · Research |
+
+Vues suggérées à créer dans Notion :
+- **Par domaine** (board grouped by Category)
+- **Par projet actif** (board grouped by Project, filter Status ≠ Done)
+- **Achats en attente** (filter Type=Purchase, sort Priority)
+- **Tech debt critique** (filter Type=Tech-debt AND Priority∈{P0,P1})
+
+## Tokens à générer (liens directs)
+
+| Service | URL génération | Scopes / Notes |
+|---------|----------------|----------------|
+| Notion (intégration) | https://www.notion.so/my-integrations | Read + Update + Insert content · connecter à DB Ops Tasks |
+| GitHub PAT | https://github.com/settings/tokens/new?scopes=repo,read:org,workflow&description=chrysa-mcp | repo · read:org · workflow |
+| Claude API (Anthropic) | https://console.anthropic.com/settings/keys | Create key → chrysa-ai-aggregator |
+| SonarCloud | https://sonarcloud.io/account/security | Generate Tokens |
+| Sentry | https://sentry.io/settings/account/api/auth-tokens/ | project:read + event:read |
+| Twitch (IGDB) | https://dev.twitch.tv/console/apps/create | Category: Game Integration · game-solver-platform |
+| Steam API | https://steamcommunity.com/dev/apikey | Import trophées (V2 game-solver-platform) |
+| Figma | https://www.figma.com/settings/account (onglet Personal access tokens) | file_read pour dev-nexus embed |
+| OpenAI (fallback) | https://platform.openai.com/api-keys | Backup si Claude API down |
+| Shelly Cloud | https://control.shelly.cloud (Settings → User settings → Authorization cloud key) | Domotique portail/volets |
+| Tailscale | https://login.tailscale.com/admin/settings/keys | Reusable auth key server Kimsufi |
+
+## Prochain run
+
+```bash
+# TOUT APPLIQUER (le flag unique · recommandé)
+bash chrysa-master.sh --all
+# équivalent : --yes --parallel --retry=2 + tous les --apply-notion/--seed-backlog/--bootstrap-projects
+#              /--sched-cleanup/--issue-83-patch/--auto-fix-push/--init-secrets
+#              /--resolve-conflicts/--push-sync-prs/--gen-reminders/--sched-to-gcal/--debian-fix
+
+# Session standard quotidienne (stages 0-8 seulement · pas destructif)
+bash chrysa-master.sh --yes --parallel --retry=2
+
+# Stages individuels (token prompté si absent)
+bash chrysa-master.sh --apply-notion --only=9
+bash chrysa-master.sh --seed-backlog --only=10
+bash chrysa-master.sh --bootstrap-projects --only=11
+bash chrysa-master.sh --sched-cleanup --only=12
+bash chrysa-master.sh --issue-83-patch --only=13
+bash chrysa-master.sh --auto-fix-push --only=14   # DESTRUCTIF · pousse branches + PRs
+bash chrysa-master.sh --init-secrets --only=15    # Collecte interactive de tous tokens
+bash chrysa-master.sh --resolve-conflicts --only=16
+bash chrysa-master.sh --push-sync-prs --only=17
+bash chrysa-master.sh --gen-reminders --only=18
+bash chrysa-master.sh --sched-to-gcal --only=19
+bash chrysa-master.sh --debian-fix --only=20      # sudo · 15 sous-phases opt-in
+```
+
+## Stage 14 · Résultats auto-fix (si exécuté)
+
+Ce stage 14 `--auto-fix-push` :
+1. Parcourt tous les repos (skip `shared-standards`, `_archived`, `skills`, `my-resume`, `linkendin-resume`, `DJango-CustomeCommands`)
+2. Détecte le stack (python/node)
+3. Lance les auto-fixers :
+   - Python : `ruff check --fix` + `ruff format`
+   - Node : `prettier --write` + `eslint --fix`
+4. Si changements → branche `chore/auto-fix-20260422-1636` + commit conventional + push
+5. Ouvre PR via `gh pr create` avec body détaillé + labels `chore,auto-merge`
+6. Scanne les issues ouvertes sans PR associée → seed Notion si trouvé
+
+**Pré-requis** : `gh auth status` valide · `ruff`/`npm` dispos pour exécution directe (sinon skip)
+```

--- a/docs/session-report-20260422-2226.md
+++ b/docs/session-report-20260422-2226.md
@@ -1,0 +1,173 @@
+# Session report chrysa · 2026-04-22T22:45:04+02:00
+
+**Durée** : 1106s · **Log** : `/home/anthony/Documents/perso/projects/chrysa/.chrysa-master-20260422-2226.log`
+**Flags** : dry=false · parallel=false · retry=1 · cron=false · apply-notion=false · seed-backlog=false · bootstrap=false · sched=false · issue-83=false · auto-fix-push=false
+
+## Résultats
+
+| Stage | Statut | Durée | Exit | Tries |
+|-------|--------|-------|------|-------|
+| 0-preflight | ✓ OK | 6s | 0 | 1 |
+| 1-fix-terminal | ✓ OK | 0s | 0 | 1 |
+| 2-fix-all | ⚠ SKIPPED | 0s | skip | 0 |
+| 3-apply-standards | ⚠ SKIPPED | 0s | skip | 0 |
+| 4-cross-project | ✗ FAILED | 12s | 130 | 1 |
+| 5-audit-issues | ⚠ SKIPPED | 0s | skip | 0 |
+| 6-manual | ⚠ SKIPPED | 0s | na | 0 |
+| 8-notion-wizard | ✓ OK | 2s | 0 | 1 |
+| 7-cleanup | ✓ OK | 2s | 0 | 1 |
+| 9-notion-apply | ⚠ SKIPPED | 0s | skip | 0 |
+| 10-seed-backlog | ⚠ SKIPPED | 0s | skip | 0 |
+| 11-bootstrap-projects | ⚠ SKIPPED | 0s | skip | 0 |
+| 12-sched-cleanup | ⚠ SKIPPED | 0s | skip | 0 |
+| 13-issue-83-patch | ⚠ SKIPPED | 0s | skip | 0 |
+| 14-auto-fix-push | ⚠ SKIPPED | 0s | skip | 0 |
+| 15-init-secrets | ⚠ SKIPPED | 0s | skip | 0 |
+| 16-resolve-conflicts | ⚠ SKIPPED | 0s | skip | 0 |
+| 17-push-sync-prs | ⚠ SKIPPED | 0s | skip | 0 |
+| 18-gen-reminders | ⚠ SKIPPED | 0s | skip | 0 |
+| 19-sched-to-gcal | ⚠ SKIPPED | 0s | skip | 0 |
+| 20-debian-fix | ✗ FAILED | 1082s | 1 | 1 |
+| 21-dependabot-merge | ⚠ SKIPPED | 0s | skip | 0 |
+
+## Synthèse
+
+- ✓ OK : 4
+- ✗ Failed : 2
+- ⚠ Skipped : 16
+
+## Reprio 2026-04-20 (ordre)
+
+1. **server Socle P0** (infra · backup DB · Let's Encrypt · stack monitoring · Tailscale keys)
+2. **chrysa-lib Socle P1** (auth — débloque 8+ projets aval)
+3. **dev-nexus Actif P0** (multiplicateur · scaffold sans auth)
+4. **ai-aggregator Actif P1** (Ollama · sans auth)
+5. Actifs P2 : doc-gen · my-fridge · lifeos
+
+## Alertes critiques restantes
+
+- 🔴 doc-gen PR #1 python-jose → joserfc · BLOQUANT
+- 🔴 chrysa-lib Sprint 1 @chrysa/auth · non démarré
+- 🟠 pre-commit-tools Issue #83 · release workflow à patcher
+- 🟠 Désactiver scheduled task `github-state-sync` (obsolète)
+- 🟠 Docker Desktop → Docker Engine (~156€/an)
+- 🟡 GitHub MCP à configurer (PAT requis)
+
+## Achats hardware pending
+
+| Item | Coût | Priorité | Débloque |
+|------|------|----------|----------|
+| TP-Link Deco mesh | ~120€ | P0 | Travaux maison |
+| Shelly 1 Plus × 3 | ~75€ | P1 | Portail auto (vs Somfy 200€) |
+| Raspberry Pi 5 | ~80€ | P2 | ntfy.sh self-host |
+
+## Split SAT (2026-04-20) — 2 projets Opportunistes P2
+
+- **satisfactory-factory-manager** (SAT v2) · scope Satisfactory-only · rename repo + PRD scope (save parser + layout 3D + optimizer + blueprints + API REST)
+- **game-solver-platform** (nouveau) · plateforme IA platinage multi-jeux · leaderboard social · partage amis · hint system 3 niveaux · stack FastAPI + React 19 + LangGraph + Claude API
+
+Seeds : `chrysa/shared-standards/seeds/{satisfactory-factory-manager,game-solver-platform}/`
+Dépendance commune : chrysa-lib/auth (Sprint 1)
+
+## Breakdown par domaine
+
+### 💻 Dev (priorité dégressive)
+
+1. server (infra P0) · chrysa-lib (auth P1) · dev-nexus (Actif P0) · ai-aggregator (Actif P1)
+2. doc-gen · my-fridge · lifeos (Actifs P2)
+3. shared-standards · skills · project-init · pre-commit-tools · guideline-checker (Socles/outils)
+4. SAT v2 · game-solver-platform · PO-GO-DEX · D-D · FabForge (Opportunistes P2-P3)
+
+### 🏠 Maison
+
+- Travaux P0 : TP-Link Deco mesh (~120€) · bloqueur démarrage travaux
+- Domotique P1 : Shelly 1 Plus × 3 (~75€) · portail + volets (vs Somfy 200€+)
+- Self-host P2 : Raspberry Pi 5 (~80€) · ntfy.sh + Home Assistant
+
+### 🎮 Jeux (Opportunistes)
+
+- SAT v2 → satisfactory-factory-manager (Satisfactory uniquement)
+- game-solver-platform → nouveau repo · platinage multi-jeux
+- D-D · FabForge · PO-GO-DEX (stables V1)
+- Discordium V3 · coach (Opportunistes V0)
+
+## Liens Notion
+
+- 🔸 INDEX : https://www.notion.so/34859293e35e81839c77d381a2db7a16
+- 🎯 Reprio : https://www.notion.so/34859293e35e81f9b015db5d9307877d
+- ⚡ Ops Tasks : https://www.notion.so/0fa827fa2ef7496aa1292860a401d8ac
+- 🏗️ Restructuration Teamspace : voir wizard YAML + plan d'exécution
+
+## Sous-catégories Notion (Ops Tasks DB)
+
+Le stage 10 `--seed-backlog` crée les tâches avec **3 propriétés structurantes** pour filtrer/grouper facilement :
+
+| Property | Valeurs |
+|----------|---------|
+| **Category** | Dev · Maison · Jeux · Infra · Ops · Achat |
+| **Project** | chrysa-lib · dev-nexus · doc-gen · server · ai-aggregator · pre-commit-tools · satisfactory-factory-manager · game-solver-platform · chrysa-workstation · my-resume · travaux · domotique · notion · chrysa-master |
+| **Type** | Bug · Feature · Tech-debt · Purchase · Admin · Research |
+
+Vues suggérées à créer dans Notion :
+- **Par domaine** (board grouped by Category)
+- **Par projet actif** (board grouped by Project, filter Status ≠ Done)
+- **Achats en attente** (filter Type=Purchase, sort Priority)
+- **Tech debt critique** (filter Type=Tech-debt AND Priority∈{P0,P1})
+
+## Tokens à générer (liens directs)
+
+| Service | URL génération | Scopes / Notes |
+|---------|----------------|----------------|
+| Notion (intégration) | https://www.notion.so/my-integrations | Read + Update + Insert content · connecter à DB Ops Tasks |
+| GitHub PAT | https://github.com/settings/tokens/new?scopes=repo,read:org,workflow&description=chrysa-mcp | repo · read:org · workflow |
+| Claude API (Anthropic) | https://console.anthropic.com/settings/keys | Create key → chrysa-ai-aggregator |
+| SonarCloud | https://sonarcloud.io/account/security | Generate Tokens |
+| Sentry | https://sentry.io/settings/account/api/auth-tokens/ | project:read + event:read |
+| Twitch (IGDB) | https://dev.twitch.tv/console/apps/create | Category: Game Integration · game-solver-platform |
+| Steam API | https://steamcommunity.com/dev/apikey | Import trophées (V2 game-solver-platform) |
+| Figma | https://www.figma.com/settings/account (onglet Personal access tokens) | file_read pour dev-nexus embed |
+| OpenAI (fallback) | https://platform.openai.com/api-keys | Backup si Claude API down |
+| Shelly Cloud | https://control.shelly.cloud (Settings → User settings → Authorization cloud key) | Domotique portail/volets |
+| Tailscale | https://login.tailscale.com/admin/settings/keys | Reusable auth key server Kimsufi |
+
+## Prochain run
+
+```bash
+# TOUT APPLIQUER (le flag unique · recommandé)
+bash chrysa-master.sh --all
+# équivalent : --yes --parallel --retry=2 + tous les --apply-notion/--seed-backlog/--bootstrap-projects
+#              /--sched-cleanup/--issue-83-patch/--auto-fix-push/--init-secrets
+#              /--resolve-conflicts/--push-sync-prs/--gen-reminders/--sched-to-gcal/--debian-fix
+
+# Session standard quotidienne (stages 0-8 seulement · pas destructif)
+bash chrysa-master.sh --yes --parallel --retry=2
+
+# Stages individuels (token prompté si absent)
+bash chrysa-master.sh --apply-notion --only=9
+bash chrysa-master.sh --seed-backlog --only=10
+bash chrysa-master.sh --bootstrap-projects --only=11
+bash chrysa-master.sh --sched-cleanup --only=12
+bash chrysa-master.sh --issue-83-patch --only=13
+bash chrysa-master.sh --auto-fix-push --only=14   # DESTRUCTIF · pousse branches + PRs
+bash chrysa-master.sh --init-secrets --only=15    # Collecte interactive de tous tokens
+bash chrysa-master.sh --resolve-conflicts --only=16
+bash chrysa-master.sh --push-sync-prs --only=17
+bash chrysa-master.sh --gen-reminders --only=18
+bash chrysa-master.sh --sched-to-gcal --only=19
+bash chrysa-master.sh --debian-fix --only=20      # sudo · 15 sous-phases opt-in
+```
+
+## Stage 14 · Résultats auto-fix (si exécuté)
+
+Ce stage 14 `--auto-fix-push` :
+1. Parcourt tous les repos (skip `shared-standards`, `_archived`, `skills`, `my-resume`, `linkendin-resume`, `DJango-CustomeCommands`)
+2. Détecte le stack (python/node)
+3. Lance les auto-fixers :
+   - Python : `ruff check --fix` + `ruff format`
+   - Node : `prettier --write` + `eslint --fix`
+4. Si changements → branche `chore/auto-fix-20260422-2226` + commit conventional + push
+5. Ouvre PR via `gh pr create` avec body détaillé + labels `chore,auto-merge`
+6. Scanne les issues ouvertes sans PR associée → seed Notion si trouvé
+
+**Pré-requis** : `gh auth status` valide · `ruff`/`npm` dispos pour exécution directe (sinon skip)
+```

--- a/docs/session-report-20260423-2227.md
+++ b/docs/session-report-20260423-2227.md
@@ -1,0 +1,173 @@
+# Session report chrysa · 2026-04-23T22:28:45+02:00
+
+**Durée** : 91s · **Log** : `/home/anthony/Documents/perso/projects/chrysa/.chrysa-master-20260423-2227.log`
+**Flags** : dry=false · parallel=false · retry=1 · cron=false · apply-notion=false · seed-backlog=false · bootstrap=false · sched=false · issue-83=false · auto-fix-push=false
+
+## Résultats
+
+| Stage | Statut | Durée | Exit | Tries |
+|-------|--------|-------|------|-------|
+| 0-preflight | ✓ OK | 10s | 0 | 1 |
+| 1-fix-terminal | ✓ OK | 0s | 0 | 1 |
+| 2-fix-all | ⚠ SKIPPED | 0s | skip | 0 |
+| 3-apply-standards | ⚠ SKIPPED | 0s | skip | 0 |
+| 4-cross-project | ✓ OK | 23s | 0 | 1 |
+| 5-audit-issues | ⚠ SKIPPED | 0s | skip | 0 |
+| 6-manual | ⚠ SKIPPED | 0s | na | 0 |
+| 8-notion-wizard | ✓ OK | 54s | 0 | 1 |
+| 7-cleanup | ✓ OK | 1s | 0 | 1 |
+| 9-notion-apply | ⚠ SKIPPED | 0s | skip | 0 |
+| 10-seed-backlog | ⚠ SKIPPED | 0s | skip | 0 |
+| 11-bootstrap-projects | ⚠ SKIPPED | 0s | skip | 0 |
+| 12-sched-cleanup | ⚠ SKIPPED | 0s | skip | 0 |
+| 13-issue-83-patch | ⚠ SKIPPED | 0s | skip | 0 |
+| 14-auto-fix-push | ⚠ SKIPPED | 0s | skip | 0 |
+| 15-init-secrets | ⚠ SKIPPED | 0s | skip | 0 |
+| 16-resolve-conflicts | ⚠ SKIPPED | 0s | skip | 0 |
+| 17-push-sync-prs | ⚠ SKIPPED | 0s | skip | 0 |
+| 18-gen-reminders | ⚠ SKIPPED | 0s | skip | 0 |
+| 19-sched-to-gcal | ⚠ SKIPPED | 0s | skip | 0 |
+| 20-debian-fix | ⚠ SKIPPED | 0s | skip | 0 |
+| 21-dependabot-merge | ⚠ SKIPPED | 0s | skip | 0 |
+
+## Synthèse
+
+- ✓ OK : 5
+- ✗ Failed : 0
+- ⚠ Skipped : 17
+
+## Reprio 2026-04-20 (ordre)
+
+1. **server Socle P0** (infra · backup DB · Let's Encrypt · stack monitoring · Tailscale keys)
+2. **chrysa-lib Socle P1** (auth — débloque 8+ projets aval)
+3. **dev-nexus Actif P0** (multiplicateur · scaffold sans auth)
+4. **ai-aggregator Actif P1** (Ollama · sans auth)
+5. Actifs P2 : doc-gen · my-fridge · lifeos
+
+## Alertes critiques restantes
+
+- 🔴 doc-gen PR #1 python-jose → joserfc · BLOQUANT
+- 🔴 chrysa-lib Sprint 1 @chrysa/auth · non démarré
+- 🟠 pre-commit-tools Issue #83 · release workflow à patcher
+- 🟠 Désactiver scheduled task `github-state-sync` (obsolète)
+- 🟠 Docker Desktop → Docker Engine (~156€/an)
+- 🟡 GitHub MCP à configurer (PAT requis)
+
+## Achats hardware pending
+
+| Item | Coût | Priorité | Débloque |
+|------|------|----------|----------|
+| TP-Link Deco mesh | ~120€ | P0 | Travaux maison |
+| Shelly 1 Plus × 3 | ~75€ | P1 | Portail auto (vs Somfy 200€) |
+| Raspberry Pi 5 | ~80€ | P2 | ntfy.sh self-host |
+
+## Split SAT (2026-04-20) — 2 projets Opportunistes P2
+
+- **satisfactory-factory-manager** (SAT v2) · scope Satisfactory-only · rename repo + PRD scope (save parser + layout 3D + optimizer + blueprints + API REST)
+- **game-solver-platform** (nouveau) · plateforme IA platinage multi-jeux · leaderboard social · partage amis · hint system 3 niveaux · stack FastAPI + React 19 + LangGraph + Claude API
+
+Seeds : `chrysa/shared-standards/seeds/{satisfactory-factory-manager,game-solver-platform}/`
+Dépendance commune : chrysa-lib/auth (Sprint 1)
+
+## Breakdown par domaine
+
+### 💻 Dev (priorité dégressive)
+
+1. server (infra P0) · chrysa-lib (auth P1) · dev-nexus (Actif P0) · ai-aggregator (Actif P1)
+2. doc-gen · my-fridge · lifeos (Actifs P2)
+3. shared-standards · skills · project-init · pre-commit-tools · guideline-checker (Socles/outils)
+4. SAT v2 · game-solver-platform · PO-GO-DEX · D-D · FabForge (Opportunistes P2-P3)
+
+### 🏠 Maison
+
+- Travaux P0 : TP-Link Deco mesh (~120€) · bloqueur démarrage travaux
+- Domotique P1 : Shelly 1 Plus × 3 (~75€) · portail + volets (vs Somfy 200€+)
+- Self-host P2 : Raspberry Pi 5 (~80€) · ntfy.sh + Home Assistant
+
+### 🎮 Jeux (Opportunistes)
+
+- SAT v2 → satisfactory-factory-manager (Satisfactory uniquement)
+- game-solver-platform → nouveau repo · platinage multi-jeux
+- D-D · FabForge · PO-GO-DEX (stables V1)
+- Discordium V3 · coach (Opportunistes V0)
+
+## Liens Notion
+
+- 🔸 INDEX : https://www.notion.so/34859293e35e81839c77d381a2db7a16
+- 🎯 Reprio : https://www.notion.so/34859293e35e81f9b015db5d9307877d
+- ⚡ Ops Tasks : https://www.notion.so/0fa827fa2ef7496aa1292860a401d8ac
+- 🏗️ Restructuration Teamspace : voir wizard YAML + plan d'exécution
+
+## Sous-catégories Notion (Ops Tasks DB)
+
+Le stage 10 `--seed-backlog` crée les tâches avec **3 propriétés structurantes** pour filtrer/grouper facilement :
+
+| Property | Valeurs |
+|----------|---------|
+| **Category** | Dev · Maison · Jeux · Infra · Ops · Achat |
+| **Project** | chrysa-lib · dev-nexus · doc-gen · server · ai-aggregator · pre-commit-tools · satisfactory-factory-manager · game-solver-platform · chrysa-workstation · my-resume · travaux · domotique · notion · chrysa-master |
+| **Type** | Bug · Feature · Tech-debt · Purchase · Admin · Research |
+
+Vues suggérées à créer dans Notion :
+- **Par domaine** (board grouped by Category)
+- **Par projet actif** (board grouped by Project, filter Status ≠ Done)
+- **Achats en attente** (filter Type=Purchase, sort Priority)
+- **Tech debt critique** (filter Type=Tech-debt AND Priority∈{P0,P1})
+
+## Tokens à générer (liens directs)
+
+| Service | URL génération | Scopes / Notes |
+|---------|----------------|----------------|
+| Notion (intégration) | https://www.notion.so/my-integrations | Read + Update + Insert content · connecter à DB Ops Tasks |
+| GitHub PAT | https://github.com/settings/tokens/new?scopes=repo,read:org,workflow&description=chrysa-mcp | repo · read:org · workflow |
+| Claude API (Anthropic) | https://console.anthropic.com/settings/keys | Create key → chrysa-ai-aggregator |
+| SonarCloud | https://sonarcloud.io/account/security | Generate Tokens |
+| Sentry | https://sentry.io/settings/account/api/auth-tokens/ | project:read + event:read |
+| Twitch (IGDB) | https://dev.twitch.tv/console/apps/create | Category: Game Integration · game-solver-platform |
+| Steam API | https://steamcommunity.com/dev/apikey | Import trophées (V2 game-solver-platform) |
+| Figma | https://www.figma.com/settings/account (onglet Personal access tokens) | file_read pour dev-nexus embed |
+| OpenAI (fallback) | https://platform.openai.com/api-keys | Backup si Claude API down |
+| Shelly Cloud | https://control.shelly.cloud (Settings → User settings → Authorization cloud key) | Domotique portail/volets |
+| Tailscale | https://login.tailscale.com/admin/settings/keys | Reusable auth key server Kimsufi |
+
+## Prochain run
+
+```bash
+# TOUT APPLIQUER (le flag unique · recommandé)
+bash chrysa-master.sh --all
+# équivalent : --yes --parallel --retry=2 + tous les --apply-notion/--seed-backlog/--bootstrap-projects
+#              /--sched-cleanup/--issue-83-patch/--auto-fix-push/--init-secrets
+#              /--resolve-conflicts/--push-sync-prs/--gen-reminders/--sched-to-gcal/--debian-fix
+
+# Session standard quotidienne (stages 0-8 seulement · pas destructif)
+bash chrysa-master.sh --yes --parallel --retry=2
+
+# Stages individuels (token prompté si absent)
+bash chrysa-master.sh --apply-notion --only=9
+bash chrysa-master.sh --seed-backlog --only=10
+bash chrysa-master.sh --bootstrap-projects --only=11
+bash chrysa-master.sh --sched-cleanup --only=12
+bash chrysa-master.sh --issue-83-patch --only=13
+bash chrysa-master.sh --auto-fix-push --only=14   # DESTRUCTIF · pousse branches + PRs
+bash chrysa-master.sh --init-secrets --only=15    # Collecte interactive de tous tokens
+bash chrysa-master.sh --resolve-conflicts --only=16
+bash chrysa-master.sh --push-sync-prs --only=17
+bash chrysa-master.sh --gen-reminders --only=18
+bash chrysa-master.sh --sched-to-gcal --only=19
+bash chrysa-master.sh --debian-fix --only=20      # sudo · 15 sous-phases opt-in
+```
+
+## Stage 14 · Résultats auto-fix (si exécuté)
+
+Ce stage 14 `--auto-fix-push` :
+1. Parcourt tous les repos (skip `shared-standards`, `_archived`, `skills`, `my-resume`, `linkendin-resume`, `DJango-CustomeCommands`)
+2. Détecte le stack (python/node)
+3. Lance les auto-fixers :
+   - Python : `ruff check --fix` + `ruff format`
+   - Node : `prettier --write` + `eslint --fix`
+4. Si changements → branche `chore/auto-fix-20260423-2227` + commit conventional + push
+5. Ouvre PR via `gh pr create` avec body détaillé + labels `chore,auto-merge`
+6. Scanne les issues ouvertes sans PR associée → seed Notion si trouvé
+
+**Pré-requis** : `gh auth status` valide · `ruff`/`npm` dispos pour exécution directe (sinon skip)
+```

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "_comment_model": "Model auto-selected from latest Claude available via Copilot. Do not hardcode a version. Fallback: anthropic/claude-sonnet-4-5 if Copilot unavailable.",
+  "instructions": "You are an expert software engineer and ecosystem architect. Default to English in code, docs, and issues. Respect CLAUDE.md per repo. Use GitHub Copilot (latest Claude) as default model.",
+  "mcp": {
+    "github": {
+      "command": [
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "enabled": true,
+      "environment": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      },
+      "type": "local"
+    },
+    "notion": {
+      "command": [
+        "npx",
+        "-y",
+        "@notionhq/notion-mcp-server"
+      ],
+      "enabled": true,
+      "environment": {
+        "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ${NOTION_API_KEY}\", \"Notion-Version\": \"2022-06-28\"}"
+      },
+      "type": "local"
+    }
+  },
+  "model": "github-copilot",
+  "provider": {
+    "github-copilot": {
+      "options": {
+        "model": "claude-sonnet-4-5"
+      },
+      "type": "copilot"
+    }
+  }
+}

--- a/scripts/apply-ci-process.sh
+++ b/scripts/apply-ci-process.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# apply-ci-process.sh · Déploie les templates CI Tier 1+2+3 sur un repo
+# Source : chrysa/shared-standards/scripts/apply-ci-process.sh
+#
+# Ce que le script fait :
+#   Tier 1 · 10 workflows process-only (non stack-specific) dans .github/workflows/
+#   Tier 2 · dependabot.yml généré selon stack détectée (pip/npm/docker)
+#   Tier 3 · config github (.github/labeler.yml, labels.yml, auto_assign.yml, actionlint.yaml)
+#   Bonus · fragment pre-commit common (à fusionner manuellement)
+#
+# Stack detection auto :
+#   pyproject.toml OR requirements*.txt → ecosystem pip
+#   package.json                        → ecosystem npm (directory auto-détecté)
+#   Dockerfile OR docker/Dockerfile     → ecosystem docker
+#   docker-compose*.yml                 → ecosystem docker-compose
+#
+# Usage :
+#   bash apply-ci-process.sh <repo_path>        # déploie sur 1 repo
+#   bash apply-ci-process.sh --all              # déploie sur tous les repos chrysa
+#   bash apply-ci-process.sh --dry-run <path>   # preview sans écriture
+#   bash apply-ci-process.sh --force <path>     # écrase sans backup
+#
+# Sortie : table résumé des actions + backups en .ci-backup-<TS>/ si overwrite
+#
+# Exit : 0 OK · 1 erreur · 2 repo absent
+
+set -uo pipefail
+
+# ─── Paths & config ───────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHRYSA_ROOT="${CHRYSA_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+TEMPLATES_DIR="$CHRYSA_ROOT/shared-standards/templates"
+WF_TEMPLATES="$TEMPLATES_DIR/workflows-process"
+CFG_TEMPLATES="$TEMPLATES_DIR/github-config"
+TS=$(date +%Y%m%d-%H%M%S)
+
+DRY_RUN=false
+FORCE=false
+TARGET_ALL=false
+TARGET_REPO=""
+
+# ─── Args parsing ────────────────────────────────────
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --force)   FORCE=true ;;
+        --all)     TARGET_ALL=true ;;
+        -h|--help)
+            sed -n '2,25p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            [[ -z "$TARGET_REPO" ]] && TARGET_REPO="$arg"
+            ;;
+    esac
+done
+
+# ─── Helpers ─────────────────────────────────────────
+log()  { echo "[$(date +%H:%M:%S)] $*"; }
+ok()   { echo -e "  \033[32m✓\033[0m $*"; }
+warn() { echo -e "  \033[33m⚠\033[0m $*"; }
+err()  { echo -e "  \033[31m✗\033[0m $*" >&2; }
+info() { echo -e "  \033[34m→\033[0m $*"; }
+
+# Assure la présence des templates avant de démarrer
+check_templates() {
+    local missing=()
+    for f in \
+        "$WF_TEMPLATES/approved-label.yml" \
+        "$WF_TEMPLATES/auto-assign.yml" \
+        "$WF_TEMPLATES/detect-conflicts.yml" \
+        "$WF_TEMPLATES/labeler.yml" \
+        "$WF_TEMPLATES/pr-dependencies.yml" \
+        "$WF_TEMPLATES/pull-request-size.yml" \
+        "$WF_TEMPLATES/sync-labels.yml" \
+        "$WF_TEMPLATES/update-pr-body.yml" \
+        "$WF_TEMPLATES/action-check.yml" \
+        "$WF_TEMPLATES/auto-update-pre-commit.yml" \
+        "$CFG_TEMPLATES/labels.yml" \
+        "$CFG_TEMPLATES/labeler.yml" \
+        "$CFG_TEMPLATES/auto_assign.yml" \
+        "$CFG_TEMPLATES/actionlint.yaml" \
+        "$CFG_TEMPLATES/dependabot.yml.tpl" \
+        "$CFG_TEMPLATES/pre-commit-common.yaml"
+    do
+        [[ -f "$f" ]] || missing+=("$f")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        err "Templates manquants :"
+        for f in "${missing[@]}"; do err "  · $f"; done
+        exit 1
+    fi
+}
+
+# Détecte les ecosystems présents dans un repo
+detect_stack() {
+    local repo="$1"
+    local stacks=""
+
+    # Python
+    if [[ -f "$repo/pyproject.toml" ]] || ls "$repo"/requirements*.txt &>/dev/null || [[ -f "$repo/setup.py" ]] || [[ -f "$repo/setup.cfg" ]]; then
+        # Préfère pyproject.toml directory
+        if [[ -f "$repo/pyproject.toml" ]]; then
+            stacks+="python:/;"
+        else
+            stacks+="python:/;"
+        fi
+    fi
+
+    # npm (cherche package.json à racine ou app/ ou frontend/ ou web/)
+    for npm_dir in "" "app" "frontend" "web" "client"; do
+        local full_path="$repo"
+        [[ -n "$npm_dir" ]] && full_path="$repo/$npm_dir"
+        if [[ -f "$full_path/package.json" ]]; then
+            local rel_dir="/"
+            [[ -n "$npm_dir" ]] && rel_dir="$npm_dir/"
+            stacks+="npm:$rel_dir;"
+            break
+        fi
+    done
+
+    # Docker
+    if [[ -f "$repo/Dockerfile" ]]; then
+        stacks+="docker:/;"
+    elif [[ -d "$repo/docker" ]] && ls "$repo/docker"/Dockerfile* &>/dev/null; then
+        stacks+="docker:docker/;"
+    fi
+
+    # Docker compose
+    if ls "$repo"/docker-compose*.y*ml &>/dev/null; then
+        stacks+="docker-compose:/;"
+    fi
+
+    echo "$stacks"
+}
+
+# Génère dependabot.yml à partir du template + stacks détectées
+generate_dependabot() {
+    local repo="$1"
+    local stacks="$2"
+    local dest="$repo/.github/dependabot.yml"
+    local tpl="$CFG_TEMPLATES/dependabot.yml.tpl"
+
+    # Start fresh : copie le tpl et retire les blocs non pertinents
+    local tmp; tmp=$(mktemp)
+    cp "$tpl" "$tmp"
+
+    # Python
+    if [[ "$stacks" == *"python:"* ]]; then
+        local dir
+        dir=$(echo "$stacks" | tr ';' '\n' | grep '^python:' | head -1 | cut -d: -f2)
+        sed -i "s|{{PIP_DIR}}|${dir:-/}|" "$tmp"
+        sed -i '/{{ECOSYSTEM_PYTHON_START}}/d; /{{ECOSYSTEM_PYTHON_END}}/d' "$tmp"
+    else
+        sed -i '/{{ECOSYSTEM_PYTHON_START}}/,/{{ECOSYSTEM_PYTHON_END}}/d' "$tmp"
+    fi
+
+    # NPM
+    if [[ "$stacks" == *"npm:"* ]]; then
+        local dir
+        dir=$(echo "$stacks" | tr ';' '\n' | grep '^npm:' | head -1 | cut -d: -f2)
+        sed -i "s|{{NPM_DIR}}|${dir:-/}|" "$tmp"
+        sed -i '/{{ECOSYSTEM_NPM_START}}/d; /{{ECOSYSTEM_NPM_END}}/d' "$tmp"
+    else
+        sed -i '/{{ECOSYSTEM_NPM_START}}/,/{{ECOSYSTEM_NPM_END}}/d' "$tmp"
+    fi
+
+    # Docker
+    if [[ "$stacks" == *"docker:"* ]]; then
+        local dir
+        dir=$(echo "$stacks" | tr ';' '\n' | grep '^docker:' | head -1 | cut -d: -f2)
+        sed -i "s|{{DOCKER_DIR}}|${dir:-/}|" "$tmp"
+        sed -i '/{{ECOSYSTEM_DOCKER_START}}/d; /{{ECOSYSTEM_DOCKER_END}}/d' "$tmp"
+    else
+        sed -i '/{{ECOSYSTEM_DOCKER_START}}/,/{{ECOSYSTEM_DOCKER_END}}/d' "$tmp"
+    fi
+
+    # Docker compose
+    if [[ "$stacks" == *"docker-compose:"* ]]; then
+        sed -i '/{{ECOSYSTEM_DOCKER_COMPOSE_START}}/d; /{{ECOSYSTEM_DOCKER_COMPOSE_END}}/d' "$tmp"
+    else
+        sed -i '/{{ECOSYSTEM_DOCKER_COMPOSE_START}}/,/{{ECOSYSTEM_DOCKER_COMPOSE_END}}/d' "$tmp"
+    fi
+
+    # Nettoie lignes vides consécutives multiples
+    awk 'NF || prev_nf {print} {prev_nf = NF}' "$tmp" > "${tmp}.clean"
+    mv "${tmp}.clean" "$tmp"
+
+    if $DRY_RUN; then
+        info "[dry-run] Générerait $dest ($(wc -l < "$tmp") lignes)"
+        rm -f "$tmp"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$dest")"
+    # Backup si exists
+    if [[ -f "$dest" ]] && ! $FORCE; then
+        local backup_dir="$repo/.ci-backup-$TS"
+        mkdir -p "$backup_dir"
+        cp "$dest" "$backup_dir/dependabot.yml"
+        info "Backup : .ci-backup-$TS/dependabot.yml"
+    fi
+    mv "$tmp" "$dest"
+    ok "dependabot.yml écrit (stacks : $stacks)"
+}
+
+# Déploie sur 1 repo
+deploy_one() {
+    local repo="$1"
+    local repo_name
+    repo_name=$(basename "$repo")
+
+    if [[ ! -d "$repo" ]]; then
+        err "$repo n'existe pas"
+        return 2
+    fi
+    if [[ ! -d "$repo/.git" ]]; then
+        warn "$repo_name : pas un repo git · skip"
+        return 0
+    fi
+
+    log "═══ Déploiement sur $repo_name ═══"
+
+    # ─── Détection stack ──────────────────
+    local stacks
+    stacks=$(detect_stack "$repo")
+    info "Stack détectée : ${stacks:-aucune (repo config/docs-only)}"
+
+    # ─── Tier 1 : 10 workflows ─────────────
+    mkdir -p "$repo/.github/workflows"
+    local wf_dest="$repo/.github/workflows"
+    local backup_dir="$repo/.ci-backup-$TS"
+    local copied=0
+    for wf in "$WF_TEMPLATES"/*.yml; do
+        local name
+        name=$(basename "$wf")
+        local dest="$wf_dest/$name"
+
+        if $DRY_RUN; then
+            info "[dry-run] Copierait $name → $wf_dest/"
+            continue
+        fi
+
+        if [[ -f "$dest" ]] && ! $FORCE; then
+            mkdir -p "$backup_dir/workflows"
+            cp "$dest" "$backup_dir/workflows/$name"
+        fi
+
+        cp "$wf" "$dest"
+        copied=$((copied + 1))
+    done
+    ok "Workflows copiés : $copied/10"
+
+    # ─── Tier 3 : github-config ─────────────
+    mkdir -p "$repo/.github"
+    for cfg in labeler.yml labels.yml auto_assign.yml actionlint.yaml; do
+        local src="$CFG_TEMPLATES/$cfg"
+        local dest="$repo/.github/$cfg"
+
+        if $DRY_RUN; then
+            info "[dry-run] Copierait .github/$cfg"
+            continue
+        fi
+
+        if [[ -f "$dest" ]] && ! $FORCE; then
+            mkdir -p "$backup_dir"
+            cp "$dest" "$backup_dir/$cfg"
+        fi
+        cp "$src" "$dest"
+    done
+    ok "github-config copié (4 fichiers)"
+
+    # ─── Tier 2 : dependabot ────────────────
+    generate_dependabot "$repo" "$stacks"
+
+    # ─── Bonus : pre-commit common ──────────
+    if [[ -f "$repo/.pre-commit-config.yaml" ]]; then
+        info "Repo a déjà .pre-commit-config.yaml · fragment common disponible dans $CFG_TEMPLATES/pre-commit-common.yaml (fusion manuelle)"
+    else
+        if $DRY_RUN; then
+            info "[dry-run] Créerait .pre-commit-config.yaml depuis template common"
+        else
+            cp "$CFG_TEMPLATES/pre-commit-common.yaml" "$repo/.pre-commit-config.yaml"
+            ok "pre-commit-config.yaml créé depuis template common"
+        fi
+    fi
+
+    log "── $repo_name : terminé"
+    echo ""
+}
+
+# ═══ Main ═══
+check_templates
+
+if $TARGET_ALL; then
+    log "Mode --all · scan des repos chrysa dans $CHRYSA_ROOT/"
+    for d in "$CHRYSA_ROOT"/*/; do
+        [[ -d "$d/.git" ]] || continue
+        [[ "$(basename "$d")" == "shared-standards" ]] && continue
+        [[ "$(basename "$d")" == "_archived" ]] && continue
+        deploy_one "$d"
+    done
+elif [[ -n "$TARGET_REPO" ]]; then
+    deploy_one "$TARGET_REPO"
+else
+    err "Usage : $0 [--all | <repo_path>] [--dry-run] [--force]"
+    exit 1
+fi
+
+log "════ FIN ════"

--- a/scripts/debian-gui-apps-autoupdate.sh
+++ b/scripts/debian-gui-apps-autoupdate.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# debian-gui-apps-autoupdate.sh · automatise les mises à jour de VS Code, Docker Desktop, GitKraken
+# Source : chrysa/shared-standards/scripts/
+#
+# Stratégie :
+#   · VS Code        → apt repo Microsoft + unattended-upgrades (auto hebdo)
+#   · Docker Desktop → apt repo Docker + unattended-upgrades (auto hebdo)
+#   · GitKraken      → pas d'apt repo officiel · systemd timer custom (check version + download .deb)
+#
+# ⚠️ RAPPEL CLAUDE.md § Alertes :
+#   · GitKraken est flaggé en remplacement par lazygit
+#   · Docker Desktop est flaggé en migration vers Docker Engine
+#   Ce script automatise les updates en PHASE TRANSITOIRE uniquement.
+#
+# Usage :
+#   sudo bash debian-gui-apps-autoupdate.sh              # setup complet (tous les 3)
+#   sudo bash debian-gui-apps-autoupdate.sh --only=vscode
+#   sudo bash debian-gui-apps-autoupdate.sh --only=docker
+#   sudo bash debian-gui-apps-autoupdate.sh --only=gitkraken
+#   sudo bash debian-gui-apps-autoupdate.sh --dry-run
+#   sudo bash debian-gui-apps-autoupdate.sh --disable    # retire les automatisations
+#
+# Exit : 0 OK · 1 erreur · 2 prérequis
+
+set -uo pipefail
+
+ONLY=""
+DRY_RUN=false
+DISABLE=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --only=*) ONLY="${arg#--only=}" ;;
+        --dry-run) DRY_RUN=true ;;
+        --disable) DISABLE=true ;;
+        -h|--help) sed -n '2,22p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    esac
+done
+
+log()  { echo "[$(date +%H:%M:%S)] $*"; }
+ok()   { echo -e "  \033[32m✓\033[0m $*"; }
+warn() { echo -e "  \033[33m⚠\033[0m $*" >&2; }
+err()  { echo -e "  \033[31m✗\033[0m $*" >&2; }
+info() { echo -e "  \033[34m→\033[0m $*"; }
+
+run() {
+    if $DRY_RUN; then
+        info "[dry-run] $*"
+    else
+        eval "$@"
+    fi
+}
+
+should_run() { [[ -z "$ONLY" || "$ONLY" == "$1" ]]; }
+
+# ─── Prérequis ───────────────────────────────────────
+if [[ $EUID -ne 0 ]] && ! $DRY_RUN; then err "Nécessite sudo (--dry-run OK en user)"; exit 2; fi
+for cmd in apt-get curl gpg; do
+    command -v "$cmd" &>/dev/null || { err "$cmd requis"; exit 2; }
+done
+
+# ═══ DISABLE mode ═══
+if $DISABLE; then
+    log "Mode --disable · retire les automatisations"
+    run "systemctl disable --now gitkraken-update.timer 2>/dev/null || true"
+    run "rm -f /etc/systemd/system/gitkraken-update.service /etc/systemd/system/gitkraken-update.timer"
+    run "rm -f /usr/local/bin/gitkraken-update.sh"
+    run "sed -i '/^Unattended-Upgrade::Allowed-Origins.*chrysa-gui/d' /etc/apt/apt.conf.d/50unattended-upgrades 2>/dev/null || true"
+    ok "Automatisations retirées (repos apt conservés · utilise apt remove pour les désinstaller complètement)"
+    exit 0
+fi
+
+# ═══ VS Code ═══
+if should_run "vscode"; then
+    log "═══ 1. VS Code · apt repo Microsoft + unattended-upgrades ═══"
+
+    if ! [[ -f /etc/apt/sources.list.d/vscode.list ]]; then
+        info "Ajout repo Microsoft…"
+        run "install -d -m 0755 /etc/apt/keyrings"
+        run "curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/keyrings/packages.microsoft.gpg"
+        run "echo 'deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main' > /etc/apt/sources.list.d/vscode.list"
+        run "apt-get update -y"
+    else
+        ok "Repo Microsoft déjà présent"
+    fi
+
+    if ! dpkg -l code 2>/dev/null | grep -q '^ii'; then
+        info "Installation VS Code…"
+        run "apt-get install -y code"
+    else
+        ok "VS Code déjà installé"
+    fi
+fi
+
+# ═══ Docker Desktop ═══
+if should_run "docker"; then
+    log "═══ 2. Docker Desktop · apt repo Docker + unattended-upgrades ═══"
+    warn "Rappel : Docker Desktop = ~156€/an · migration Docker Engine recommandée (voir CLAUDE.md alertes)"
+
+    if ! [[ -f /etc/apt/sources.list.d/docker.list ]]; then
+        info "Ajout repo Docker (pour Engine ET Desktop)…"
+        run "install -d -m 0755 /etc/apt/keyrings"
+        run "curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg"
+        run "chmod a+r /etc/apt/keyrings/docker.gpg"
+        # Auto-detect codename
+        CODENAME=$(lsb_release -cs 2>/dev/null || echo "bookworm")
+        run "echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $CODENAME stable' > /etc/apt/sources.list.d/docker.list"
+        run "apt-get update -y"
+    else
+        ok "Repo Docker déjà présent"
+    fi
+
+    if ! dpkg -l docker-desktop 2>/dev/null | grep -q '^ii'; then
+        warn "Docker Desktop n'est pas installé via apt · télécharge manuellement le .deb : https://docs.docker.com/desktop/install/debian/"
+        info "Une fois le .deb installé, ce script configure les updates auto au prochain run."
+    else
+        ok "Docker Desktop déjà installé"
+    fi
+fi
+
+# ═══ Unattended-upgrades pour VS Code + Docker ═══
+if should_run "vscode" || should_run "docker"; then
+    log "═══ 3. Config unattended-upgrades (auto weekly) ═══"
+
+    if ! dpkg -l unattended-upgrades 2>/dev/null | grep -q '^ii'; then
+        run "apt-get install -y unattended-upgrades apt-listchanges"
+    fi
+
+    CONF=/etc/apt/apt.conf.d/50unattended-upgrades
+    if ! grep -q 'chrysa-gui' "$CONF" 2>/dev/null; then
+        info "Ajout des origines GUI à unattended-upgrades…"
+        run "cp $CONF ${CONF}.bak-\$(date +%Y%m%d)"
+        # Ajoute après la dernière ligne Allowed-Origins (avant le }; de fermeture)
+        run "sed -i '/^Unattended-Upgrade::Allowed-Origins/,/^};/{
+            /^};/i\\    \"Microsoft:stable\";  // chrysa-gui (VS Code)\\
+    \"Docker:stable\";     // chrysa-gui (Docker Desktop/Engine)
+        }' $CONF"
+    else
+        ok "Origins chrysa-gui déjà configurées dans $CONF"
+    fi
+
+    # Active le timer systemd apt-daily-upgrade si désactivé
+    run "systemctl enable --now apt-daily-upgrade.timer"
+    ok "Unattended-upgrades armé (check daily · upgrade si Allowed-Origins match)"
+fi
+
+# ═══ GitKraken · systemd timer custom ═══
+if should_run "gitkraken"; then
+    log "═══ 4. GitKraken · systemd timer custom (pas d'apt repo officiel) ═══"
+    warn "Rappel : GitKraken deadline 14/04 · lazygit recommandé (voir CLAUDE.md alertes)"
+
+    # Script de mise à jour (check version puis download .deb si nouvelle)
+    UPDATE_SCRIPT=/usr/local/bin/gitkraken-update.sh
+    if $DRY_RUN; then
+        info "[dry-run] Créerait $UPDATE_SCRIPT"
+    else
+        cat > "$UPDATE_SCRIPT" <<'GKEOF'
+#!/usr/bin/env bash
+# gitkraken-update.sh · check + install dernière version GitKraken
+# Déployé par debian-gui-apps-autoupdate.sh
+set -uo pipefail
+
+URL="https://release.gitkraken.com/linux/gitkraken-amd64.deb"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+DEB="$TMP/gitkraken.deb"
+
+# Version installée (si présente)
+CURRENT=$(dpkg-query -W -f='${Version}' gitkraken 2>/dev/null || echo "none")
+
+# Download .deb (GitKraken publie uniquement latest · pas d'API version)
+curl -sfL -o "$DEB" "$URL" || { echo "[gitkraken-update] download fail"; exit 1; }
+[[ -s "$DEB" ]] || { echo "[gitkraken-update] empty deb"; exit 1; }
+
+# Extract version du .deb
+NEW=$(dpkg-deb -f "$DEB" Version 2>/dev/null || echo "unknown")
+
+if [[ "$CURRENT" == "$NEW" ]]; then
+    echo "[gitkraken-update] $(date -Iseconds) · déjà à jour ($CURRENT)"
+    exit 0
+fi
+
+echo "[gitkraken-update] $(date -Iseconds) · upgrade $CURRENT → $NEW"
+DEBIAN_FRONTEND=noninteractive apt-get install -y "$DEB" || {
+    dpkg -i "$DEB" || { echo "[gitkraken-update] install fail"; exit 1; }
+    apt-get install -y -f
+}
+echo "[gitkraken-update] OK · now $NEW"
+GKEOF
+        chmod +x "$UPDATE_SCRIPT"
+        ok "Script créé : $UPDATE_SCRIPT"
+    fi
+
+    # Service + timer systemd
+    SERVICE=/etc/systemd/system/gitkraken-update.service
+    TIMER=/etc/systemd/system/gitkraken-update.timer
+
+    if $DRY_RUN; then
+        info "[dry-run] Créerait $SERVICE et $TIMER"
+    else
+        cat > "$SERVICE" <<SVCEOF
+[Unit]
+Description=GitKraken auto-update (chrysa · shared-standards)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/gitkraken-update.sh
+StandardOutput=journal
+StandardError=journal
+SVCEOF
+
+        cat > "$TIMER" <<TIMEOF
+[Unit]
+Description=Run gitkraken-update weekly (chrysa · shared-standards)
+
+[Timer]
+OnCalendar=Mon 04:00
+RandomizedDelaySec=30m
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMEOF
+        systemctl daemon-reload
+        systemctl enable --now gitkraken-update.timer
+        ok "Timer systemd armé · lundi 04:00 (+ jitter 30min)"
+        info "Status : systemctl status gitkraken-update.timer · logs : journalctl -u gitkraken-update.service"
+    fi
+fi
+
+log "═══ FIN ═══"
+cat <<EOF
+
+─── Récap des updates automatiques activés ──────────────────────────
+  · VS Code        → unattended-upgrades (daily check · apt Microsoft)
+  · Docker Desktop → unattended-upgrades (daily check · apt Docker)
+  · GitKraken      → systemd timer (weekly lundi 04:00 · download .deb)
+
+  Disable all :   sudo bash $0 --disable
+  Logs VS/Docker : journalctl -u apt-daily-upgrade.service
+  Logs GitKraken : journalctl -u gitkraken-update.service -n 20
+─────────────────────────────────────────────────────────────────────
+
+EOF

--- a/scripts/debian-install-gdrive.sh
+++ b/scripts/debian-install-gdrive.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# debian-install-gdrive.sh · installe gdrive v3 (glotlabs/gdrive) sur Debian
+# Source : chrysa/shared-standards/scripts/
+#
+# Contexte : Google Drive CLI pour sync/upload/download depuis terminal.
+# Projet : https://github.com/glotlabs/gdrive (successeur de prasmussen/gdrive archivé).
+# Binaire pré-compilé · pas d'apt repo officiel · install dans /usr/local/bin/.
+#
+# Usage :
+#   sudo bash debian-install-gdrive.sh              # install dernière release
+#   sudo bash debian-install-gdrive.sh --version 3.9.1   # pin version
+#   sudo bash debian-install-gdrive.sh --uninstall  # supprime
+#   bash debian-install-gdrive.sh --account-setup   # lance le OAuth add (non-sudo)
+#
+# Prérequis post-install : création Google Cloud OAuth client (manuel · doc UI-only) :
+#   https://console.cloud.google.com/apis/credentials
+#   → Create Credentials → OAuth client ID → Desktop app → récupère client_id + secret
+#   Puis : gdrive account add  (colle ces valeurs)
+#
+# Exit : 0 OK · 1 erreur · 2 prérequis
+
+set -uo pipefail
+
+GDRIVE_REPO="glotlabs/gdrive"
+INSTALL_PATH="/usr/local/bin/gdrive"
+ARCH=$(dpkg --print-architecture 2>/dev/null || uname -m)
+VERSION=""
+UNINSTALL=false
+ACCOUNT_SETUP=false
+
+# ─── Args ─────────────────────────────────────────────
+for arg in "$@"; do
+    case "$arg" in
+        --version) shift; VERSION="$1" ;;
+        --version=*) VERSION="${arg#--version=}" ;;
+        --uninstall) UNINSTALL=true ;;
+        --account-setup) ACCOUNT_SETUP=true ;;
+        -h|--help)
+            sed -n '2,22p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+    esac
+    shift 2>/dev/null || true
+done
+
+log()  { echo "[$(date +%H:%M:%S)] $*"; }
+ok()   { echo -e "  \033[32m✓\033[0m $*"; }
+warn() { echo -e "  \033[33m⚠\033[0m $*" >&2; }
+err()  { echo -e "  \033[31m✗\033[0m $*" >&2; }
+info() { echo -e "  \033[34m→\033[0m $*"; }
+
+# ─── Uninstall ───────────────────────────────────────
+if $UNINSTALL; then
+    if [[ $EUID -ne 0 ]]; then err "--uninstall nécessite sudo"; exit 2; fi
+    [[ -f "$INSTALL_PATH" ]] && rm -f "$INSTALL_PATH" && ok "Binaire supprimé : $INSTALL_PATH"
+    ok "gdrive désinstallé (config utilisateur préservée dans ~/.config/gdrive3/)"
+    exit 0
+fi
+
+# ─── Account setup mode ──────────────────────────────
+if $ACCOUNT_SETUP; then
+    if ! command -v gdrive &>/dev/null; then
+        err "gdrive pas installé · lance d'abord : sudo bash $0"
+        exit 2
+    fi
+    log "Lancement de : gdrive account add"
+    info "Tu vas être invité à coller un OAuth client_id + secret."
+    info "Doc création credentials : https://github.com/glotlabs/gdrive/blob/main/docs/create_google_api_credentials.md"
+    exec gdrive account add
+fi
+
+# ─── Prérequis ───────────────────────────────────────
+if [[ $EUID -ne 0 ]]; then err "Install nécessite sudo"; exit 2; fi
+for cmd in curl tar; do
+    command -v "$cmd" &>/dev/null || { err "$cmd requis"; exit 2; }
+done
+
+# ─── Mapping arch Debian → release asset ─────────────
+case "$ARCH" in
+    amd64|x86_64) ASSET_ARCH="x86_64-unknown-linux-musl" ;;
+    arm64|aarch64) ASSET_ARCH="aarch64-unknown-linux-musl" ;;
+    *) err "Arch non supportée : $ARCH"; exit 2 ;;
+esac
+
+# ─── Résolution version ──────────────────────────────
+if [[ -z "$VERSION" ]]; then
+    log "Résolution dernière release de $GDRIVE_REPO…"
+    VERSION=$(curl -sL "https://api.github.com/repos/${GDRIVE_REPO}/releases/latest" \
+        | grep -oP '"tag_name":\s*"\K[^"]+' | head -1)
+    if [[ -z "$VERSION" ]]; then
+        err "Impossible de récupérer la dernière version (API GitHub rate limit ?)"
+        exit 1
+    fi
+fi
+info "Version cible : $VERSION"
+
+# ─── Téléchargement ──────────────────────────────────
+# Format asset : gdrive_X.Y.Z_linux_x86_64.tar.gz (selon tag convention glotlabs)
+VERSION_NO_V="${VERSION#v}"
+ASSET_NAME="gdrive_${ASSET_ARCH}.tar.gz"
+URL="https://github.com/${GDRIVE_REPO}/releases/download/${VERSION}/${ASSET_NAME}"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+log "Téléchargement depuis $URL"
+if ! curl -sL -o "$TMP/gdrive.tar.gz" "$URL"; then
+    err "Échec téléchargement · URL : $URL"
+    exit 1
+fi
+[[ -s "$TMP/gdrive.tar.gz" ]] || { err "Fichier vide"; exit 1; }
+
+# ─── Extract + install ──────────────────────────────
+log "Extraction…"
+tar -xzf "$TMP/gdrive.tar.gz" -C "$TMP" || { err "tar extract fail"; exit 1; }
+BIN=$(find "$TMP" -name "gdrive" -type f -executable | head -1)
+[[ -z "$BIN" ]] && { err "Binaire introuvable dans l'archive"; exit 1; }
+
+install -m 0755 "$BIN" "$INSTALL_PATH"
+ok "Installé : $INSTALL_PATH ($("$INSTALL_PATH" version 2>/dev/null | head -1))"
+
+# ─── Next steps ──────────────────────────────────────
+cat <<EOF
+
+─── Étapes suivantes (manuelles · UI-only) ──────────────────────────
+  1. Crée un OAuth client Google Cloud :
+       https://github.com/glotlabs/gdrive/blob/main/docs/create_google_api_credentials.md
+     TL;DR : console.cloud.google.com → APIs & Services → Credentials →
+             Create Credentials → OAuth client ID → type Desktop app
+
+  2. Ajoute le compte dans gdrive :
+       gdrive account add
+     (colle client_id + secret · navigateur s'ouvre pour valider)
+
+  3. Vérifie :
+       gdrive account list
+       gdrive files list
+
+  Raccourci : bash $0 --account-setup
+─────────────────────────────────────────────────────────────────────
+
+EOF
+
+exit 0

--- a/seeds/media-tracker/README.md
+++ b/seeds/media-tracker/README.md
@@ -1,0 +1,174 @@
+# chrysa/media-tracker
+
+> Tracker films + séries centralisé · Simkl API primaire · self-host option via Yamtrack · remplacement BetaSeries.
+
+**Rôle** : Opportuniste P2
+**Status** : V0 (repo à créer)
+**Public** : oui (instance cloud) · self-host Yamtrack option
+**Stack** : Python 3.14 · FastAPI ≥0.115 · React 19 + Vite 6 · PostgreSQL 16 · Simkl API + TMDB fallback
+**Auth** : `@chrysa/auth` (dépend chrysa-lib Sprint 1)
+
+## Contexte · pourquoi remplacer BetaSeries
+
+BetaSeries a longtemps été le meilleur tracker FR mais en 2026 l'écosystème a bougé. Le vrai besoin utilisateur chrysa : **suivre Netflix + Prime Video + Disney+ + Crunchyroll** (4 services actifs).
+
+### Matrix couverture scrobbling 2026
+
+| Service | BetaSeries | Simkl ext | Trakt Streaming Scrobbler | Yamtrack |
+|---------|:----------:|:---------:|:--------------------------:|:--------:|
+| Netflix | limité | ✅ ext | ✅ **officiel** | ❌ |
+| Prime Video | — | ⚠️ manual | ✅ **officiel** | ❌ |
+| Disney+ | — | ❌ | ✅ **officiel** | ❌ |
+| Crunchyroll | — | ✅ **natif** | ⚠️ ext | ❌ |
+| Apple TV+ / Hulu / Max / Paramount+ | — | ❌ | ✅ officiel | ❌ |
+| Plex / Jellyfin self-host | ❌ | ✅ | ✅ | ✅ natif |
+| Watchlist gratuite | illimitée | illimitée | 100 items (VIP 30€/an) | illimitée |
+| Anime-first design | ❌ | ✅ | partiel | ✅ |
+| Self-host | ❌ | ❌ cloud-only | ❌ | ✅ **Docker** |
+
+### Décision D-0001 · Trakt VIP primary + Jellyfin source locale + Yamtrack mirror
+
+**Architecture à 3 sources convergentes** :
+
+```
+┌────────────────────┐     ┌────────────────────┐     ┌────────────────────┐
+│  Jellyfin Kimsufi  │     │  Trakt Streaming   │     │  Simkl Chrome ext  │
+│  (bibliothèque     │     │  Scrobbler + Univ. │     │  (Crunchyroll      │
+│   perso local)     │     │  Trakt Scrobbler   │     │   natif anime)     │
+└─────────┬──────────┘     └─────────┬──────────┘     └─────────┬──────────┘
+          │ plugin Jellyfin-Trakt    │ Netflix/Prime/Disney+/HBO │
+          └──────────────┬───────────┴───────────────────────────┘
+                         ▼
+                ┌─────────────────┐
+                │  Trakt (cloud)  │
+                │  single source  │
+                └────────┬────────┘
+                         │ nightly sync
+                         ▼
+            ┌─────────────────────────┐
+            │  Yamtrack self-host     │
+            │  (mirror · souveraineté)│
+            │  sur Kimsufi            │
+            └─────────────────────────┘
+```
+
+**Pourquoi Trakt primary** : seule API 2026 avec **Streaming Scrobbler officiel** couvrant Netflix/Prime/Disney+/Apple TV+/Hulu/Max/Paramount+.
+
+**Pourquoi Jellyfin comme source locale** : plugin natif `Jellyfin.Plugin.Trakt` scrobble en temps réel tout ce que tu regardes dans ta bibliothèque perso (FireTV/iPhone/Apple TV/browser compris). Zéro dépendance aux extensions browser pour ce contenu.
+
+**Pourquoi Yamtrack mirror** : souveraineté des données · si Trakt disparaît ou change de modèle, tu as tout ton historique en local.
+
+**Coût** : 30€/an Trakt VIP (watchlist illimitée) · 0€ Jellyfin (déjà sur Kimsufi) · 0€ Yamtrack.
+
+**Alternative si Crunchyroll ≥ 60% du temps** : bascule sur Simkl-primary (voir Appendix A).
+
+## Architecture V1
+
+```
+chrysa/media-tracker/
+  api/                       FastAPI
+    apps/
+      auth/                  @chrysa/auth wrapper
+      providers/
+        trakt.py             Trakt OAuth2 PRIMARY · scrobbling Netflix/Prime/Disney+
+        simkl.py             Simkl OAuth2 fallback Crunchyroll (anime)
+        yamtrack.py          Yamtrack REST self-host mirror (souveraineté)
+        tmdb.py              Metadata enrichment (posters · casting)
+      tracker/
+        models.py            Movie · Episode · WatchEvent · Watchlist
+        services.py          Unified API au-dessus des providers
+        sync.py              Scrobbling + sync Trakt → Yamtrack nightly
+      recommendation/        V2 : scoring + suggestions soir
+  web/                       React 19 + Vite + shadcn/ui
+    src/
+      features/
+        watchlist/           vues watchlist + to-watch
+        history/             historique + notes
+        discover/            catalogue TMDB
+        settings/            OAuth provider switching
+  infra/
+    docker-compose.yml       Postgres + API + web + Yamtrack sidecar
+```
+
+## Scrobbling · comment ça marche concrètement
+
+Trakt ne peut PAS savoir ce que tu regardes sur Netflix/Prime/Disney+ sans ton aide. 3 options actives à activer côté utilisateur :
+
+1. **Trakt Streaming Scrobbler officiel** (dans le site Trakt, Settings → Streaming) → Trakt poll les APIs internes de ces services pour détecter ta dernière vue. Fonctionne sur les services avec un compte Trakt connecté en amont.
+2. **Universal Trakt Scrobbler (extension Chrome/Firefox)** · https://github.com/trakt-tools/universal-trakt-scrobbler · détecte ce que tu regardes dans ton browser en temps réel et scrobble.
+3. **Apps mobiles tierces** (wako) · wrappent les services et scrobble au play.
+
+Pour Crunchyroll spécifiquement, 2 options :
+- Trakt universal extension (moins fiable pour anime)
+- **Simkl Chrome extension** (natif Crunchyroll · recommandé en complément si tu fais beaucoup d'anime)
+
+## Migration BetaSeries
+
+**Via Simkl (natif)** :
+1. Login Simkl → Settings → Import → "Betaseries"
+2. Saisir ton username BetaSeries
+3. Simkl crawl + sync historique (5-10 min)
+4. Verify watchlist + historique + notes préservés
+
+**Via script (Trakt)** :
+- https://github.com/tuxity/betaseries-to-trakt (Python, peut nécessiter update 2026)
+
+**Export CSV manuel** :
+- BetaSeries → Profil → Export CSV (historique + watchlist)
+- Import Simkl/Yamtrack CSV (format standard MediaTracker)
+
+## Features V1 (Q3 2026, après chrysa-lib/auth)
+
+- [ ] OAuth2 Simkl + stockage refresh_token (chrysa-lib/auth)
+- [ ] Sync historique + watchlist (pull Simkl → Postgres local)
+- [ ] UI React : watchlist avec posters TMDB + filters (genre, statut)
+- [ ] UI React : historique chronologique + notes
+- [ ] Scrobbling manuel (mark as watched via UI)
+- [ ] Widget dev-nexus embed : "dernière série vue · prochains épisodes"
+- [ ] Scheduled task weekly-recap (nouveaux épisodes dispo · séries abandonnées · suggestions)
+
+## Features V2
+
+- [ ] Scrobbling auto via Jellyfin webhook (si Jellyfin sur server Kimsufi)
+- [ ] Agent lifeos "suggestion soirée" (genre préféré + dispo + humeur)
+- [ ] Recommendations ML (similar shows via TMDB knn)
+- [ ] Watch party multi-user (notes partagées, vote suivant)
+- [ ] Export CSV backup (redondance Simkl)
+- [ ] Migration 1-clic Simkl → Yamtrack (pour souveraineté future)
+
+## Interactions portefeuille
+
+- **Dépend de** : `chrysa-lib/auth` (Sprint 1) · `server` (DB Postgres shared)
+- **Exporte** : widget `dev-nexus` (embed "last watched") · hook `lifeos` (suggestions planning soir)
+- **Option** : si self-host Yamtrack choisi → déployé sur `server/docker-compose.yml` avec Nginx reverse proxy
+
+## Secrets requis
+
+Collectés par `chrysa-master.sh --init-secrets` (stage 15) :
+- `SIMKL_CLIENT_ID` + `SIMKL_CLIENT_SECRET`
+- `TRAKT_CLIENT_ID` + `TRAKT_CLIENT_SECRET` (optionnel · alternative)
+- `TMDB_API_KEY` (enrichissement metadata · gratuit illimité)
+
+## Budget
+
+- Effort V1 : 60h (Simkl OAuth + UI watchlist + history + scheduled sync)
+- Effort V2 : 80h (scrobbling + recommandations + agents)
+- Infra : 0€ (Simkl cloud gratuit · TMDB gratuit · DB sur Postgres server Kimsufi existant)
+- SaaS : 0€ si Simkl · 30€/an si Trakt VIP (non recommandé)
+- Auto-hébergé Yamtrack : +1Go RAM sur server Kimsufi
+
+## Décisions à acter (D-XXXX à créer)
+
+- D-0001 : Provider primaire = Simkl (vs Trakt vs BetaSeries)
+- D-0002 : Architecture = API dédiée vs extension lifeos agent
+- D-0003 : Scope V1 = tracker-only (pas recommandations ni scrobbling auto)
+- D-0004 : Migration BetaSeries via Simkl native import (pas script custom)
+- D-0005 : Yamtrack self-host = V2 optionnel, pas bloquant V1
+
+## Sources
+
+- [Simkl docs](https://docs.simkl.org/)
+- [Simkl vs Trakt comparison](https://docs.simkl.org/how-to-use-simkl/faq/frequently-asked-questions/simkl-alternatives/simkl-vs-trakt)
+- [Yamtrack GitHub](https://github.com/FuzzyGrim/Yamtrack)
+- [Migration BetaSeries → Simkl](https://docs.simkl.org/how-to-use-simkl/advanced-usage/import-export-data/importing-to-simkl/supported-platforms/betaseries)
+- [TMDB API docs](https://developer.themoviedb.org/reference/intro/getting-started)

--- a/seeds/n8n-notion-comment-agent/README.md
+++ b/seeds/n8n-notion-comment-agent/README.md
@@ -1,0 +1,191 @@
+# n8n · Notion comment agent (conflict resolver)
+
+> Agent qui écoute les commentaires posés dans Notion et répond automatiquement si un conflit est détecté avec une autre partie du document.
+
+**Status** : Design (pending infra n8n)
+**Déploiement** : self-host sur server Kimsufi · docker compose
+**Déclenchement** : Notion webhook (comments) → n8n workflow
+
+## Valeur
+
+Tu poses un commentaire dans une page Notion (ex: "Aelys porte une dague runique ici")
+alors qu'une autre section de la même page dit "Aelys perd sa dague au ch07".
+L'agent détecte le conflit et répond au commentaire avec :
+- Le passage conflictuel (lien direct)
+- 2-3 options de résolution
+- Propose de mettre à jour le canon si nécessaire
+
+Supprime 80% du back-and-forth manuel de vérification de cohérence.
+
+## Pré-requis
+
+- n8n auto-hébergé sur server Kimsufi (dans server/docker-compose.yml)
+- Notion integration avec scope `read:content + insert:comments`
+- Webhook Notion configuré (Settings → Integrations → Webhooks)
+- Claude API (via ai-aggregator pour limiter tokens)
+
+## Architecture du workflow n8n
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Notion Webhook Trigger                                       │
+│ Event: comment.created                                       │
+│ Filter: workspace_id = chrysa                                │
+└─────────┬────────────────────────────────────────────────────┘
+          ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Node 1 · Fetch Comment Context                               │
+│ · GET /v1/comments/{comment_id}                              │
+│ · GET /v1/blocks/{parent_block_id}/children                  │
+│ · GET /v1/pages/{page_id}  (full content)                    │
+└─────────┬────────────────────────────────────────────────────┘
+          ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Node 2 · Extract Claims                                      │
+│ · Envoyer le commentaire + contexte à Claude via ai-agg      │
+│ · Extraire les "claims" = assertions factuelles              │
+│   (ex: "Aelys porte X" · "chapitre Y se passe à Z")          │
+│ · Output : JSON list of claims                               │
+└─────────┬────────────────────────────────────────────────────┘
+          ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Node 3 · Scan Full Document                                  │
+│ · Récupérer TOUS les blocks de la page                       │
+│ · Pour chaque claim, chercher assertions contradictoires     │
+│   via embedding (Qdrant local · server stack)                │
+│ · Score similarité · seuil 0.75                              │
+└─────────┬────────────────────────────────────────────────────┘
+          ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Node 4 · Classify Conflict                                   │
+│ · Si 0 conflit → skip (don't post)                           │
+│ · Si 1-2 conflits → post réponse "Attention"                 │
+│ · Si 3+ conflits → post réponse "Review" + flag page         │
+└─────────┬────────────────────────────────────────────────────┘
+          ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Node 5 · Generate Response                                   │
+│ · Prompt Claude (template fixed · voir prompts/)             │
+│ · Output max 150 mots · format structuré                     │
+│ · Inclut liens vers passages conflictuels                    │
+└─────────┬────────────────────────────────────────────────────┘
+          ↓
+┌──────────────────────────────────────────────────────────────┐
+│ Node 6 · Post Reply + Update Ops DB                          │
+│ · POST /v1/comments (reply to original comment)              │
+│ · Create task in Ops Tasks DB si conflit MAJEUR              │
+│ · Push ntfy notification                                     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Template prompt (prompts/conflict-detect.md)
+
+```
+[Task] Détecter contradictions entre commentaire utilisateur et contenu du document
+[Data]
+ - Commentaire : "{{ comment_body }}"
+ - Passage ciblé : "{{ target_block_content }}"
+ - Document complet : voir blocks joints
+[Goal] Identifier conflits factuels (pas stylistiques) · préserver l'intention utilisateur
+[Output]
+ - Format : JSON { "conflicts": [{ "with_block": "uuid", "summary": "...", "severity": "low|medium|high" }] }
+ - Max 3 conflits
+ - Severity high si incompatibilité logique (personnage mort vs présent)
+```
+
+## Template réponse (prompts/reply-template.md)
+
+```markdown
+🤖 Conflict check · agent n8n
+
+{{#if conflicts}}
+**{{ conflicts.length }} conflit(s) détecté(s)** avec d'autres sections :
+
+{{#each conflicts}}
+- ⚠️ **{{ severity }}** : {{ summary }}
+  → Section : [voir passage]({{ link }})
+  → Options : {{ options[0] }} · {{ options[1] }}
+
+{{/each}}
+
+Résolution manuelle si souhaitée · ou réponds avec "ignore" pour clore.
+{{else}}
+✅ Aucun conflit détecté · claim intégré au canon.
+{{/if}}
+
+---
+*Généré par chrysa/n8n-notion-comment-agent · {{ timestamp }}*
+```
+
+## Configuration (config.yml)
+
+```yaml
+listeners:
+  - workspace: chrysa-perso
+    pages_filter:
+      include_databases:
+        - "FabForge GDD"
+        - "Discordium V3 lore"
+        - "Campagnes D-D"
+        - "Writing drafts"
+      exclude_pages:
+        - "Sandbox"
+
+conflict_detection:
+  embedding_model: nomic-embed-text   # via Ollama local
+  similarity_threshold: 0.75
+  max_context_blocks: 200
+  use_qdrant: true                     # vector store self-hosted
+
+response:
+  post_reply: true
+  min_severity_to_post: medium
+  create_ops_task_if: high
+  max_response_words: 150
+
+rate_limit:
+  max_responses_per_page_per_day: 10   # évite spam sur discussions longues
+  cooldown_minutes: 5
+
+notifications:
+  ntfy_topic: chrysa-morning
+  push_on_conflict: high
+```
+
+## Safety
+
+- **Opt-in par database** via `include_databases` (pas global)
+- **Rate limiting** (max 10 réponses/page/jour)
+- **Pas d'édition de contenu** · uniquement des commentaires en réponse
+- **Severity threshold** : ne répond jamais sur severity low (évite bruit)
+- **Signature** : chaque réponse signée `🤖 Conflict check` pour reconnaître l'agent
+- **Opt-out** : répondre "ignore" au commentaire → l'agent marque et skip
+- **Budget tokens** : via ai-aggregator · réduit coûts 30-50% sinon Claude direct
+
+## Intégration portefeuille
+
+- **Dépend de** :
+  - `server` (Kimsufi · n8n docker · Qdrant)
+  - `ai-aggregator` (proxy Claude · compression doc · budget tracking)
+  - `chrysa-lib/auth` (pas direct · mais pour l'UI admin n8n)
+- **Consomme** : Notion API (webhook + comments)
+- **Exporte** : tâches dans Ops Tasks DB Notion
+
+## Effort estimé
+
+- Design + docker-compose : 2h
+- Webhook Notion setup : 1h
+- 6 nodes n8n : 6h
+- Prompt templates + tests : 3h
+- Qdrant embedding pipeline : 4h
+- Tests integration : 2h
+
+**Total** : ~18h · P2 après server/n8n ready
+
+## Décisions attendues
+
+- D-0001 : embedding model = Ollama nomic-embed-text (local, gratuit) vs OpenAI ada-002
+- D-0002 : Qdrant vs Pgvector vs Weaviate
+- D-0003 : Réponse en français (défaut) vs langue du commentaire auto-détectée
+- D-0004 : Historique embedding persisté ou recalculé à chaque comment
+- D-0005 : Integration avec writing-coherence skill (données partagées ?)

--- a/templates/github-config/actionlint.yaml
+++ b/templates/github-config/actionlint.yaml
@@ -1,0 +1,7 @@
+config-variables:
+- GITHUB_TOKEN
+self-hosted-runner:
+  labels:
+  - ubuntu-22.04
+  - ubuntu-24.04
+  - ubuntu-latest

--- a/templates/github-config/auto_assign.yml
+++ b/templates/github-config/auto_assign.yml
@@ -1,0 +1,10 @@
+addAssignees: author
+addReviewers: true
+numberOfReviewers: 1
+reviewers:
+- anthony-greau
+- chrysa
+skipKeywords:
+- '[SKIP CI]'
+- draft
+- wip

--- a/templates/github-config/dependabot.yml.tpl
+++ b/templates/github-config/dependabot.yml.tpl
@@ -1,0 +1,174 @@
+---
+# Dependabot template chrysa · avril 2026
+# Source : shared-standards/templates/github-config/dependabot.yml.tpl
+#
+# Schedule unifié : vendredi 04h00 UTC cron (évite PR en cours de sprint)
+# Cooldown 7j sur ecosystems bruyants · groups pour réduire volume PR
+#
+# Marqueurs {{ ... }} à remplacer par le script apply-ci-process.sh selon stack détectée.
+# Ecosystems possibles : pip, npm, docker, docker-compose, github-actions, pre-commit, cargo
+
+version: 2
+updates:
+    # ═══ GitHub Actions (tous repos) ═══
+    - package-ecosystem: github-actions
+      directory: .github/workflows/
+      assignees:
+          - chrysa
+      reviewers:
+          - chrysa
+      open-pull-requests-limit: 8
+      commit-message:
+          prefix: "[SKIP CI] [GA] "
+      labels:
+          - skip-ci
+          - dependencies
+          - Ci
+      schedule:
+          interval: cron
+          cronjob: "0 4 * * 5"
+      groups:
+          actions-official:
+              patterns:
+                  - actions/*
+          peter-evans:
+              patterns:
+                  - peter-evans/*
+          community-actions:
+              patterns:
+                  - "*"
+      cooldown:
+          default-days: 7
+
+    # ═══ Pre-commit (tous repos avec .pre-commit-config.yaml) ═══
+    - package-ecosystem: pre-commit
+      directory: /
+      assignees:
+          - chrysa
+      reviewers:
+          - chrysa
+      open-pull-requests-limit: 2
+      commit-message:
+          prefix: "[SKIP CI] [pre-commit] "
+      labels:
+          - skip-ci
+          - dependencies
+          - Pre-commit
+      schedule:
+          interval: cron
+          cronjob: "0 4 * * 5"
+
+# {{ECOSYSTEM_PYTHON_START}}
+    # ═══ Python · pip ═══
+    - package-ecosystem: pip
+      directory: {{PIP_DIR}}
+      assignees:
+          - chrysa
+      reviewers:
+          - chrysa
+      open-pull-requests-limit: 10
+      commit-message:
+          prefix: "[pip] "
+      labels:
+          - dependencies
+          - Python
+      schedule:
+          interval: cron
+          cronjob: "0 4 * * 5"
+      groups:
+          testing:
+              patterns:
+                  - pytest*
+                  - faker
+                  - mock
+                  - coverage*
+          typing-stubs:
+              patterns:
+                  - mypy*
+                  - types-*
+          linters:
+              patterns:
+                  - ruff*
+                  - black*
+                  - flake8*
+      cooldown:
+          default-days: 7
+# {{ECOSYSTEM_PYTHON_END}}
+
+# {{ECOSYSTEM_NPM_START}}
+    # ═══ Node / npm ═══
+    - package-ecosystem: npm
+      directory: {{NPM_DIR}}
+      assignees:
+          - chrysa
+      reviewers:
+          - chrysa
+      open-pull-requests-limit: 10
+      commit-message:
+          prefix: "[npm] "
+      labels:
+          - dependencies
+          - JavaScript
+      schedule:
+          interval: cron
+          cronjob: "0 4 * * 5"
+      groups:
+          react-ecosystem:
+              patterns:
+                  - react
+                  - react-*
+                  - "@types/react*"
+          testing:
+              patterns:
+                  - vitest
+                  - "@testing-library/*"
+                  - jest*
+          build-tools:
+              patterns:
+                  - vite
+                  - "@vitejs/*"
+                  - typescript
+                  - "@typescript-eslint/*"
+                  - eslint*
+      cooldown:
+          default-days: 7
+# {{ECOSYSTEM_NPM_END}}
+
+# {{ECOSYSTEM_DOCKER_START}}
+    # ═══ Docker ═══
+    - package-ecosystem: docker
+      directory: {{DOCKER_DIR}}
+      assignees:
+          - chrysa
+      reviewers:
+          - chrysa
+      open-pull-requests-limit: 5
+      commit-message:
+          prefix: "[docker] "
+      labels:
+          - dependencies
+          - Docker
+      schedule:
+          interval: cron
+          cronjob: "0 4 * * 5"
+# {{ECOSYSTEM_DOCKER_END}}
+
+# {{ECOSYSTEM_DOCKER_COMPOSE_START}}
+    # ═══ docker-compose ═══
+    - package-ecosystem: docker-compose
+      directory: /
+      assignees:
+          - chrysa
+      reviewers:
+          - chrysa
+      open-pull-requests-limit: 5
+      commit-message:
+          prefix: "[SKIP CI] [docker-compose] "
+      labels:
+          - skip-ci
+          - dependencies
+          - Docker
+      schedule:
+          interval: cron
+          cronjob: "0 4 * * 5"
+# {{ECOSYSTEM_DOCKER_COMPOSE_END}}

--- a/templates/github-config/labeler.yml
+++ b/templates/github-config/labeler.yml
@@ -1,0 +1,128 @@
+Api:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/api/**'
+    - '**/api_urls.py'
+    - '**/routes/**'
+    - '**/services/**'
+Auth:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/auth/**'
+    - '**/authentication/**'
+Ci:
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/workflows/**
+    - .github/actions/**
+Configurations:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/config/**'
+    - '**/.eslintrc*'
+    - '**/eslint.config.*'
+    - '**/vite.config.*'
+    - '**/vitest.config.*'
+    - '**/ruff.toml'
+    - '**/mypy.ini'
+Database:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/migrations/**'
+    - '**/models/**'
+    - '**/models.py'
+    - '**/schema.sql'
+Docker:
+- changed-files:
+  - any-glob-to-any-file:
+    - docker/**
+    - Dockerfile*
+    - .dockerignore
+    - docker-compose*.y[a]ml
+Docs:
+- changed-files:
+  - any-glob-to-any-file:
+    - docs/**
+    - '**/*.md'
+    - '**/*.rst'
+JavaScript:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/*.js'
+    - '**/*.jsx'
+    - '**/*.mjs'
+    - '**/*.cjs'
+    - package.json
+    - package-lock.json
+    - pnpm-lock.yaml
+    - yarn.lock
+Makefiles:
+- changed-files:
+  - any-glob-to-any-file:
+    - Makefile
+    - makefiles/**
+Pre-commit:
+- changed-files:
+  - any-glob-to-any-file:
+    - .pre-commit-config.yaml
+Python:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/*.py'
+    - pyproject.toml
+    - requirements*.txt
+    - setup.cfg
+    - setup.py
+Release:
+- base-branch:
+  - main
+  - master
+Scripts:
+- changed-files:
+  - any-glob-to-any-file:
+    - scripts/**
+    - bin/**
+Shell:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/*.sh'
+    - '**/*.bash'
+    - Makefile
+Staging:
+- base-branch: develop
+Tests:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/tests/**'
+    - '**/__tests__/**'
+    - '**/*.test.*'
+    - '**/*.spec.*'
+    - '**/conftest.py'
+Translations:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/i18n/**'
+    - '**/locales/**'
+    - '**/translations/**'
+TypeScript:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/*.ts'
+    - '**/*.tsx'
+    - tsconfig*.json
+Ui:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/components/**'
+    - '**/pages/**'
+    - '**/layouts/**'
+    - '**/styles/**'
+    - '**/*.css'
+    - '**/*.scss'
+skip-ci:
+- changed-files:
+  - any-glob-to-all-files:
+    - docs/**
+    - '*.md'
+    - '*.rst'
+    - LICENSE

--- a/templates/github-config/labels.yml
+++ b/templates/github-config/labels.yml
@@ -1,0 +1,159 @@
+# GitHub Labels — Template chrysa unifié
+# Source : shared-standards/templates/github-config/labels.yml
+# Inspiré padam-av · simplifié pour portefeuille chrysa (stacks hétérogènes)
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# CRITICAL — Red
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'tests failing'
+  color: 'D73A4A'
+  description: 'CI tests are failing'
+- name: 'bug'
+  color: 'CC317C'
+  description: 'Bug report'
+- name: 'security'
+  color: 'B60205'
+  description: 'Security-related change'
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# BLOCKING — Orange/Yellow
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'Blocked'
+  color: 'DA7300'
+  description: 'PR blocked by dependencies'
+- name: 'Conflicts'
+  color: 'E1C82E'
+  description: 'Merge conflicts detected'
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# APPROVAL — Green
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'Approved'
+  color: '0E8A16'
+  description: 'Approved by at least one committer'
+- name: 'ready to review'
+  color: '2ECC71'
+  description: 'Ready for review'
+- name: 'auto-merge'
+  color: '2ECC71'
+  description: 'Enabled auto-merge on CI green + owner approval'
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# SIZE — Yellow Scale
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'Size/XS'
+  color: 'FBCA04'
+  description: 'Extra small change (<20 lines)'
+- name: 'Size/S'
+  color: 'FCE47B'
+  description: 'Small change (<50 lines)'
+- name: 'Size/M'
+  color: 'F9D576'
+  description: 'Medium change (<200 lines)'
+- name: 'Size/L'
+  color: 'E5AF0C'
+  description: 'Large change (<800 lines)'
+- name: 'Size/XL'
+  color: 'D4860E'
+  description: 'Extra large change (>800 lines)'
+- name: 'Size/XXL'
+  color: 'B85E0A'
+  description: 'Very large change'
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# TYPE — Work Type
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'feature'
+  color: 'A2EEEF'
+  description: 'New feature'
+- name: 'refactor'
+  color: '009800'
+  description: 'Code refactoring without behavior changes'
+- name: 'chore'
+  color: '607D8B'
+  description: 'Maintenance changes'
+- name: 'docs-only'
+  color: '0075CA'
+  description: 'Documentation-only change'
+- name: 'dependencies'
+  color: '0366D6'
+  description: 'Dependency update (Dependabot)'
+- name: 'hotfix'
+  color: 'E11D21'
+  description: 'Urgent production fix'
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# LANGUAGE — Blue variants
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'Python'
+  color: '3572A5'
+  description: 'Python code change'
+- name: 'TypeScript'
+  color: '3178C6'
+  description: 'TypeScript code change'
+- name: 'JavaScript'
+  color: 'F7DF1E'
+  description: 'JavaScript code change'
+- name: 'Shell'
+  color: '89E051'
+  description: 'Shell/bash scripts'
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# AREA — Technical Domain (Teal/Cyan)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'Api'
+  color: '0052CC'
+  description: 'API layer'
+- name: 'Ui'
+  color: '5319E7'
+  description: 'UI/UX changes'
+- name: 'Auth'
+  color: '1D5CC3'
+  description: 'Authentication/authorization'
+- name: 'Database'
+  color: '1D5CC3'
+  description: 'DB schema/migrations'
+- name: 'Tests'
+  color: '5CBF82'
+  description: 'Test files'
+- name: 'Translations'
+  color: '8E44AD'
+  description: 'i18n strings'
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# INFRA / META — Gray
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'Ci'
+  color: 'A6A6A6'
+  description: 'GitHub Actions / CI workflows'
+- name: 'Docker'
+  color: '2F74AA'
+  description: 'Dockerfiles / compose'
+- name: 'Docs'
+  color: 'A6A6A6'
+  description: 'Documentation'
+- name: 'Makefiles'
+  color: 'A6A6A6'
+  description: 'Makefiles'
+- name: 'Pre-commit'
+  color: 'A6A6A6'
+  description: 'Pre-commit config / hooks'
+- name: 'Configurations'
+  color: 'A6A6A6'
+  description: 'Config files (eslint/ruff/tsconfig/pyproject)'
+- name: 'Scripts'
+  color: 'A6A6A6'
+  description: 'Repo scripts'
+- name: 'Quality'
+  color: 'A6A6A6'
+  description: 'Linters / formatters'
+- name: 'Release'
+  color: 'A6A6A6'
+  description: 'Release workflow'
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# CI CONTROL — skip-ci etc
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+- name: 'skip-ci'
+  color: 'A6A6A6'
+  description: 'Documentation-only or config-only; CI can be skipped'

--- a/templates/github-config/pre-commit-common.yaml
+++ b/templates/github-config/pre-commit-common.yaml
@@ -1,0 +1,63 @@
+repos:
+- hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-json
+  - id: check-toml
+  - args:
+    - --maxkb=1024
+    id: check-added-large-files
+  - id: check-merge-conflict
+  - id: check-case-conflict
+  - id: mixed-line-ending
+  - id: detect-private-key
+  repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+- hooks:
+  - args:
+    - --baseline
+    - .secrets.baseline
+    exclude: package.lock.json|yarn.lock|pnpm-lock.yaml
+    id: detect-secrets
+  repo: https://github.com/Yelp/detect-secrets
+  rev: v1.5.0
+- hooks:
+  - args:
+    - --strict
+    - --force-scope
+    - feat
+    - fix
+    - chore
+    - docs
+    - refactor
+    - test
+    - ci
+    - build
+    - perf
+    id: conventional-pre-commit
+    stages:
+    - commit-msg
+  repo: https://github.com/compilerla/conventional-pre-commit
+  rev: v3.4.0
+- hooks:
+  - args:
+    - --disable
+    - MD013
+    - MD033
+    - --
+    id: markdownlint
+  repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.43.0
+- hooks:
+  - args:
+    - -d
+    - '{extends: default, rules: {line-length: disable, document-start: disable}}'
+    id: yamllint
+  repo: https://github.com/adrienverge/yamllint
+  rev: v1.35.1
+- hooks:
+  - files: ^\.github/workflows/.*\.ya?ml$
+    id: actionlint
+  repo: https://github.com/rhysd/actionlint
+  rev: v1.7.7

--- a/templates/workflows-process/action-check.yml
+++ b/templates/workflows-process/action-check.yml
@@ -1,0 +1,28 @@
+true:
+  pull_request:
+    paths:
+    - .github/actionlint.yaml
+    - .github/workflows/**
+  push:
+    branches:
+    - develop
+    - main
+    - master
+    paths:
+    - .github/workflows/**
+jobs:
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+    - name: Run actionlint
+      uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc
+      with:
+        matcher: true
+name: Actionlint
+permissions:
+  contents: read

--- a/templates/workflows-process/approved-label.yml
+++ b/templates/workflows-process/approved-label.yml
@@ -1,0 +1,21 @@
+true: pull_request_review
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+jobs:
+  label-when-approved:
+    name: Label when approved
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label when approved by committers
+      uses: TobKed/label-when-approved-action@0058d0094da27e116fad6e0da516ebe1107f26de
+      with:
+        comment: PR approved by at least one committer.
+        label: Approved
+        remove_label_when_approval_missing: 'false'
+        require_committers_approval: 'true'
+        token: ${{ github.token }}
+name: Label when approved
+permissions:
+  contents: read
+  pull-requests: write

--- a/templates/workflows-process/auto-assign.yml
+++ b/templates/workflows-process/auto-assign.yml
@@ -1,0 +1,22 @@
+true:
+  pull_request:
+    types:
+    - opened
+    - ready_for_review
+    - reopened
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+    - name: Auto assign reviewers
+      uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6
+      with:
+        configuration-path: .github/auto_assign.yml
+name: Auto Assign Reviewers
+permissions:
+  contents: read
+  pull-requests: write

--- a/templates/workflows-process/auto-update-pre-commit.yml
+++ b/templates/workflows-process/auto-update-pre-commit.yml
@@ -1,0 +1,39 @@
+true:
+  schedule:
+  - cron: 0 5 * * 1
+  workflow_dispatch: null
+jobs:
+  pre-commit-autoupdate:
+    name: Bump pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Python
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+      with:
+        python-version: '3.12'
+    - name: Install pre-commit
+      run: pip install --upgrade pre-commit
+    - name: Autoupdate hooks
+      run: pre-commit autoupdate
+    - name: Open PR if changes
+      uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f
+      with:
+        body: Automated weekly bump of `.pre-commit-config.yaml` hooks.
+        branch: chore/pre-commit-autoupdate
+        commit-message: 'chore(pre-commit): autoupdate hook versions'
+        delete-branch: true
+        labels: 'skip-ci
+
+          Pre-commit
+
+          '
+        title: '[SKIP CI] [pre-commit] Autoupdate weekly'
+name: Auto-update pre-commit hooks
+permissions:
+  contents: write
+  pull-requests: write

--- a/templates/workflows-process/detect-conflicts.yml
+++ b/templates/workflows-process/detect-conflicts.yml
@@ -1,0 +1,53 @@
+true:
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+jobs:
+  detect-conflicts:
+    name: Detect conflicts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check merge conflicts and manage PR status
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+      with:
+        script: "const pr = context.payload.pull_request;\nconst prNumber = pr.number;\n\
+          const conflictsLabel = 'Conflicts';\nconst titlePrefix = '[CONFLICTS] ';\n\
+          const baseBranch = pr.base.ref;\n\nlet mergeable = pr.mergeable;\nif (mergeable\
+          \ === null) {\n  for (let i = 0; i < 10; i++) {\n    await new Promise(r\
+          \ => setTimeout(r, 3000));\n    const { data: freshPr } = await github.rest.pulls.get({\n\
+          \      owner: context.repo.owner,\n      repo: context.repo.repo,\n    \
+          \  pull_number: prNumber\n    });\n    mergeable = freshPr.mergeable;\n\
+          \    if (mergeable !== null) break;\n  }\n}\n\nconst labels = pr.labels.map(l\
+          \ => l.name);\nconst hasConflictsLabel = labels.includes(conflictsLabel);\n\
+          \nif (mergeable === false) {\n  if (!hasConflictsLabel) {\n    await github.rest.issues.addLabels({\n\
+          \      owner: context.repo.owner, repo: context.repo.repo,\n      issue_number:\
+          \ prNumber, labels: [conflictsLabel]\n    });\n  }\n  const currentTitle\
+          \ = pr.title;\n  const alreadyPrefixed = currentTitle.startsWith(titlePrefix);\n\
+          \  if (!pr.draft || !alreadyPrefixed) {\n    const newTitle = alreadyPrefixed\
+          \ ? currentTitle : titlePrefix + currentTitle;\n    await github.rest.pulls.update({\n\
+          \      owner: context.repo.owner, repo: context.repo.repo,\n      pull_number:\
+          \ prNumber, draft: true, title: newTitle\n    });\n    await github.rest.issues.createComment({\n\
+          \      owner: context.repo.owner, repo: context.repo.repo,\n      issue_number:\
+          \ prNumber,\n      body: `\u26A0\uFE0F **Conflits d\xE9tect\xE9s \u2014\
+          \ PR en draft**\\n\\nConflits avec \\`${baseBranch}\\`. R\xE9solvez puis\
+          \ repassez \"Ready for review\".`\n    });\n  }\n} else if (mergeable ===\
+          \ true && hasConflictsLabel) {\n  await github.rest.issues.removeLabel({\n\
+          \    owner: context.repo.owner, repo: context.repo.repo,\n    issue_number:\
+          \ prNumber, name: conflictsLabel\n  });\n  const currentTitle = pr.title;\n\
+          \  if (currentTitle.startsWith(titlePrefix)) {\n    await github.rest.pulls.update({\n\
+          \      owner: context.repo.owner, repo: context.repo.repo,\n      pull_number:\
+          \ prNumber, title: currentTitle.slice(titlePrefix.length)\n    });\n  }\n\
+          \  await github.rest.issues.createComment({\n    owner: context.repo.owner,\
+          \ repo: context.repo.repo,\n    issue_number: prNumber,\n    body: `\u2705\
+          \ Conflits r\xE9solus.`\n  });\n}\n"
+    timeout-minutes: 5
+name: Check Conflicts
+permissions:
+  contents: read
+  pull-requests: write
+run-name: Check Conflicts

--- a/templates/workflows-process/labeler.yml
+++ b/templates/workflows-process/labeler.yml
@@ -1,0 +1,23 @@
+true:
+  pull_request: null
+  workflow_call: null
+  workflow_dispatch: null
+jobs:
+  labels:
+    name: Apply labels on pull request
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
+      with:
+        sync-labels: true
+name: Pull Request Labels
+permissions:
+  contents: read
+  pull-requests: write
+run-name: "\U0001F3F7\uFE0F apply labeler by ${{ github.actor }}"

--- a/templates/workflows-process/pr-dependencies.yml
+++ b/templates/workflows-process/pr-dependencies.yml
@@ -1,0 +1,32 @@
+true:
+  pull_request:
+    branches-ignore:
+    - develop
+    - main
+    - master
+    types:
+    - auto_merge_enabled
+    - opened
+    - ready_for_review
+    - reopened
+    - synchronize
+  schedule:
+  - cron: 0 0 * * *
+  workflow_call: null
+  workflow_dispatch: null
+jobs:
+  check_dependencies:
+    name: Check Dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: gregsdennis/dependencies-action@v1.4.2
+    - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
+      with:
+        use-label: Blocked
+name: Check PR dependencies
+permissions:
+  contents: read
+  pull-requests: write
+run-name: ${{ github.workflow }} by ${{ github.actor }}

--- a/templates/workflows-process/pull-request-size.yml
+++ b/templates/workflows-process/pull-request-size.yml
@@ -1,0 +1,20 @@
+true: pull_request_target
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      name: Label pull request by size
+      uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        fail_if_xl: false
+        l_max_size: 800
+        m_max_size: 200
+        s_max_size: 50
+        xs_max_size: 20
+name: Label Pull Request Size
+permissions:
+  contents: read
+  pull-requests: write

--- a/templates/workflows-process/sync-labels.yml
+++ b/templates/workflows-process/sync-labels.yml
@@ -1,0 +1,27 @@
+true:
+  push:
+    branches:
+    - develop
+    - main
+    - master
+    paths:
+    - .github/labels.yml
+  schedule:
+  - cron: 0 2 * * 1
+  workflow_dispatch: null
+jobs:
+  sync-labels:
+    name: Synchronize labels
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - name: Sync labels
+      uses: marocchino/create-labels@v1.3.0
+      with:
+        labels: .github/labels.yml
+name: Sync GitHub Labels
+permissions:
+  contents: read
+  issues: write
+run-name: "\U0001F3F7\uFE0F Sync labels from config"

--- a/templates/workflows-process/update-pr-body.yml
+++ b/templates/workflows-process/update-pr-body.yml
@@ -1,0 +1,40 @@
+true:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+jobs:
+  update-body:
+    if: contains(github.event.pull_request.body, '<!-- auto-changes-start -->')
+    name: Fill auto-changes section
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 0
+    - env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      name: Update PR body
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+      with:
+        script: "const { execSync } = require('child_process');\nconst baseRef = process.env.BASE_REF;\n\
+          const prNumber = parseInt(process.env.PR_NUMBER, 10);\n\nexecSync(`git fetch\
+          \ origin ${baseRef} --depth=50`, { stdio: 'inherit' });\n\nconst rawLog\
+          \ = execSync(\n    `git log origin/${baseRef}..HEAD --oneline --no-merges\
+          \ --reverse`,\n    { encoding: 'utf8' }\n).trim();\n\nconst bullets = rawLog.length\
+          \ > 0\n    ? rawLog.split('\\n').map(line => `- ${line}`).join('\\n')\n\
+          \    : '- _no commits yet_';\n\nconst { data: pr } = await github.rest.pulls.get({\n\
+          \    owner: context.repo.owner,\n    repo: context.repo.repo,\n    pull_number:\
+          \ prNumber,\n});\n\nconst marker = /<!-- auto-changes-start -->[\\s\\S]*?<!--\
+          \ auto-changes-end -->/;\nconst replacement = `<!-- auto-changes-start -->\\\
+          n${bullets}\\n<!-- auto-changes-end -->`;\nconst updatedBody = pr.body.replace(marker,\
+          \ replacement);\n\nif (updatedBody === pr.body) {\n    console.log('No change\
+          \ detected \u2014 skipping update.');\n    return;\n}\n\nawait github.rest.pulls.update({\n\
+          \    owner: context.repo.owner,\n    repo: context.repo.repo,\n    pull_number:\
+          \ prNumber,\n    body: updatedBody,\n});\n\nconsole.log('PR body updated.');\n"
+name: Update PR body
+permissions:
+  contents: read
+  pull-requests: write


### PR DESCRIPTION
Adds 5 project-type-specific GitHub Copilot instruction templates that extend `base.md`:

- `fastapi.md`: FastAPI layout, async SQLAlchemy, JWT, Pydantic, testing
- `react19.md`: React 19, React Query, RTK, Zod, Vitest, MSW
- `monorepo.md`: pnpm workspaces, Turborepo, changesets, CI filters
- `gas.md`: GAS ES2020, clasp deploy, CONFIG_* pattern, Jest mocks
- `python-library.md`: PEP 561, mypy strict, flit/hatchling, mkdocs

Closes #27