### PR TITLE
chore(makefile): declare tier (lib)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# makefile-tier: lib
 .PHONY: help install dev test test-cov lint format typecheck build clean pre-commit
 
 help:


### PR DESCRIPTION
Declare `# makefile-tier: lib`. All required targets are already present — `docker-test` is recommended (not required).

Part of the Makefile uniformization campaign (Phase C). Enforced by the makefile-check hook (pre-commit-tools #200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)