### PR TITLE
docs: standardize artifact distribution (PyPI public + private GHCR)

### DIFF
--- a/CODE_MANIFEST.md
+++ b/CODE_MANIFEST.md
@@ -335,8 +335,8 @@ CI matrix : tests sur 3 OS minimum pour les libs publiques. Pour les apps, Linux
 
 - `quality-checks.yml` — lint + type + test + coverage
 - `security.yml` — `detect-secrets` + Trivy + bandit/audit
-- `build-image.yml` — Docker build + scan + push registry
-- `release.yml` — GitVersion + CHANGELOG + GitHub Release
+- `build-image.yml` — Docker build + scan + push to **private GHCR** (`ghcr.io/chrysa/<repo>`, private)
+- `release.yml` — GitVersion + CHANGELOG + GitHub Release; publishes distributable libraries to **public PyPI** on tag `v*.*.*`
 - `enforce-issue-link.yml` — toute PR doit référencer une issue (status check bloquant)
 
 ### 8.2 Quality gates

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -33,3 +33,22 @@ Two cross-cutting standards are added to `CODE_MANIFEST.md` for every app exposi
 
 Both criteria are added to the Ready-to-Dev gate (§13, now 12 criteria). Existing projects migrate via a
 per-project compliance task (tracked in Notion `📦 Projets chrysa`). Manifest bumped to v1.1.
+
+---
+
+## D-0003 — Artifact distribution: public PyPI (packages) + private GHCR (images)
+
+**Date**: 2026-06-08
+**Status**: accepted
+
+Portfolio-wide standard formalizing how build artifacts are distributed:
+
+1. **Python-installable projects** (libraries / distributable packages) are published to **public PyPI**,
+   triggered by CI on a git tag `v*.*.*`, via Trusted Publishing (PyPI OIDC) — no API token in plaintext.
+   Applications without distribution are not published to PyPI.
+2. **Docker images** are pushed to a **private registry** — **GHCR** under the chrysa org
+   (`ghcr.io/chrysa/<repo>`, package visibility **private**, never public). CI auth via `GITHUB_TOKEN`.
+
+Codified in `EXECUTION_STANDARD.md` §6 (Registry) and §11 (Distribution), and reflected in
+`CODE_MANIFEST.md` §8.1 (`build-image.yml`, `release.yml`). Workflow implementation lives in
+`chrysa/github-actions`. Execution Standard bumped to v1.5.

--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -1,6 +1,6 @@
 # Chrysa — Execution Standard
 
-**Version 1.4 — 2026-06-07**
+**Version 1.5 — 2026-06-08**
 
 This document defines the **mandatory execution conventions** for every chrysa project.
 All repos scaffolded with `project-init` must comply. Deviations require a documented ADR.
@@ -243,6 +243,15 @@ All reusable workflows are sourced from `chrysa/shared-standards`.
 - No secrets in image layers
 - `docker-compose.yml` must define `healthcheck` + `restart: unless-stopped`
 
+### Registry (mandatory)
+
+- Docker images are pushed to a **private registry** — **GHCR** under the chrysa org:
+  `ghcr.io/chrysa/{repo}`, package visibility **private** (never public).
+- Published tags mirror the git tag: `ghcr.io/chrysa/{repo}:{version}` (semver) **and** `:latest`.
+- CI authenticates to `ghcr.io` via `docker/login-action` using the workflow `GITHUB_TOKEN`
+  (or a least-privilege `packages:write` token) — **no PAT in plaintext**, no long-lived secret in image layers.
+- The build + scan + push is carried by the reusable `build-image.yml` workflow (see `chrysa/github-actions`).
+
 ---
 
 ## 7. Documentation
@@ -366,6 +375,16 @@ ignore_missing_imports = true
 - `setup.cfg` is permitted only for non-Python tooling (e.g. uwsgi); never for Python packaging.
 - Library packages use `src/` layout with `[tool.hatch.build.targets.wheel] packages = ["src/<pkg>"]`.
 - Applications without distribution do not need `[build-system]`; only `[tool.*]` sections are required.
+
+### Distribution
+
+Distribution is driven by the project type declared in the **Build backend** table above:
+
+- **Library / package (distributable)** → published to **public PyPI**, triggered by CI on a git tag
+  matching `v*.*.*`. Build with `hatchling`, upload via Trusted Publishing (PyPI OIDC) — **no PyPI API
+  token in plaintext**. Include `CHANGELOG.md`, `LICENSE`, and `README.md` in the sdist.
+- **Application (no distribution)** → **not** published to PyPI; shipped as a **private GHCR image** (see §6).
+- Publication is carried by the reusable `release.yml` workflow (tag → publish; see `chrysa/github-actions`).
 
 ---
 


### PR DESCRIPTION
## Context

The chrysa standards did not formalize **how build artifacts are distributed**. State before this PR:
- `python-library.md` mentioned PyPI publish (per-stack Copilot hint, not normative).
- `CODE_MANIFEST.md` §8.1 said `build-image.yml — push registry` without naming the registry or its privacy.
- `EXECUTION_STANDARD.md` §6 (Docker) and §11 (Python Packaging) had **no** distribution rule.

## Change

Formalize a portfolio-wide distribution standard:

1. **Python-installable projects** (distributable libraries) → **public PyPI** on git tag `v*.*.*`, via Trusted Publishing (PyPI OIDC, no token in plaintext). Apps without distribution are not published.
2. **Docker images** → **private GHCR** (`ghcr.io/chrysa/<repo>`, private visibility, never public). CI auth via `GITHUB_TOKEN`.

## Files

- `EXECUTION_STANDARD.md` — new §6 *Registry* block + §11 *Distribution* subsection; version bump 1.4 → 1.5.
- `CODE_MANIFEST.md` — §8.1 `build-image.yml` / `release.yml` lines clarified.
- `DECISIONS.md` — new ADR **D-0003**.

Documentation only. Workflow implementation (`build-image.yml`, `release.yml`) lives in `chrysa/github-actions` and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)