### PR TITLE
fix(ci): bump actions/checkout to v6 in sonar.yml

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
             - name: SonarCloud scan


### PR DESCRIPTION
- `actions/checkout@v4` → `@v6` in `.github/workflows/sonar.yml`
- Node.js 20 deprecation fix (deadline June 2 2026)