### PR TITLE
docs(standards): Public API Contract + interface review ledger; setuptools backend

### DIFF
--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -331,15 +331,19 @@ Never commit `.env`. Always commit `.env.example` with placeholder values.
 
 | Project type | Backend | `requires` |
 |---|---|---|
-| Library / package | `hatchling` | `["hatchling"]` |
+| Library / package | `setuptools` | `["setuptools>=70", "wheel"]` |
 | Application (no distribution) | `setuptools` | `["setuptools>=72", "wheel"]` |
+
+> Backend rationale (2026-06-10): the portfolio standardised on
+> `setuptools` (7/8 libs already use it). `hatchling` is **not** used;
+> migrate any stray `hatchling` lib (e.g. `django-autoload`) to setuptools.
 
 ### Mandatory sections
 
 ```toml
 [build-system]
-requires = ["hatchling"]           # or setuptools for apps
-build-backend = "hatchling.build"
+requires = ["setuptools>=70", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "..."
@@ -373,7 +377,8 @@ ignore_missing_imports = true
 - All tool config (`ruff`, `mypy`, `pytest`, `coverage`) lives in `[tool.*]` sections of `pyproject.toml`.
 - External config files (`ruff.toml`, `mypy.ini`, `pytest.ini`, `.mypy.ini`) are **forbidden**.
 - `setup.cfg` is permitted only for non-Python tooling (e.g. uwsgi); never for Python packaging.
-- Library packages use `src/` layout with `[tool.hatch.build.targets.wheel] packages = ["src/<pkg>"]`.
+- Library packages use `src/` layout with `[tool.setuptools.packages.find] where = ["src"]`.
+- Library packages follow the **Public API Contract** (`docs/PUBLIC-API-CONTRACT.md`): sorted `__all__`, relative imports in `__init__`, `__version__` via `importlib.metadata`, uniform `install()` entrypoint, shared types in `chrysa-lib`.
 - Applications without distribution do not need `[build-system]`; only `[tool.*]` sections are required.
 
 ### Distribution
@@ -381,7 +386,7 @@ ignore_missing_imports = true
 Distribution is driven by the project type declared in the **Build backend** table above:
 
 - **Library / package (distributable)** → published to **public PyPI**, triggered by CI on a git tag
-  matching `v*.*.*`. Build with `hatchling`, upload via Trusted Publishing (PyPI OIDC) — **no PyPI API
+  matching `v*.*.*`. Build with `setuptools`, upload via Trusted Publishing (PyPI OIDC) — **no PyPI API
   token in plaintext**. Include `CHANGELOG.md`, `LICENSE`, and `README.md` in the sdist.
 - **Application (no distribution)** → **not** published to PyPI; shipped as a **private GHCR image** (see §6).
 - Publication is carried by the reusable `release.yml` workflow (tag → publish; see `chrysa/github-actions`).

--- a/docs/INTERFACE-REVIEW-LEDGER.md
+++ b/docs/INTERFACE-REVIEW-LEDGER.md
@@ -1,0 +1,100 @@
+# Interface Review Ledger — portfolio-wide coherence campaign
+
+> Goal: make every product's interface optimal and **coherent per product
+> family**. "Interface" = public API for libs, HTTP surface for services,
+> UI for frontends, CLI for tools.
+>
+> Driving standards: `docs/PUBLIC-API-CONTRACT.md` (libs),
+> `CODE_MANIFEST.md` §3 (services), `docs/UX-UI-GUIDELINES.md` +
+> `.claude/skills/ui-ux/SKILL.md` (UI), this ledger (tracking).
+>
+> Execution rule: **Rule 1+2** — max 1 Socle + 2 Actifs repos in flight.
+> One family per session. Each repo: review → P0/P1/P2 findings →
+> worktree → fix → `make test` (Docker) → `review` agent → draft PR → mark.
+>
+> Status legend: `todo → in-review → fix → PR-open → merged`
+
+## Phase 1 — Lib mirror families `django-*` / `fastapi-*`
+
+| Repo | Status | PR | P0/P1/P2 | Notes |
+|---|---|---|---|---|
+| django-traceid | fix | — | — | ✅ src/ migration + importlib.metadata; Docker 29 pass cov 98.7% (branch `chore/src-layout-and-version`) |
+| fastapi-traceid | fix | — | — | ✅ importlib.metadata; Docker 27 pass cov 97.9% (branch `chore/version-metadata`) |
+| django-query-optimizer | todo | — | — | importlib.metadata, relative imports, export `Severity` |
+| fastapi-query-optimizer | todo | — | — | importlib.metadata, review `__getattr__` |
+| django-pytest | todo | — | — | flat→src/, add `__version__` |
+| fastapi-pytest | todo | — | — | verify `__all__` sorted |
+| django-autoload | todo | — | — | add `__version__` |
+| fastapi-autoload | todo | — | — | reference |
+| django-app-forge | todo | — | — | flat→src/, add `__version__` (PR #4 open — coordinate) |
+| fastapi-app-forge | todo | — | — | reference |
+
+## Phase 2 — Other libs (chrysa-lib first: extract shared enums)
+
+| Repo | Status | PR | Notes |
+|---|---|---|---|
+| chrysa-lib | todo | — | Socle — host shared `Severity` and friends (C7) |
+| doc-gen | todo | — | |
+| discord-bot-back | todo | — | |
+| guideline-checker | todo | — | issue #98 open (allowlist) |
+| pre-commit-tools | todo | — | large surface (~1214 symbols) |
+| quality-gatekeeper | todo | — | |
+| chrysa-portfolio-viz | todo | — | |
+| ai-aggregator | ✓ done | #159 | design campaign |
+
+## Phase 3 — API-only services (CODE_MANIFEST §3 conformance)
+
+| Repo | Status | PR | Notes |
+|---|---|---|---|
+| audit-platform | todo | — | |
+| cdn-explorer | todo | — | |
+| sport-intelligence-hub | todo | — | |
+| link-reader-bot | todo | — | phase 3 semantic search blocked on ai-aggregator embeddings |
+| feedback-gateway | todo | — | stateless gateway |
+| mirrador | todo | — | API surface (UI tracked in Phase 4) |
+
+## Phase 4 — UI (= existing Design Campaign, epic 37759293e35e81e1973ce30839822b79)
+
+Build on `docs/UX-UI-GUIDELINES.md` + `DESIGN-SYSTEM.md` (do not reinvent).
+
+| Repo | Status | PR | Notes |
+|---|---|---|---|
+| gaming-os | ✓ done | #128 | |
+| ai-aggregator | ✓ done | #159 | |
+| studioverse | ✓ done | #65 | |
+| mirrador | todo | — | resume here (4/17) |
+| dev-nexus | todo | — | React 19 |
+| devtool | todo | — | React |
+| container-webview | todo | — | React |
+| satisfactory-factory-manager | todo | — | React 19 |
+| discordium | todo | — | React; CI red, PRs #89/#90 open |
+| D-D | todo | — | SvelteKit |
+| PO-GO-DEX | todo | — | SvelteKit |
+| my-resume | todo | — | SvelteKit (predecessor of linkendin-resume) |
+| linkendin-resume | todo | — | React 19 |
+
+## Phase 5 — CLI + VS Code extension
+
+| Repo | Status | PR | Notes |
+|---|---|---|---|
+| coach | todo | — | |
+| genealogy-validator | todo | — | |
+| diy-stream-deck | todo | — | |
+| floating-agent | todo | — | overlay; lifeos/my-assistant are siblings |
+| gestureOS | todo | — | pre-alpha |
+| lifeos | todo | — | pre-alpha (sibling of my-assistant) |
+| my-assistant | todo | — | pre-alpha |
+| notion-readme-sync | todo | — | |
+| pilote-paperclip | todo | — | |
+| project-init | todo | — | |
+| satisfactory-automated_calculator | todo | — | GAS |
+| windows-docker-state-notification | todo | — | |
+| pre-commit-hooks-changelog | todo | — | |
+| automations | todo | — | Node/GAS |
+| django-query-optimizer-vscode | todo | — | `contributes.commands` naming |
+
+## Out of scope
+agent-config, catalog, chrysa-skills, claude-config, dotfiles,
+github-actions, homeassistant-config, infra-v2, orchestrator, paperclip,
+server, shared-standards, usefull-containers, windows-autonome (infra/meta);
+django_auto_discover, game-solver-platform, mediavault (stub/empty).

--- a/docs/INTERFACE-REVIEW-LEDGER.md
+++ b/docs/INTERFACE-REVIEW-LEDGER.md
@@ -18,10 +18,10 @@
 
 | Repo | Status | PR | P0/P1/P2 | Notes |
 |---|---|---|---|---|
-| django-traceid | fix | — | — | ✅ src/ migration + importlib.metadata; Docker 29 pass cov 98.7% (branch `chore/src-layout-and-version`) |
-| fastapi-traceid | fix | — | — | ✅ importlib.metadata; Docker 27 pass cov 97.9% (branch `chore/version-metadata`) |
-| django-query-optimizer | todo | — | — | importlib.metadata, relative imports, export `Severity` |
-| fastapi-query-optimizer | todo | — | — | importlib.metadata, review `__getattr__` |
+| django-traceid | PR-open | #23 | — | ✅ src/ migration + importlib.metadata; Docker 29 pass cov 98.7% |
+| fastapi-traceid | PR-open | #4 | — | ✅ importlib.metadata; Docker 27 pass cov 97.9% |
+| django-query-optimizer | PR-open | #57 | — | ✅ metadata, relative imports, export `Severity`, sorted `__all__`; Docker 288 pass cov 95% |
+| fastapi-query-optimizer | PR-open | #4 | — | ✅ metadata, relative imports; `__getattr__` kept (justified); Docker 179 pass |
 | django-pytest | todo | — | — | flat→src/, add `__version__` |
 | fastapi-pytest | todo | — | — | verify `__all__` sorted |
 | django-autoload | todo | — | — | add `__version__` |

--- a/docs/PUBLIC-API-CONTRACT.md
+++ b/docs/PUBLIC-API-CONTRACT.md
@@ -1,0 +1,127 @@
+# Public API Contract — Python library packages
+
+> Scope: every distributable Python library in the chrysa portfolio
+> (`django-*`, `fastapi-*`, `chrysa-lib`, `ai-aggregator`, `doc-gen`,
+> `discord-bot-back`, `guideline-checker`, `pre-commit-tools`,
+> `quality-gatekeeper`, `chrysa-portfolio-viz`).
+>
+> This document fills the gap **between** `EXECUTION_STANDARD.md` §11
+> (which mandates the `src/` layout and build backend) **and** the
+> code: it specifies what the package's top-level `__init__.py` is
+> allowed to expose and how. It does **not** restate API/REST rules —
+> those live in `CODE_MANIFEST.md` §3 — nor UI rules
+> (`docs/UX-UI-GUIDELINES.md`, `.claude/skills/ui-ux/SKILL.md`).
+
+The top-level `__init__.py` **is** the package's public contract. A
+consumer should never have to reach into a submodule. Everything below
+is enforced uniformly across mirror families so that
+`import django_x` and `import fastapi_x` feel like the same product.
+
+---
+
+## C1 — Layout (already mandated, restated for compliance)
+
+- `src/<pkg>/__init__.py` layout — per `EXECUTION_STANDARD.md` §11.
+- **Flat-layout packages are non-conformant** and must be migrated.
+
+## C2 — `__all__` is mandatory and sorted
+
+- Every public `__init__.py` declares `__all__`.
+- `__all__` is **alphabetically sorted** and contains **only** the
+  stable public surface (no private helpers, no re-exported stdlib).
+- Anything not in `__all__` is private and may change without a major bump.
+
+## C3 — Single import style inside `__init__.py`
+
+- Use **relative imports** in `__init__.py`: `from .module import X`.
+- Absolute self-imports (`from pkg.module import X`) are forbidden in
+  `__init__.py` — they duplicate the package name and break on rename.
+
+## C4 — `__version__` exposed, single source of truth
+
+- `__init__.py` **must** expose `__version__`.
+- The value is read at runtime from installed metadata — **never**
+  hardcoded and never duplicated in a `_internal/version.py`:
+
+  ```python
+  from importlib.metadata import PackageNotFoundError, version
+
+  try:
+      __version__ = version("<dist-name>")
+  except PackageNotFoundError:  # editable / not installed
+      __version__ = "0.0.0+unknown"
+  ```
+
+- `pyproject.toml [project].version` is the **only** declared version.
+  Remove any second source (`_internal/version.py`, `__about__.py`).
+
+## C5 — Installation / wiring entrypoint, uniform name
+
+- A library that wires into a framework (middleware, plugin, app
+  registry) exposes **one** entrypoint, named identically across the
+  family:
+  - `install(...)` — idempotent, wires the library into the host.
+  - Django libs: zero-arg `install()` (settings-driven).
+  - FastAPI libs: `install(app_or_engine)` — takes the host object.
+- Libraries that are pure toolkits (no host wiring) **do not** invent a
+  fake `install()`; they expose their primary callable instead.
+
+## C6 — No lazy `__getattr__` unless justified
+
+- Module-level `__getattr__` for lazy export is allowed **only** to break
+  a heavy/optional import cycle, and must be documented inline with the
+  reason. Default: eager imports. Do not add it for symmetry alone.
+
+## C7 — Shared types live in `chrysa-lib`
+
+- Cross-package enums/types (e.g. `Severity`) are defined **once** in
+  `chrysa-lib` and imported, not redefined per repo.
+- A package re-exports the shared type through its `__all__` if it is
+  part of that package's public surface.
+
+## C8 — README "Public API" section
+
+- The README carries a `## Public API` section listing every name in
+  `__all__` with a one-line purpose, and a minimal usage example.
+- Mirror families (`django-x` / `fastapi-x`) use the **same example
+  shape** so the docs read consistently.
+
+---
+
+## Conformance snapshot (2026-06-10)
+
+Evidence from `__init__.py` + `pyproject.toml` inspection of the mirror
+families. **All repos hardcode `__version__ = "0.1.0"`** (C4 violated
+everywhere). Build backend is `setuptools` everywhere except
+`django-autoload` (`hatchling` — migrate to setuptools per
+`EXECUTION_STANDARD.md` §11).
+
+| Repo | C1 layout | C4 version | C3 imports | Backend | Action |
+|---|---|---|---|---|---|
+| django-traceid | ❌ flat | ⚠️ hardcoded | relative ok | setuptools | migrate to `src/`, importlib.metadata |
+| django-pytest | ❌ flat | ⚠️ hardcoded | — | setuptools | migrate to `src/`, importlib.metadata |
+| django-app-forge | ❌ flat | ⚠️ hardcoded | — | setuptools | migrate to `src/`, importlib.metadata (PR #4 open) |
+| django-autoload | ✅ src | ⚠️ hardcoded | relative ok | ⚠️ hatchling | importlib.metadata; backend → setuptools |
+| django-query-optimizer | ✅ src | ⚠️ `_internal.version` | ❌ absolute | setuptools | importlib.metadata, relative imports, export `Severity` |
+| fastapi-traceid | ✅ src | ⚠️ hardcoded | ✅ | setuptools | importlib.metadata |
+| fastapi-pytest | ✅ src | ⚠️ hardcoded | ✅ | setuptools | importlib.metadata, verify `__all__` sorted |
+| fastapi-autoload | ✅ src | ⚠️ hardcoded | ✅ | setuptools | importlib.metadata |
+| fastapi-query-optimizer | ✅ src | ⚠️ `_internal.version` | ❌ absolute | setuptools | importlib.metadata; review `__getattr__` (C6) |
+| fastapi-app-forge | ✅ src | ⚠️ hardcoded | ✅ | setuptools | importlib.metadata |
+
+Cross-family: `Severity` is exported by `fastapi-query-optimizer` and
+`fastapi-pytest` but not `django-query-optimizer` → extract to
+`chrysa-lib` (C7).
+
+---
+
+## Verification (per repo, Docker only)
+
+```bash
+make install
+python -c "import <pkg> as m; assert m.__all__ == sorted(m.__all__); print(m.__version__, m.__all__)"
+make lint && make test
+```
+
+> Host invocation of `python`/`ruff`/`pytest` is forbidden
+> (`EXECUTION_STANDARD.md` §12). Run inside the project's `make` targets.

--- a/docs/PUBLIC-API-CONTRACT.md
+++ b/docs/PUBLIC-API-CONTRACT.md
@@ -41,7 +41,7 @@ is enforced uniformly across mirror families so that
 
 - `__init__.py` **must** expose `__version__`.
 - The value is read at runtime from installed metadata — **never**
-  hardcoded and never duplicated in a `_internal/version.py`:
+  hardcoded:
 
   ```python
   from importlib.metadata import PackageNotFoundError, version
@@ -53,7 +53,15 @@ is enforced uniformly across mirror families so that
   ```
 
 - `pyproject.toml [project].version` is the **only** declared version.
-  Remove any second source (`_internal/version.py`, `__about__.py`).
+  No hardcoded copy anywhere (delete any `__about__.py` or
+  `_internal/version.py` that holds a literal string).
+- When other modules also need the version (SARIF/report headers, user
+  agents), **centralize** the `importlib.metadata` read in a single
+  internal accessor (e.g. `_internal/version.py` that itself reads
+  metadata) and import `__version__` from there — both in `__init__` and
+  in those modules. This avoids importing the package root from a
+  submodule and creating an import cycle. The rule is *no hardcoded
+  second value*, not *no internal module*.
 
 ## C5 — Installation / wiring entrypoint, uniform name
 


### PR DESCRIPTION
## Context
Foundational artifacts for the portfolio-wide **interface coherence campaign** (review every product's interface, make it coherent per family).

## Changes
- **`docs/PUBLIC-API-CONTRACT.md`** — `__init__` public-surface contract for libs: sorted `__all__`, relative imports, `__version__` via `importlib.metadata` (single source), uniform `install()` entrypoint, shared types in `chrysa-lib`. Includes a conformance snapshot of the `django-*`/`fastapi-*` mirror families.
- **`docs/INTERFACE-REVIEW-LEDGER.md`** — campaign tracker, ~40 reviewable repos, 5 phases, statuses.
- **`EXECUTION_STANDARD.md`** — build-backend standard aligned to **setuptools** (7/8 libs already use it; hatchling was aspirational/unused) + pointer to the new contract.

## Notes
Docs only. No code paths touched. First PR of the campaign; `*-traceid` family PRs follow.