### PR TITLE
chore(claude): migrate hooks to nested {hooks:[...]} format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,10 +5,14 @@
   "hooks": {
     "Notification": [
       {
-        "command": "notify-send 'Claude Code' 'En attente de ton input' 2>/dev/null || true",
-        "name": "notify-user-input",
-        "timeout": 3000,
-        "type": "command"
+        "hooks": [
+          {
+            "command": "notify-send 'Claude Code' 'En attente de ton input' 2>/dev/null || true",
+            "name": "notify-user-input",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -26,9 +30,13 @@
     ],
     "PreCompact": [
       {
-        "command": "~/.claude/hooks/pre-compact.sh",
-        "timeout": 5000,
-        "type": "command"
+        "hooks": [
+          {
+            "command": "~/.claude/hooks/pre-compact.sh",
+            "timeout": 5000,
+            "type": "command"
+          }
+        ]
       }
     ],
     "PreToolUse": [


### PR DESCRIPTION
Align `.claude/settings.json` with the current Claude Code hooks schema (nested `{hooks:[{...}]}` format instead of the deprecated flat form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)