### PR TITLE
ci: fix dead label-sync action in template (marocchino 404 -> crazy-max v6)

### DIFF
--- a/templates/workflows-process/sync-labels.yml
+++ b/templates/workflows-process/sync-labels.yml
@@ -17,9 +17,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     - name: Sync labels
-      uses: marocchino/create-labels@v1.3.0
+      uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
       with:
-        labels: .github/labels.yml
+        yaml-file: .github/labels.yml
+        skip-delete: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 name: Sync GitHub Labels
 permissions:
   contents: read


### PR DESCRIPTION
Fix the SOURCE template so new repos stop inheriting the dead `marocchino/create-labels` action (404). Same swap as the 43-repo backfill: crazy-max/ghaction-github-labeler@v6, skip-delete: true.

Generated with Claude Code