### PR TITLE
fix(workflows): replace incorrect uses: comments with copy-to-use instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,21 @@ Shared GitHub Copilot instructions, generic workflows, templates, and Claude Cod
 copilot-instructions/
   base.md                       # Base GitHub Copilot instructions
 
-workflows/
-  ci-python.yml                 # Reusable CI workflow for Python projects
-  ci-node.yml                   # Reusable CI workflow for Node/React projects
-  sonar.yml                     # SonarQube analysis workflow
-  release.yml                   # Semantic release workflow (softprops/action-gh-release)
-  labeler.yml                   # PR auto-labeler workflow (actions/labeler@v6)
-  pr-size.yml                   # PR size label workflow (codelytv/pr-size-labeler)
-  pages.yml                     # GitHub Pages deploy (peaceiris or official actions/deploy-pages)
-  notion-roadmap-sync.yml       # Notion roadmap sync (issues/PR events → Notion table row)
-  notion-branch-sync.yml        # Per-branch Notion docs (every push → Branch Activity DB)
+workflows/                        # ⚠️ COPY-TO-USE templates — NOT callable via `uses: chrysa/shared-standards/...`
+  ci-python.yml                 # Full CI pipeline template for Python projects (copy to .github/workflows/ci.yml)
+  ci-node.yml                   # Full CI pipeline template for Node/React projects
+  sonar.yml                     # SonarCloud workflow template (workflow_call-compatible after copy)
+  release.yml                   # Semantic release template (GitVersion + cliff)
+  labeler.yml                   # PR auto-labeler template (actions/labeler@v6)
+  pr-size.yml                   # PR size label template (codelytv/pr-size-labeler)
+  pages.yml                     # GitHub Pages deploy template
+  notion-roadmap-sync.yml       # Notion roadmap sync template
+  notion-branch-sync.yml        # Per-branch Notion docs template
+  regression-gate.yml           # Regression gate (coverage + test count delta)
+  mutation-testing.yml          # Mutation testing template (mutmut)
+  contract-testing.yml          # Consumer-driven contract testing template
+  enforce-feature-branch.yml    # Block PRs from non-conventional branch names
+  secret-scan.yml               # Secret scanning with gitleaks
 
 templates/
   CLAUDE.md                     # Bootstrap CLAUDE.md template
@@ -67,7 +72,15 @@ Copy `copilot-instructions/base.md` to `.github/copilot-instructions.md` in your
 
 ### Workflows
 
