### PR TITLE
chore(ci): update actions/checkout from v4 to v5

### DIFF
--- a/workflows/ci-node.yml
+++ b/workflows/ci-node.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Lint & pre-commit
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-node@v4
               with:
                   node-version: '22'
@@ -32,7 +32,7 @@ jobs:
         name: Tests
         needs: lint
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-node@v4
               with:
                   node-version: '22'

--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -20,7 +20,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Lint & pre-commit
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-python@v5
               with:
                   python-version: '3.12'
@@ -32,7 +32,7 @@ jobs:
         name: Tests
         needs: lint
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: actions/setup-python@v5
               with:
                   python-version: '3.12'

--- a/workflows/notion-branch-sync.yml
+++ b/workflows/notion-branch-sync.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     if: vars.NOTION_BRANCHES_DB_ID != ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # full history needed for CHANGELOG diff
 

--- a/workflows/pages.yml
+++ b/workflows/pages.yml
@@ -77,7 +77,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Deploy (peaceiris)
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Set up Python
               if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'pip') }}
@@ -112,7 +112,7 @@ jobs:
         runs-on: ubuntu-latest
         name: Build site (official)
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - name: Set up Python
               if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'pip') }}

--- a/workflows/release.yml
+++ b/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         name: Semantic Release
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
                   token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/workflows/sonar.yml
+++ b/workflows/sonar.yml
@@ -55,7 +55,7 @@ jobs:
         name: SonarCloud
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 


### PR DESCRIPTION
## Summary
Update `actions/checkout` from v4 to v5 across shared workflow templates.

Node.js 20 (v4) is deprecated — v5 uses updated runner support.
Deadline: 2 juin 2026.

## Changed files
- `workflows/ci-node.yml`
- `workflows/ci-python.yml`
- `workflows/notion-branch-sync.yml`
- `workflows/pages.yml`
- `workflows/release.yml`
- `workflows/sonar.yml`