### PR TITLE
fix(templates): grant write permissions to dependabot-auto-merge caller

### DIFF
--- a/templates/workflows-process/dependabot-auto-merge.yml
+++ b/templates/workflows-process/dependabot-auto-merge.yml
@@ -4,6 +4,14 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Required: the reusable workflow declares contents:write + pull-requests:write.
+# A reusable workflow cannot exceed the caller's token scope, and the repo
+# default is read-only, so the caller must grant write explicitly (otherwise
+# the run fails at startup).
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency:
   cancel-in-progress: false
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds the missing `permissions` block to the dependabot-auto-merge caller **template**.

**Root cause:** the caller declares no `permissions:`, so the GITHUB_TOKEN defaults to the repo read-only setting. The reusable `chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@main` requires `contents: write` + `pull-requests: write`. A reusable workflow cannot exceed the caller's token scope → consumer repos hit `startup_failure` (observed on feedback-gateway, fixed there in #9). 40+ repos inherit this template.

**Fix:** add `permissions: contents: write, pull-requests: write` to the template caller so synced repos inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)