### PR TITLE
chore(ci): upgrade GitHub Actions to latest versions in workflow templates

### DIFF
--- a/workflows/ci-node.yml
+++ b/workflows/ci-node.yml
@@ -18,8 +18,8 @@ jobs:
         runs-on: ubuntu-latest
         name: Lint & pre-commit
         steps:
-            - uses: actions/checkout@v5
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: 'npm'
@@ -32,8 +32,8 @@ jobs:
         name: Tests
         needs: lint
         steps:
-            - uses: actions/checkout@v5
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: 'npm'

--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -21,8 +21,8 @@ jobs:
         runs-on: ubuntu-latest
         name: Lint & pre-commit
         steps:
-            - uses: actions/checkout@v5
-            - uses: actions/setup-python@v5
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
               with:
                   python-version: '3.12'
             - name: Run pre-commit
@@ -33,8 +33,8 @@ jobs:
         name: Tests
         needs: lint
         steps:
-            - uses: actions/checkout@v5
-            - uses: actions/setup-python@v5
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
               with:
                   python-version: '3.12'
             - name: Install dependencies

--- a/workflows/contract-testing.yml
+++ b/workflows/contract-testing.yml
@@ -73,7 +73,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ inputs.node-version }}
                   cache: npm

--- a/workflows/notion-branch-sync.yml
+++ b/workflows/notion-branch-sync.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     if: vars.NOTION_BRANCHES_DB_ID != ''
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # full history needed for CHANGELOG diff
 

--- a/workflows/pages.yml
+++ b/workflows/pages.yml
@@ -77,17 +77,17 @@ jobs:
         runs-on: ubuntu-latest
         name: Deploy (peaceiris)
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Set up Python
               if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'pip') }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ inputs.python-version }}
 
             - name: Set up Node
               if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'npm') }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ inputs.node-version }}
 
@@ -112,17 +112,17 @@ jobs:
         runs-on: ubuntu-latest
         name: Build site (official)
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Set up Python
               if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'pip') }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ inputs.python-version }}
 
             - name: Set up Node
               if: ${{ inputs.build-command != '' && contains(inputs.build-command, 'npm') }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ inputs.node-version }}
 

--- a/workflows/regression-gate.yml
+++ b/workflows/regression-gate.yml
@@ -71,10 +71,10 @@ jobs:
 
         steps:
             # ── Checkout ──────────────────────────────────────────────────
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             # ── Python setup ──────────────────────────────────────────────
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                   python-version: ${{ inputs.python-version }}
 
@@ -197,7 +197,7 @@ jobs:
 
             - name: Upload quality baseline artifact
               if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ${{ inputs.baseline-artifact-name }}
                   path: .quality-baseline.json

--- a/workflows/release.yml
+++ b/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         name: Semantic Release
 
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/workflows/sonar.yml
+++ b/workflows/sonar.yml
@@ -56,7 +56,7 @@ jobs:
         name: SonarCloud
 
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to latest stable versions in workflow templates:

- `actions/checkout` v5 → **v6**
- `actions/setup-python` v5 → **v6**
- `actions/setup-node` v4 → **v6**
- `actions/upload-artifact` v4 → **v7**

Affected templates: pages.yml, ci-node.yml, notion-branch-sync.yml, ci-python.yml, sonar.yml, regression-gate.yml, release.yml, contract-testing.yml

Part of ecosystem-wide standards compliance audit.