### PR TITLE
fix(claude): markdownlint MD040 on commands/agents fenced blocks

### DIFF
--- a/.claude/agents/general-pm.md
+++ b/.claude/agents/general-pm.md
@@ -145,7 +145,7 @@ And I click "Upload Image"
 Then the image should be uploaded successfully
 And I should see the new profile image in the dashboard
 And the old image should be replaced
-```
+```text
 
 ## Definition of Done
 - [ ] Dashboard page created with responsive design

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -8,7 +8,7 @@ Create well-formatted commits following the chrysa Conventional Commits standard
 
 ## Usage
 
-```
+```text
 /commit
 ```
 
@@ -25,7 +25,7 @@ Create well-formatted commits following the chrysa Conventional Commits standard
 
 Format — see `EXECUTION_STANDARD.md` §3 (source of truth):
 
-```
+```text
 <type>(<scope>): <description>
 ```
 

--- a/.claude/commands/custom-init.md
+++ b/.claude/commands/custom-init.md
@@ -9,7 +9,7 @@ parallel specialist analysis.
 
 ## Usage
 
-```
+```text
 /custom-init
 ```
 

--- a/.claude/commands/help-commands.md
+++ b/.claude/commands/help-commands.md
@@ -8,7 +8,7 @@ List the chrysa custom slash commands and how to use them.
 
 ## Usage
 
-```
+```text
 /help-commands
 ```
 

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -9,7 +9,7 @@ Analyze and resolve the GitHub issue in $ARGUMENTS following GitHub Flow and chr
 
 ## Usage
 
-```
+```text
 /issue <issue-number>
 ```
 

--- a/.claude/commands/reviewpr.md
+++ b/.claude/commands/reviewpr.md
@@ -9,7 +9,7 @@ Review the GitHub pull request in $ARGUMENTS and submit structured feedback.
 
 ## Usage
 
-```
+```text
 /reviewpr <pr-number>
 ```
 

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -9,7 +9,7 @@ Run and improve the test suite for the scope in $ARGUMENTS.
 
 ## Usage
 
-```
+```text
 /test <file-or-directory>
 /test <feature>
 /test all

--- a/templates/claude/agents/general-pm.md
+++ b/templates/claude/agents/general-pm.md
@@ -145,7 +145,7 @@ And I click "Upload Image"
 Then the image should be uploaded successfully
 And I should see the new profile image in the dashboard
 And the old image should be replaced
-```
+```text
 
 ## Definition of Done
 - [ ] Dashboard page created with responsive design

--- a/templates/claude/commands/commit.md
+++ b/templates/claude/commands/commit.md
@@ -8,7 +8,7 @@ Create well-formatted commits following the chrysa Conventional Commits standard
 
 ## Usage
 
-```
+```text
 /commit
 ```
 
@@ -25,7 +25,7 @@ Create well-formatted commits following the chrysa Conventional Commits standard
 
 Format — see `EXECUTION_STANDARD.md` §3 (source of truth):
 
-```
+```text
 <type>(<scope>): <description>
 ```
 

--- a/templates/claude/commands/custom-init.md
+++ b/templates/claude/commands/custom-init.md
@@ -9,7 +9,7 @@ parallel specialist analysis.
 
 ## Usage
 
-```
+```text
 /custom-init
 ```
 

--- a/templates/claude/commands/help-commands.md
+++ b/templates/claude/commands/help-commands.md
@@ -8,7 +8,7 @@ List the chrysa custom slash commands and how to use them.
 
 ## Usage
 
-```
+```text
 /help-commands
 ```
 

--- a/templates/claude/commands/issue.md
+++ b/templates/claude/commands/issue.md
@@ -9,7 +9,7 @@ Analyze and resolve the GitHub issue in $ARGUMENTS following GitHub Flow and chr
 
 ## Usage
 
-```
+```text
 /issue <issue-number>
 ```
 

--- a/templates/claude/commands/reviewpr.md
+++ b/templates/claude/commands/reviewpr.md
@@ -9,7 +9,7 @@ Review the GitHub pull request in $ARGUMENTS and submit structured feedback.
 
 ## Usage
 
-```
+```text
 /reviewpr <pr-number>
 ```
 

--- a/templates/claude/commands/test.md
+++ b/templates/claude/commands/test.md
@@ -9,7 +9,7 @@ Run and improve the test suite for the scope in $ARGUMENTS.
 
 ## Usage
 
-```
+```text
 /test <file-or-directory>
 /test <feature>
 /test all


### PR DESCRIPTION
Bare ``` fences in the propagated `.claude` command/agent docs failed markdownlint MD040 (fenced-code-language) in repos that run the hook, blocking the rollout there. Opening fences now tagged `text`. Read-only check: 0 bare opening fences remain. MD013/MD033 already disabled org-wide, so MD040 was the only blocker.