### PR TITLE
docs(copilot): add Django per-stack instructions (django.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ cp -r path/to/shared-standards/.claude/hooks/ .claude/hooks/
 ### Copilot instructions
 
 Copy `copilot-instructions/base.md` to `.github/copilot-instructions.md` in your repo and adjust.
+Then append the per-stack guide that matches the repo: `fastapi.md`, `django.md`, `react19.md`,
+`python-library.md`, `monorepo.md`, or `gas.md`. Each extends `base.md` and overrides it on conflict.
 
 ### Workflows
 

--- a/copilot-instructions/django.md
+++ b/copilot-instructions/django.md
@@ -1,0 +1,151 @@
+# GitHub Copilot Instructions — Django
+
+<!-- @[claude-sonnet-4] -->
+
+Extends [base.md](base.md). Read base rules first; rules here take precedence where they conflict.
+For reusable Django *libraries* (pluggable apps published to PyPI), [python-library.md](python-library.md)
+also applies — use `src/` layout and the library packaging rules from there.
+
+## Project layout (Django application)
+
+```
+src/
+  <project_name>/
+    __init__.py
+    settings/
+      __init__.py
+      base.py        # shared settings, read from env — no secrets inline
+      dev.py         # local overrides
+      test.py        # test overrides (fast password hasher, in-memory cache)
+      prod.py        # production overrides
+    urls.py          # root URLConf; includes per-app urls under /api/v1/
+    asgi.py
+    wsgi.py
+  <app_name>/        # one Django app per bounded context
+    __init__.py
+    apps.py
+    admin.py
+    models.py        # ORM models only
+    serializers.py   # DRF serializers — separate classes from models
+    views.py         # DRF ViewSets / APIViews — HTTP concerns only
+    services.py      # business logic (no HTTP, no request/response objects)
+    permissions.py   # custom DRF permission classes
+    filters.py       # django-filter FilterSets
+    urls.py          # app router registration
+    migrations/      # always committed, never hand-edited
+    selectors.py     # read queries (optional, keeps views thin)
+manage.py
+tests/
+  unit/              # models, serializers, services, permissions in isolation
+  integration/       # views + DB through the API
+  conftest.py
+pyproject.toml       # single source of truth for metadata, deps, tooling
+```
+
+- **Application** → `src/<project_name>/` layout above, with `manage.py` at repo root.
+- **Reusable Django library** (e.g. `django-traceid`, `django-autoload`) → `src/<package_name>/`
+  layout per [python-library.md](python-library.md); no `manage.py`, ship a `tests/` Django project.
+- One Django app = one bounded context. Do not create a single god-app.
+
+## Architecture rules
+
+- **Views own HTTP concerns only** — request parsing, status codes, response serialisation.
+  No business logic, no multi-step orchestration in a view.
+- **Business logic lives in `services.py`** (write) and `selectors.py` (read). Services must not
+  import `rest_framework`, `HttpRequest`, or `Response`.
+- **Models and serializers are separate classes** — never expose a model directly as the wire format.
+- **Fat models, thin views**: model methods may hold row-level invariants; cross-row / cross-model
+  workflows belong in services.
+- Settings come from environment via `django-environ` (or `os.environ` wrapped in `settings/base.py`).
+  Never read `os.environ` outside the settings module.
+- `DJANGO_SETTINGS_MODULE` defaults to `<project_name>.settings.dev`; CI uses `.settings.test`,
+  prod uses `.settings.prod`.
+
+## DRF API design
+
+- Use **Django REST Framework** for all JSON APIs. Server-rendered templates only for Django Admin.
+- All paths use kebab-case and a version prefix: `/api/v1/user-profiles/{id}`.
+- HTTP semantics: `POST` creates, `PUT` replaces, `PATCH` updates partial, `DELETE` removes.
+- `ModelViewSet` for standard CRUD; `APIView` / `@action` for custom operations.
+- **One serializer per representation** — split read vs write serializers when they diverge; never
+  reuse a model instance as the response body.
+- Register routes with DRF `DefaultRouter`; mount under `/api/v1/` in the root URLConf.
+- Use `status.HTTP_*` constants, never magic integers.
+- Validate input in serializer `validate_*` / `validate` methods — never trust raw `request.data`.
+
+## Pagination, filtering, sorting
+
+- Pagination is **mandatory** on every list endpoint. Set a global
+  `DEFAULT_PAGINATION_CLASS` + `PAGE_SIZE`; cap `size` at **100**.
+- Filtering via `django-filter` `FilterSet` classes, exposed through `filterset_class`.
+- Ordering via DRF `OrderingFilter`; `-` prefix = DESC (`?ordering=-created_at`).
+- Never return an unbounded queryset.
+
+## Permissions & auth
+
+- Set a restrictive global `DEFAULT_PERMISSION_CLASSES` (e.g. `IsAuthenticated`); relax per-view, never the reverse.
+- Authn via JWT (`djangorestframework-simplejwt`) or session auth for the admin only.
+- Authorization through DRF permission classes (`permissions.py`), not inline `if request.user...` in views.
+- Object-level checks via `has_object_permission`; enforce tenant/owner scoping in `get_queryset()`.
+
+## ORM & queries
+
+- **Prevent N+1**: use `select_related` (FK/O2O) and `prefetch_related` (M2M/reverse FK) on every
+  list endpoint. N+1 in a hot path is a blocking review failure.
+- Keep queries in `selectors.py` / `services.py`, not in serializers or views.
+- Index every field used in filters, ordering, or FK lookups (`db_index=True` / `Meta.indexes`).
+- Use `QuerySet.only()` / `defer()` for wide models on list endpoints.
+- Wrap multi-write operations in `transaction.atomic()`.
+
+## Migrations
+
+- Always run `makemigrations` and **commit the generated migration files**.
+- Never hand-author schema migrations; for data migrations use `RunPython` with a reverse function.
+- Never call `create_all` / raw `CREATE TABLE`. Migrations are the only schema source of truth.
+- Squash long migration chains on a `chore/` branch when they slow tests.
+
+## Error handling
+
+- Register a custom DRF `EXCEPTION_HANDLER` that returns a consistent error body
+  (`{"type", "title", "status", "detail"}`); align with RFC 7807 where practical.
+- Use `rest_framework.exceptions` (`ValidationError`, `PermissionDenied`, `NotFound`) — not bare `Http404`/asserts.
+- Never expose stack traces, SQL, or internal paths in API responses. `DEBUG=False` in prod.
+
+## Structured logging & observability
+
+- Configure `LOGGING` for structured JSON in prod; emit `request_id`, `method`, `path`, `status`, `duration_ms`, `user_id`.
+- Propagate `X-Request-ID` via middleware (pairs with `django-traceid`); return it on every response.
+- **Never log PII** — mask email, tokens, passwords.
+- Wire Sentry (`sentry-sdk[django]`) for 5xx capture.
+
+## Health endpoints
+
+| Path | Purpose | Auth |
+|---|---|---|
+| `GET /health` | General health | None |
+| `GET /health/ready` | Readiness — runs `SELECT 1` against the DB | None |
+
+- Exclude health endpoints from auth, throttling, and CORS restrictions.
+
+## Settings & security
+
+- `SECRET_KEY`, DB creds, and all environment-varying config come from env vars — never committed.
+- `ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`, `SECURE_*` flags set explicitly in `settings/prod.py`.
+- `CORS_ALLOWED_ORIGINS` is an explicit whitelist; never `CORS_ALLOW_ALL_ORIGINS = True` in prod.
+- Keep `DEBUG = False` outside local dev; never ship the default `SECRET_KEY`.
+- Use Django's password hashers and validators; never store plaintext.
+
+## Testing
+
+- Use `pytest` + `pytest-django`; mark DB tests with `@pytest.mark.django_db`.
+- Build fixtures with `factory-boy` (`DjangoModelFactory`) — avoid loading large JSON fixtures.
+- Per endpoint, cover at minimum: happy path, validation error (400), auth failure (401/403), not-found (404).
+- Use DRF `APIClient` for integration tests; assert on status + serialized body.
+- Use the fast password hasher and a local-memory cache in `settings/test.py`.
+- Coverage target: **85%+ lines** (services and serializers are the priority surface).
+
+## Dependencies
+
+- Pin versions in `pyproject.toml` under `[project.dependencies]`.
+- Core: `django`, `djangorestframework`, `django-filter`, `django-environ`.
+- Dev extras: `ruff`, `mypy` (with `django-stubs`), `pytest`, `pytest-django`, `factory-boy`.


### PR DESCRIPTION
## Why

The fleet has 7 Django repos but `copilot-instructions/` shipped no `django.md` — only `fastapi.md`, `python-library.md`, `react19.md`, `gas.md`, `monorepo.md`. Django appeared just 3× across all standards docs. You cannot verify "Django code structure compliance" against a standard that was never written. This authors it.

## What

- **`copilot-instructions/django.md`** — canonical Django/DRF standard, parallel to `fastapi.md`:
  project layout (settings split, per-app `models/serializers/views/services/selectors`, `src/` for Django libraries), services-vs-views separation, DRF API design, mandatory pagination, ORM N+1 prevention, migrations-always-committed, settings/security, `pytest-django` + `factory-boy` testing at 85%.
- **`README.md`** — register `django.md` in the per-stack guide list.

## Follow-ups (separate PRs, this campaign)

- `guideline-checker`: add `django.instructions.md` to the `init` scaffold (machine-checkable rules).
- Audit the 7 Django repos against this standard + remediate (layout, missing CLAUDE.md, build outliers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)