### PR TITLE
ci: update to Python 3.14 and chrysa/github-actions composites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - uses: actions/setup-python@v6.2.0
+            - uses: actions/setup-python@v6
               with:
-                  python-version: '3.12'
+                  python-version: "3.14"
+                  cache: pip
 
             - name: Run pre-commit hooks
               uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Update CI to use Python 3.14, fix action version, add pip cache:
- `setup-python@v6.2.0` → `@v6`; python 3.12 → 3.14 + `cache: pip`