### PR TITLE
docs: add standardized documentation structure template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ and standards for the ecosystem.
   api-design/           # REST standards + FastAPI patterns + status codes
 copilot-instructions/   # GitHub Copilot instruction templates (base.md = ecosystem-wide)
 templates/              # Bootstrap file templates (CLAUDE.md, opencode.json, settings.json, copilot-instructions.md, .gitignore, dependabot.yml, etc.)
+templates/docs-structure/ # Standardized project documentation skeleton (docs, ai, prompts, schemas, workflows, decisions, postmortems, tests, examples/{python,node}) — copied by /chrysa-init
 workflows/              # Reusable GitHub Actions workflow templates
 ```
 

--- a/templates/docs-structure/README.md
+++ b/templates/docs-structure/README.md
@@ -1,0 +1,30 @@
+# docs-structure — standardized project documentation skeleton
+
+Canonical documentation tree copied into every new repo by `/chrysa-init`
+(`chrysa/claude-config/claude/commands/chrysa-init.md`). Existing repos are
+backfilled gradually.
+
+## Layout
+- `docs/` — product/architecture/process docs (app-spec, architecture, security, deployment, observability, …)
+- `ai/` — AI-feature assets (`CLAUDE.md` is a pointer to repo-root canon; prompt-library, evaluation-datasets)
+- `prompts/` — agent system prompts
+- `schemas/` — JSON Schema (draft 2020-12) data contracts
+- `workflows/` — end-to-end flow docs
+- `decisions/` — `_TEMPLATE.md` + DEC-NNN records (ADR canon stays in `docs/adr/`)
+- `postmortems/` — `_TEMPLATE.md` + incident records
+- `tests/` — test scenario catalogues
+- `examples/` — “perfect” reference implementations, one variant per stack (`python/`, `node/`)
+
+## Usage in /chrysa-init
+Copy the tree, then keep only the `examples/<stack>` matching the project type and drop the rest:
+```bash
+cp -r "$_SHARED/templates/docs-structure/." .
+# keep python OR node examples depending on project type, then:
+#   mv examples/python/* examples/ && rm -rf examples/python examples/node   (python projects)
+#   mv examples/node/*   examples/ && rm -rf examples/python examples/node   (frontend/node projects)
+```
+
+## Reconciliation (do not duplicate existing canon)
+- Never overwrite an existing root `CLAUDE.md`, `AGENTS.md`, `README.md`, `CHANGELOG.md`, `DECISIONS.md`, or `docs/adr/`.
+- `ai/CLAUDE.md`, `docs/changelog.md` are pointers; `docs/decision-log.md` indexes `docs/adr/`.
+- Stub files carry `status: stub` — remove once populated.

--- a/templates/docs-structure/STRUCTURE.md
+++ b/templates/docs-structure/STRUCTURE.md
@@ -1,4 +1,6 @@
-# docs-structure — standardized project documentation skeleton
+# STRUCTURE — standardized project documentation skeleton
+
+> This file (`STRUCTURE.md`) is copied to the repo root by `/chrysa-init` and documents the layout below.
 
 Canonical documentation tree copied into every new repo by `/chrysa-init`
 (`chrysa/claude-config/claude/commands/chrysa-init.md`). Existing repos are

--- a/templates/docs-structure/ai/CLAUDE.md
+++ b/templates/docs-structure/ai/CLAUDE.md
@@ -1,0 +1,11 @@
+---
+title: AI Agent Context (pointer)
+status: pointer
+---
+
+# AI Agent Context
+
+Canonical agent context lives at the repo root:
+[`../CLAUDE.md`](../CLAUDE.md) (Claude Code) and [`../AGENTS.md`](../AGENTS.md) (generic agents).
+
+This `ai/` directory holds supporting assets only — see `prompt-library.md` and `evaluation-datasets.md`.

--- a/templates/docs-structure/ai/evaluation-datasets.md
+++ b/templates/docs-structure/ai/evaluation-datasets.md
@@ -1,0 +1,17 @@
+---
+title: Evaluation Datasets
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Evaluation Datasets
+
+## Purpose
+
+Datasets and rubrics used to evaluate AI features (golden sets, edge cases, scoring).
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/ai/prompt-library.md
+++ b/templates/docs-structure/ai/prompt-library.md
@@ -1,0 +1,17 @@
+---
+title: Prompt Library
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Prompt Library
+
+## Purpose
+
+Reusable, versioned prompts used by the app's AI features. One section per prompt with inputs/outputs.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/decisions/DEC-001-auth-provider.md
+++ b/templates/docs-structure/decisions/DEC-001-auth-provider.md
@@ -1,0 +1,16 @@
+---
+id: DEC-001
+title: Auth provider choice
+status: example
+date: TODO
+---
+
+# DEC-001 — Auth provider choice
+
+> **EXAMPLE** — illustrative stub. Replace with a real decision or delete.
+
+## Context
+
+## Decision
+
+## Consequences

--- a/templates/docs-structure/decisions/DEC-002-db-choice.md
+++ b/templates/docs-structure/decisions/DEC-002-db-choice.md
@@ -1,0 +1,16 @@
+---
+id: DEC-002
+title: Database choice
+status: example
+date: TODO
+---
+
+# DEC-002 — Database choice
+
+> **EXAMPLE** — illustrative stub. Replace with a real decision or delete.
+
+## Context
+
+## Decision
+
+## Consequences

--- a/templates/docs-structure/decisions/DEC-003-cache-strategy.md
+++ b/templates/docs-structure/decisions/DEC-003-cache-strategy.md
@@ -1,0 +1,16 @@
+---
+id: DEC-003
+title: Cache strategy
+status: example
+date: TODO
+---
+
+# DEC-003 — Cache strategy
+
+> **EXAMPLE** — illustrative stub. Replace with a real decision or delete.
+
+## Context
+
+## Decision
+
+## Consequences

--- a/templates/docs-structure/decisions/_TEMPLATE.md
+++ b/templates/docs-structure/decisions/_TEMPLATE.md
@@ -1,0 +1,16 @@
+---
+id: DEC-NNN
+title: TODO
+status: proposed   # proposed | accepted | superseded | rejected
+date: TODO
+---
+
+# DEC-NNN — TODO
+
+## Context
+
+## Decision
+
+## Consequences
+
+## Alternatives considered

--- a/templates/docs-structure/docs/anti-patterns.md
+++ b/templates/docs-structure/docs/anti-patterns.md
@@ -1,0 +1,17 @@
+---
+title: Anti-Patterns
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Anti-Patterns
+
+## Purpose
+
+Patterns to avoid in this codebase and why.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/api-contracts.md
+++ b/templates/docs-structure/docs/api-contracts.md
@@ -1,0 +1,17 @@
+---
+title: API Contracts
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# API Contracts
+
+## Purpose
+
+Public API surface: endpoints, request/response shapes, error contracts, versioning.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/app-spec.md
+++ b/templates/docs-structure/docs/app-spec.md
@@ -1,0 +1,17 @@
+---
+title: Application Specification
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Application Specification
+
+## Purpose
+
+High-level description of what this application does, its scope, and primary capabilities.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/architecture.md
+++ b/templates/docs-structure/docs/architecture.md
@@ -1,0 +1,17 @@
+---
+title: Architecture
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Architecture
+
+## Purpose
+
+System architecture: components, boundaries, data flow, and major design decisions.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/brand-brief.md
+++ b/templates/docs-structure/docs/brand-brief.md
@@ -1,0 +1,17 @@
+---
+title: Brand Brief
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Brand Brief
+
+## Purpose
+
+Brand positioning, tone, values, and visual identity guidelines.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/business-rules.md
+++ b/templates/docs-structure/docs/business-rules.md
@@ -1,0 +1,17 @@
+---
+title: Business Rules
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Business Rules
+
+## Purpose
+
+Domain invariants and business rules the system must enforce.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/changelog.md
+++ b/templates/docs-structure/docs/changelog.md
@@ -1,0 +1,9 @@
+---
+title: Changelog (pointer)
+status: pointer
+---
+
+# Changelog
+
+The canonical changelog is the repo-root [`CHANGELOG.md`](../CHANGELOG.md),
+generated automatically via git-cliff. Do not edit by hand here.

--- a/templates/docs-structure/docs/coding-standards.md
+++ b/templates/docs-structure/docs/coding-standards.md
@@ -1,0 +1,17 @@
+---
+title: Coding Standards
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Coding Standards
+
+## Purpose
+
+Project coding standards. Defers to chrysa/shared-standards canon; record local deltas only.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/copywriting-guide.md
+++ b/templates/docs-structure/docs/copywriting-guide.md
@@ -1,0 +1,17 @@
+---
+title: Copywriting Guide
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Copywriting Guide
+
+## Purpose
+
+Voice, tone, terminology, and microcopy conventions.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/data-dictionary.md
+++ b/templates/docs-structure/docs/data-dictionary.md
@@ -1,0 +1,17 @@
+---
+title: Data Dictionary
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Data Dictionary
+
+## Purpose
+
+Canonical definitions of every entity, field, type, and constraint.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/decision-log.md
+++ b/templates/docs-structure/docs/decision-log.md
@@ -1,0 +1,13 @@
+---
+title: Decision Log
+status: stub
+---
+
+# Decision Log
+
+Chronological index of architecture decisions. Full records live in
+[`docs/adr/`](./adr/) (ADR-NNN) and the repo-root [`DECISIONS.md`](../DECISIONS.md).
+
+| Date | ID | Title | Status |
+|------|----|-------|--------|
+| TODO | ADR-001 | TODO | accepted |

--- a/templates/docs-structure/docs/deployment.md
+++ b/templates/docs-structure/docs/deployment.md
@@ -1,0 +1,17 @@
+---
+title: Deployment
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Deployment
+
+## Purpose
+
+Environments, deploy pipeline, rollback, and release procedure.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/domain-glossary.md
+++ b/templates/docs-structure/docs/domain-glossary.md
@@ -1,0 +1,17 @@
+---
+title: Domain Glossary
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Domain Glossary
+
+## Purpose
+
+Ubiquitous-language glossary of domain terms (DDD).
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/error-journal.md
+++ b/templates/docs-structure/docs/error-journal.md
@@ -1,0 +1,17 @@
+---
+title: Error Journal
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Error Journal
+
+## Purpose
+
+Running log of notable errors encountered and their resolutions.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/feature-backlog.md
+++ b/templates/docs-structure/docs/feature-backlog.md
@@ -1,0 +1,17 @@
+---
+title: Feature Backlog
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Feature Backlog
+
+## Purpose
+
+Lightweight backlog of candidate features (source of truth remains the tracker/Notion).
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/integrations.md
+++ b/templates/docs-structure/docs/integrations.md
@@ -1,0 +1,17 @@
+---
+title: Integrations
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Integrations
+
+## Purpose
+
+Third-party services and internal systems this app integrates with, and how.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/known-issues.md
+++ b/templates/docs-structure/docs/known-issues.md
@@ -1,0 +1,17 @@
+---
+title: Known Issues
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Known Issues
+
+## Purpose
+
+Currently known bugs, limitations, and workarounds.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/observability.md
+++ b/templates/docs-structure/docs/observability.md
@@ -1,0 +1,17 @@
+---
+title: Observability
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Observability
+
+## Purpose
+
+Logging, metrics, tracing, alerting, and dashboards.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/personas.md
+++ b/templates/docs-structure/docs/personas.md
@@ -1,0 +1,17 @@
+---
+title: Personas
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Personas
+
+## Purpose
+
+User personas: goals, contexts, pain points, and success criteria.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/security.md
+++ b/templates/docs-structure/docs/security.md
@@ -1,0 +1,17 @@
+---
+title: Security
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Security
+
+## Purpose
+
+Threat model, authn/authz model, secrets handling, and security controls.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/system-patterns.md
+++ b/templates/docs-structure/docs/system-patterns.md
@@ -1,0 +1,17 @@
+---
+title: System Patterns
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# System Patterns
+
+## Purpose
+
+Recurring architectural and implementation patterns used across the codebase.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/docs/ux-rules.md
+++ b/templates/docs-structure/docs/ux-rules.md
@@ -1,0 +1,17 @@
+---
+title: UX Rules
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# UX Rules
+
+## Purpose
+
+Interaction and usability rules that all UI work must follow.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/examples/node/perfect-api-route.ts
+++ b/templates/docs-structure/examples/node/perfect-api-route.ts
@@ -1,0 +1,15 @@
+// EXAMPLE — canonical pattern, copy & adapt.
+// A typed, validated API route handler.
+import { z } from 'zod';
+
+const Query = z.object({ id: z.string().uuid() });
+
+export async function GET(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const parsed = Query.safeParse(Object.fromEntries(url.searchParams));
+  if (!parsed.success) {
+    return Response.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+  // TODO: business logic via a service, never inline here.
+  return Response.json({ id: parsed.data.id });
+}

--- a/templates/docs-structure/examples/node/perfect-form.tsx
+++ b/templates/docs-structure/examples/node/perfect-form.tsx
@@ -1,0 +1,27 @@
+// EXAMPLE — canonical pattern, copy & adapt.
+// A controlled form with schema validation.
+import { useState } from 'react';
+import { z } from 'zod';
+
+const Schema = z.object({ email: z.string().email() });
+
+export function PerfectForm({ onSubmit }: { onSubmit: (v: { email: string }) => void }) {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  function handle(e: React.FormEvent) {
+    e.preventDefault();
+    const r = Schema.safeParse({ email });
+    if (!r.success) return setError('Invalid email');
+    setError(null);
+    onSubmit(r.data);
+  }
+
+  return (
+    <form onSubmit={handle}>
+      <input value={email} onChange={(e) => setEmail(e.target.value)} />
+      {error && <p role="alert">{error}</p>}
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/templates/docs-structure/examples/node/perfect-hook.ts
+++ b/templates/docs-structure/examples/node/perfect-hook.ts
@@ -1,0 +1,14 @@
+// EXAMPLE — canonical pattern, copy & adapt.
+// A data-fetching hook built on React Query.
+import { useQuery } from '@tanstack/react-query';
+
+export function useUser(id: string) {
+  return useQuery({
+    queryKey: ['user', id],
+    queryFn: async () => {
+      const res = await fetch(`/api/user?id=${id}`);
+      if (!res.ok) throw new Error('Failed to load user');
+      return res.json();
+    },
+  });
+}

--- a/templates/docs-structure/examples/node/perfect-page.tsx
+++ b/templates/docs-structure/examples/node/perfect-page.tsx
@@ -1,0 +1,10 @@
+// EXAMPLE — canonical pattern, copy & adapt.
+// A page: composition + loading/error states, no data logic inline.
+import { useUser } from './perfect-hook';
+
+export function UserPage({ id }: { id: string }) {
+  const { data, isLoading, error } = useUser(id);
+  if (isLoading) return <p>Loading…</p>;
+  if (error) return <p role="alert">Something went wrong.</p>;
+  return <h1>{data.id}</h1>;
+}

--- a/templates/docs-structure/examples/node/perfect-schema.ts
+++ b/templates/docs-structure/examples/node/perfect-schema.ts
@@ -1,0 +1,11 @@
+// EXAMPLE — canonical pattern, copy & adapt.
+// A shared zod schema + inferred type.
+import { z } from 'zod';
+
+export const User = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  createdAt: z.string().datetime(),
+});
+
+export type User = z.infer<typeof User>;

--- a/templates/docs-structure/examples/node/perfect-service.ts
+++ b/templates/docs-structure/examples/node/perfect-service.ts
@@ -1,0 +1,15 @@
+// EXAMPLE — canonical pattern, copy & adapt.
+// A service: pure business logic, no framework/transport concerns.
+export interface UserRepo {
+  findById(id: string): Promise<{ id: string } | null>;
+}
+
+export class UserService {
+  constructor(private readonly repo: UserRepo) {}
+
+  async getUser(id: string) {
+    const user = await this.repo.findById(id);
+    if (!user) throw new Error('NotFound');
+    return user;
+  }
+}

--- a/templates/docs-structure/examples/python/perfect_api_view.py
+++ b/templates/docs-structure/examples/python/perfect_api_view.py
@@ -6,6 +6,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from perfect_serializer import PerfectSerializer
+
 
 class PerfectAPIView(APIView):
     def get(self, request, *args, **kwargs):

--- a/templates/docs-structure/examples/python/perfect_api_view.py
+++ b/templates/docs-structure/examples/python/perfect_api_view.py
@@ -1,0 +1,15 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A thin DRF view: validate via serializer, delegate to a service.
+"""
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class PerfectAPIView(APIView):
+    def get(self, request, *args, **kwargs):
+        serializer = PerfectSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        # TODO: delegate to a service; no business logic inline.
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)

--- a/templates/docs-structure/examples/python/perfect_repository.py
+++ b/templates/docs-structure/examples/python/perfect_repository.py
@@ -1,0 +1,11 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A repository: the only place that touches the ORM/storage.
+"""
+from __future__ import annotations
+
+
+class UserRepository:
+    def find_by_id(self, user_id: str):
+        # TODO: real ORM query, e.g. User.objects.filter(pk=user_id).first()
+        raise NotImplementedError

--- a/templates/docs-structure/examples/python/perfect_schema.py
+++ b/templates/docs-structure/examples/python/perfect_schema.py
@@ -1,0 +1,16 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A pydantic schema = typed data contract at a boundary.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class User(BaseModel):
+    id: UUID
+    email: EmailStr
+    created_at: datetime

--- a/templates/docs-structure/examples/python/perfect_serializer.py
+++ b/templates/docs-structure/examples/python/perfect_serializer.py
@@ -1,0 +1,14 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A DRF serializer = the validation/transport boundary.
+"""
+from rest_framework import serializers
+
+
+class PerfectSerializer(serializers.Serializer):
+    id = serializers.UUIDField()
+    email = serializers.EmailField()
+
+    def validate_email(self, value: str) -> str:
+        # TODO: domain-specific validation.
+        return value.lower()

--- a/templates/docs-structure/examples/python/perfect_service.py
+++ b/templates/docs-structure/examples/python/perfect_service.py
@@ -5,6 +5,10 @@ A service: pure business logic, framework-agnostic.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from perfect_repository import UserRepository
 
 
 class NotFoundError(Exception):
@@ -18,7 +22,7 @@ class User:
 
 
 class UserService:
-    def __init__(self, repo: "UserRepository") -> None:
+    def __init__(self, repo: UserRepository) -> None:
         self._repo = repo
 
     def get_user(self, user_id: str) -> User:

--- a/templates/docs-structure/examples/python/perfect_service.py
+++ b/templates/docs-structure/examples/python/perfect_service.py
@@ -1,0 +1,28 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A service: pure business logic, framework-agnostic.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class NotFoundError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class User:
+    id: str
+    email: str
+
+
+class UserService:
+    def __init__(self, repo: "UserRepository") -> None:
+        self._repo = repo
+
+    def get_user(self, user_id: str) -> User:
+        user = self._repo.find_by_id(user_id)
+        if user is None:
+            raise NotFoundError(user_id)
+        return user

--- a/templates/docs-structure/examples/python/perfect_viewset.py
+++ b/templates/docs-structure/examples/python/perfect_viewset.py
@@ -1,0 +1,10 @@
+"""EXAMPLE — canonical pattern, copy & adapt.
+
+A DRF ViewSet wiring serializer + queryset; logic stays in services.
+"""
+from rest_framework import viewsets
+
+
+class PerfectViewSet(viewsets.ModelViewSet):
+    serializer_class = None  # TODO: PerfectSerializer
+    queryset = None          # TODO: Model.objects.all()

--- a/templates/docs-structure/postmortems/_TEMPLATE.md
+++ b/templates/docs-structure/postmortems/_TEMPLATE.md
@@ -1,0 +1,20 @@
+---
+title: TODO incident
+status: template
+date: TODO
+severity: TODO   # SEV1 | SEV2 | SEV3
+---
+
+# Postmortem — TODO
+
+## Summary
+
+## Impact
+
+## Timeline
+
+## Root cause
+
+## Resolution
+
+## Action items

--- a/templates/docs-structure/postmortems/payment-incident-2026-05.md
+++ b/templates/docs-structure/postmortems/payment-incident-2026-05.md
@@ -1,0 +1,20 @@
+---
+title: Payment incident (May 2026)
+status: example
+date: TODO
+severity: TODO
+---
+
+# Postmortem — Payment incident (May 2026)
+
+> **EXAMPLE** — illustrative stub. Replace with a real postmortem or delete.
+
+## Summary
+
+## Impact
+
+## Timeline
+
+## Root cause
+
+## Action items

--- a/templates/docs-structure/postmortems/webhook-failure-2026-06.md
+++ b/templates/docs-structure/postmortems/webhook-failure-2026-06.md
@@ -1,0 +1,20 @@
+---
+title: Webhook failure (June 2026)
+status: example
+date: TODO
+severity: TODO
+---
+
+# Postmortem — Webhook failure (June 2026)
+
+> **EXAMPLE** — illustrative stub. Replace with a real postmortem or delete.
+
+## Summary
+
+## Impact
+
+## Timeline
+
+## Root cause
+
+## Action items

--- a/templates/docs-structure/prompts/classification-agent.md
+++ b/templates/docs-structure/prompts/classification-agent.md
@@ -1,0 +1,17 @@
+---
+title: Classification Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Classification Agent Prompt
+
+## Purpose
+
+System prompt + label set for the classification agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/prompts/extraction-agent.md
+++ b/templates/docs-structure/prompts/extraction-agent.md
@@ -1,0 +1,17 @@
+---
+title: Extraction Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Extraction Agent Prompt
+
+## Purpose
+
+System prompt + schema for the structured-extraction agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/prompts/onboarding-agent.md
+++ b/templates/docs-structure/prompts/onboarding-agent.md
@@ -1,0 +1,17 @@
+---
+title: Onboarding Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Onboarding Agent Prompt
+
+## Purpose
+
+System prompt + behavior spec for the onboarding agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/prompts/sales-agent.md
+++ b/templates/docs-structure/prompts/sales-agent.md
@@ -1,0 +1,17 @@
+---
+title: Sales Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Sales Agent Prompt
+
+## Purpose
+
+System prompt + behavior spec for the sales agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/prompts/support-agent.md
+++ b/templates/docs-structure/prompts/support-agent.md
@@ -1,0 +1,17 @@
+---
+title: Support Agent Prompt
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Support Agent Prompt
+
+## Purpose
+
+System prompt + behavior spec for the support agent.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/schemas/payment.schema.json
+++ b/templates/docs-structure/schemas/payment.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://chrysa.dev/schemas/payment.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "STUB — define the real schema.",
+  "properties": {
+    "id": {
+      "description": "Unique identifier (TODO)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "title": "Payment",
+  "type": "object"
+}

--- a/templates/docs-structure/schemas/project.schema.json
+++ b/templates/docs-structure/schemas/project.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://chrysa.dev/schemas/project.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "STUB — define the real schema.",
+  "properties": {
+    "id": {
+      "description": "Unique identifier (TODO)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "title": "Project",
+  "type": "object"
+}

--- a/templates/docs-structure/schemas/user.schema.json
+++ b/templates/docs-structure/schemas/user.schema.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://chrysa.dev/schemas/user.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "STUB — define the real schema.",
+  "properties": {
+    "id": {
+      "description": "Unique identifier (TODO)",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "title": "User",
+  "type": "object"
+}

--- a/templates/docs-structure/tests/e2e-scenarios.md
+++ b/templates/docs-structure/tests/e2e-scenarios.md
@@ -1,0 +1,17 @@
+---
+title: E2E Scenarios
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# E2E Scenarios
+
+## Purpose
+
+End-to-end user scenarios covered (or to cover) by E2E tests.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/tests/edge-cases.md
+++ b/templates/docs-structure/tests/edge-cases.md
@@ -1,0 +1,17 @@
+---
+title: Edge Cases
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Edge Cases
+
+## Purpose
+
+Catalogue of edge cases the system must handle, with expected behavior.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/tests/regression-tests.md
+++ b/templates/docs-structure/tests/regression-tests.md
@@ -1,0 +1,17 @@
+---
+title: Regression Tests
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Regression Tests
+
+## Purpose
+
+Index of regression scenarios tied to past incidents/bugs.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/workflows/auth-flow.md
+++ b/templates/docs-structure/workflows/auth-flow.md
@@ -1,0 +1,17 @@
+---
+title: Auth Flow
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Auth Flow
+
+## Purpose
+
+End-to-end authentication flow: actors, steps, states, and edge cases.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/workflows/billing-flow.md
+++ b/templates/docs-structure/workflows/billing-flow.md
@@ -1,0 +1,17 @@
+---
+title: Billing Flow
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Billing Flow
+
+## Purpose
+
+End-to-end billing flow: plans, checkout, invoices, dunning.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/workflows/notification-flow.md
+++ b/templates/docs-structure/workflows/notification-flow.md
@@ -1,0 +1,17 @@
+---
+title: Notification Flow
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Notification Flow
+
+## Purpose
+
+End-to-end notification flow: triggers, channels, preferences, delivery.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.

--- a/templates/docs-structure/workflows/onboarding-flow.md
+++ b/templates/docs-structure/workflows/onboarding-flow.md
@@ -1,0 +1,17 @@
+---
+title: Onboarding Flow
+status: stub
+owner: TODO
+last-reviewed: TODO
+---
+
+# Onboarding Flow
+
+## Purpose
+
+End-to-end onboarding flow from signup to activation.
+
+## TODO
+
+- [ ] Fill in this document for the project.
+- [ ] Remove the `status: stub` marker once populated.


### PR DESCRIPTION
## What
Add `templates/docs-structure/` — the canonical project documentation skeleton, copied into every new repo by `/chrysa-init`.

## Tree
`docs/` · `ai/` · `prompts/` · `schemas/` (JSON Schema 2020-12) · `workflows/` · `decisions/` · `postmortems/` · `tests/` · `examples/{python,node}`

## Notes
- Stub files carry `status: stub`; `examples/` is stack-split (python + node).
- Reconciliation: pointers for `ai/CLAUDE.md` & `docs/changelog.md`; `docs/decision-log.md` indexes `docs/adr/`. Never overwrites existing root canon.
- Referenced in `CLAUDE.md`. Follow-up wires the copy step into `/chrysa-init` (claude-config).

Part of the org-wide documentation-standard rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)