### PR TITLE
feat(ci): release-gated lint templates (move lint to pre-commit)

### DIFF
--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -4,6 +4,11 @@
 #
 # ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it cannot be
 #    called via `uses: chrysa/shared-standards/...`. Copy it to your repo.
+#
+# NOTE: Lint (ruff/mypy/pre-commit) does NOT run here. It lives in pre-commit
+#       (local) and is replayed in CI only at release time via release.yml's
+#       lint gate (chrysa/github-actions/.github/workflows/lint-python.yml).
+#       This CI keeps only tests, to gate PRs without per-push lint billing.
 
 name: CI Python
 
@@ -17,21 +22,9 @@ permissions:
     contents: read
 
 jobs:
-    lint:
-        runs-on: ubuntu-latest
-        name: Lint & pre-commit
-        steps:
-            - uses: actions/checkout@v5
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: '3.12'
-            - name: Run pre-commit
-              uses: pre-commit/action@v3.0.1
-
     test:
         runs-on: ubuntu-latest
         name: Tests
-        needs: lint
         steps:
             - uses: actions/checkout@v5
             - uses: actions/setup-python@v5

--- a/workflows/release.yml
+++ b/workflows/release.yml
@@ -11,6 +11,10 @@
 # Expects:
 #   - GitVersion.yml at repo root
 #   - cliff.toml at repo root (or pass changelog-config input)
+#
+# Lint gate: the `lint` job replays the full pre-commit suite (ruff + mypy at
+# pre-push stage) once per release. Lint no longer runs on every PR/push — it
+# lives in pre-commit (local) and is gated here. `release` needs `lint`.
 
 name: Release
 
@@ -49,9 +53,17 @@ permissions:
     pull-requests: read
 
 jobs:
+    lint:
+        name: Lint gate (pre-commit replay)
+        uses: chrysa/github-actions/.github/workflows/lint-python.yml@main
+        with:
+            python-version: '3.14'
+            extras: dev
+
     release:
         runs-on: ubuntu-latest
         name: Semantic Release
+        needs: lint
 
         steps:
             - uses: actions/checkout@v5


### PR DESCRIPTION
## Why
Lint ran on every branch push + PR across ~46 repos -> high Actions billing. Move lint to pre-commit (local), replay in CI only at release.

## What
- `workflows/ci-python.yml`: drop the lint/pre-commit job, keep the **test** job gating PRs.
- `workflows/release.yml`: add a **lint gate** job calling `chrysa/github-actions/.github/workflows/lint-python.yml@main` (pre-commit replay: ruff + mypy at pre-push). `release` now `needs: lint`.

Future `/chrysa-init` repos inherit the new pattern. Pilot consumer: django-pytest (separate PR). Depends on chrysa/github-actions#106.

Generated with Claude Code