### PR TITLE
fix(ci): remove cache:pip in CI, skip no-commit-to-branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,11 @@ jobs:
             - uses: actions/setup-python@v6
               with:
                   python-version: "3.14"
-                  cache: pip
 
             - name: Run pre-commit hooks
               uses: pre-commit/action@v3.0.1
+              env:
+                  SKIP: no-commit-to-branch
 
     validate-templates:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Fixes
- Remove `cache: pip` from `actions/setup-python@v6` — no `pyproject.toml`/`requirements.txt` exists in this docs-only repo
- Add `SKIP: no-commit-to-branch` env to pre-commit step — prevents false CI failure on main branch