-Reference the generic workflows from `.github/workflows/` in your repo CIs.
+Copy the relevant template from `workflows/` to `.github/workflows/` in your repo and adapt.
+These are **copy-to-use templates**, not reusable workflows callable via `uses:`.
+Composite actions (atomic steps) live in [`chrysa/github-actions`](https://github.com/chrysa/github-actions) — use them from inside your copied workflows.
+
+```bash
+# Example: add SonarCloud CI to your project
+cp path/to/shared-standards/workflows/sonar.yml .github/workflows/sonar.yml
+# Then edit to set your project key and secrets
+```
 
 ### Templates
 

--- a/copilot-instructions/fastapi.md
+++ b/copilot-instructions/fastapi.md
@@ -39,6 +39,107 @@ tests/
 - Use `status.HTTP_*` constants, not magic integers.
 - Validate path and query params with Annotated types and field constraints.
 
+## HATEOAS (NON-NEGOTIABLE)
+
+Every endpoint that returns a resource or collection **MUST** include a `links` field. Clients must be able to navigate the entire API from links — no hardcoded paths allowed.
+
+```python
+class Link(BaseModel):
+    href: str
+    rel: str
+    method: str = "GET"
+
+class ResourceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    # ... resource fields ...
+    links: list[Link]
+```
+
+- `links` is **required** on every response model, never optional.
+- Standard rels: `self`, `collection`, `next`, `prev`, `first`, `last`, `related`, `create`, `update`, `delete`.
+- Follow [IANA link relations](https://www.iana.org/assignments/link-relations/) where applicable.
+- Build URLs via `request.url_for()` or `str(request.base_url)` — never hardcode host/port.
+- Collection responses must include `total`, `page`, `size` and full pagination links (`next`, `prev`, `first`, `last`).
+
+## RFC 7807 — Problem Details
+
+All error responses **MUST** use [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) with `Content-Type: application/problem+json`.
+
+```python
+class ProblemDetail(BaseModel):
+    type: str = "about:blank"
+    title: str
+    status: int
+    detail: str
+    instance: str  # request URL
+```
+
+- Register a global `HTTPException` handler in `main.py` that wraps all errors in `ProblemDetail`.
+- Never return FastAPI's default `{"detail": "..."}` in production.
+- Never expose stack traces or internal paths in `detail` or `instance`.
+
+## Health endpoints
+
+Every API must expose:
+
+| Path | Purpose | Auth |
+|---|---|---|
+| `GET /health` | General health | None |
+| `GET /health/live` | Kubernetes liveness | None |
+| `GET /health/ready` | Kubernetes readiness (checks DB) | None |
+
+- `HealthResponse`: `{"status": "ok" | "degraded" | "down", "version": "x.y.z"}`.
+- `/health/ready` must execute `SELECT 1` to verify DB reachability.
+- Health endpoints are excluded from auth, rate limiting, and CORS restrictions.
+
+## Filtering, sorting, search
+
+- `sort`: `-` prefix = DESC. Example: `?sort=-created_at,name`.
+- Filters: bracket notation `?filter[status]=active` — never flat `?status=active`.
+- `search`: full-text on documented fields.
+- `size` max: **100** — never allow unbounded collection queries.
+- Use a shared `CollectionParams` Pydantic model injected via `Depends()`.
+
+## Idempotency
+
+- Critical `POST` endpoints (payments, bookings, notifications) must accept `Idempotency-Key` header.
+- Store the key on the resource row; return the identical response on replay within 24 h.
+- Document supported endpoints in Swagger.
+
+## API versioning & deprecation
+
+- Version prefix: `/api/v1/` — bump to `/api/v2/` on breaking changes only.
+- Deprecated endpoints must set response headers: `Deprecation: true`, `Sunset: <RFC7231 date>`, `Link: </api/v2/resource>; rel="successor-version"`.
+- Minimum deprecation window: **3 months**. Remove only after Sunset date and zero traffic.
+
+## Structured logging & observability
+
+- Every request must emit a structured JSON log: `timestamp`, `request_id`, `method`, `path`, `status`, `duration_ms`, `user_id`.
+- Propagate `X-Request-ID` from incoming request or generate one; return it in every response.
+- **Never log PII** — mask or omit email, token, password, card data.
+- Log level: `WARNING` for 4xx, `ERROR` for 5xx.
+- Wire Sentry in `lifespan` for 5xx exception capture.
+- Add a `RequestLoggingMiddleware` that sets `X-Request-ID` and emits the access log entry.
+
+## Rate limiting
+
+- Use `slowapi`. Always include rate limit headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After` (on 429).
+- Default limits: login/register `5/min` · public reads `100/min` · authenticated `1000/min`.
+- 429 body must be a `ProblemDetail` with `type: "urn:problem:rate-limit-exceeded"`.
+
+## HTTP caching
+
+- Return `ETag` (content hash) and `Cache-Control` on read-heavy GET endpoints.
+- Respond `304 Not Modified` when `If-None-Match` matches the current ETag.
+- `Cache-Control: private` for authenticated resources, `no-store` for collections and mutations.
+
+## Long-running async operations
+
+- Operations > ~2 s: return `202 Accepted` + `JobResponse` with `links.status`; run in `BackgroundTasks` or ARQ.
+- `JobResponse` fields: `job_id`, `status` (`pending|running|done|failed`), `result`, `error`, `links`.
+- Polling endpoint returns `Retry-After` header while job is in progress.
+
 ## Database
 
 - Use SQLAlchemy 2.x async (`AsyncSession`).

--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -1,8 +1,9 @@
 ---
-# Reusable CI workflow for Python projects (chrysa ecosystem)
-# Usage: uses: chrysa/shared-standards/.github/workflows/ci-python.yml@main
+# CI workflow template for Python projects (chrysa ecosystem)
+# Usage: copy to .github/workflows/ci.yml and adapt.
 #
-# Or copy this file to .github/workflows/ci.yml and adapt.
+# ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it cannot be
+#    called via `uses: chrysa/shared-standards/...`. Copy it to your repo.
 
 name: CI Python
 

--- a/workflows/mutation-testing.yml
+++ b/workflows/mutation-testing.yml
@@ -1,8 +1,11 @@
 ---
-# Reusable mutation testing workflow (chrysa ecosystem)
+# Mutation testing workflow template (chrysa ecosystem)
 #
-# Usage:
-#   uses: chrysa/shared-standards/.github/workflows/mutation-testing.yml@main
+# Usage: copy to .github/workflows/mutation-testing.yml and adapt.
+# ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it cannot be
+#    called via `uses: chrysa/shared-standards/...`. Copy it to your repo.
+#
+# Parameters when used as a standalone workflow:
 #   with:
 #     python-version: "3.12"            # optional, default 3.12
 #     paths-to-mutate: "src/engine/"    # required

--- a/workflows/release.yml
+++ b/workflows/release.yml
@@ -1,9 +1,10 @@
 ---
-# Reusable semantic release workflow (chrysa ecosystem)
+# Semantic release workflow template (chrysa ecosystem)
 # Uses: GitVersion + cliff (git-cliff) for changelog generation
 #
-# Usage:
-#   uses: chrysa/shared-standards/.github/workflows/release.yml@main
+# Usage: copy to .github/workflows/release.yml and adapt.
+# ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it cannot be
+#    called via `uses: chrysa/shared-standards/...`. Copy it to your repo.
 #
 # Required secrets: GITHUB_TOKEN (automatic), RELEASE_TOKEN (for protected branches)
 #

--- a/workflows/sonar.yml
+++ b/workflows/sonar.yml
@@ -1,8 +1,9 @@
 ---
-# Reusable SonarCloud analysis workflow (chrysa ecosystem)
-# Usage:
-#   uses: chrysa/shared-standards/.github/workflows/sonar.yml@main
-#   (or copy to .github/workflows/sonar.yml and adapt)
+# SonarCloud analysis workflow template (chrysa ecosystem)
+# Usage: copy to .github/workflows/sonar.yml and adapt.
+#
+# ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it cannot be
+#    called via `uses: chrysa/shared-standards/...`. Copy it to your repo.
 #
 # Required secrets: SONAR_TOKEN, SONAR_HOST_URL (defaults to sonarcloud.io)
 #


### PR DESCRIPTION
## Summary

Closes #57

Implements **Option A**: keep `workflows/` as pure copy-to-use templates.

## Changes

- `workflows/sonar.yml`: remove incorrect `uses:` comment
- `workflows/ci-python.yml`: replace `uses:` with copy-to-use note
- `workflows/release.yml`: replace `uses:` with copy-to-use note
- `workflows/mutation-testing.yml`: replace `uses:` with copy-to-use note
- `README.md`: clarify `workflows/` are copy-to-use templates (pre-existing uncommitted changes)
- `copilot-instructions/fastapi.md`: add HATEOAS + RFC 7807 spec (pre-existing uncommitted changes)

## Decision

Option A chosen: these are **copy-to-use templates**, not reusable workflows callable via `uses:`. The copilot-instructions already document this correctly. No ecosystem repo uses the incorrect pattern.