### PR TITLE
ci(pre-commit): bump chrysa/pre-commit-tools to v0.1.1-72

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   - id: env-file-check
   - id: env-example-sync
   repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-58
+  rev: v0.1.1-72
 - hooks:
   - id: gitleaks
   repo: https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
Bump `chrysa/pre-commit-tools` rev to `v0.1.1-72` — compatible with Python 3.14 (`setuptools.backends.legacy` fix).