### PR TITLE
ci(pre-commit): wire makefile-check hook (v0.1.1-94)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
   repo: https://github.com/igorshubovych/markdownlint-cli
   rev: v0.48.0
 - hooks:
+  - id: makefile-check
   # --- generic (all repos) ---
   - exclude: ^(\.github/|workflows/|templates/)
     id: yaml-sorter
@@ -64,7 +65,7 @@ repos:
   - id: react-no-async-in-useeffect
   - id: react-direct-dom
   repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-93
+  rev: v0.1.1-94
 - hooks:
   - id: gitleaks
   repo: https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
Wire the `makefile-check` hook (pre-commit-tools v0.1.1-94) into pre-commit, enforcing the archetype-tiered Makefile contract (shared-standards EXECUTION_STANDARD.md §1). Bumps the pre-commit-tools rev to v0.1.1-94 (additive only — no existing hook changed) and adds `- id: makefile-check`.

Completes the Makefile uniformization campaign (Phase C): the contract is now enforced on every commit touching a Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)