### PR TITLE
chore(standards): realign gitignore + sonar pin

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: SonarCloud scan
-        uses: chrysa/github-actions/sonar-scan-python@v1
+        uses: chrysa/github-actions/sonar-scan-python@v1.1.0
         with:
           python-version: "3.14"
           sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ Thumbs.db
 # graphify (local knowledge graph — never commit)
 graphify-out/
 graphify-out/
+/graphify
+/sys
+.graphify_version
+graphify
+sys


### PR DESCRIPTION
Propagate today's standards realign:
- add `graphify`/`sys` artifacts to `.gitignore`
- pin `sonar-scan` action to `@v1.1.0`

Files: .gitignore .github/workflows/sonar.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)