### PR TITLE
docs(standards): C2 RUF022 ordering; ledger pytest family

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,21 @@
 {
   "mcpServers": {
     "github": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }
     },
     "notion": {
+      "args": [
+        "-y",
+        "@notionhq/notion-mcp-server"
+      ],
       "command": "npx",
-      "args": ["-y", "@notionhq/notion-mcp-server"],
       "env": {
         "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ${NOTION_API_KEY}\", \"Notion-Version\": \"2022-06-28\"}"
       }

--- a/docs/INTERFACE-REVIEW-LEDGER.md
+++ b/docs/INTERFACE-REVIEW-LEDGER.md
@@ -22,8 +22,8 @@
 | fastapi-traceid | PR-open | #4 | — | ✅ importlib.metadata; Docker 27 pass cov 97.9% |
 | django-query-optimizer | PR-open | #57 | — | ✅ metadata, relative imports, export `Severity`, sorted `__all__`; Docker 288 pass cov 95% |
 | fastapi-query-optimizer | PR-open | #4 | — | ✅ metadata, relative imports; `__getattr__` kept (justified); Docker 179 pass |
-| django-pytest | todo | — | — | flat→src/, add `__version__` |
-| fastapi-pytest | todo | — | — | verify `__all__` sorted |
+| django-pytest | PR-open | #28 | — | ✅ src/ migration + importlib.metadata + `__all__`; Docker 45 pass cov 85% |
+| fastapi-pytest | PR-open | #4 | — | ✅ importlib.metadata + relative imports + RUF022 `__all__`; Docker 135 pass cov 97% |
 | django-autoload | todo | — | — | add `__version__` |
 | fastapi-autoload | todo | — | — | reference |
 | django-app-forge | todo | — | — | flat→src/, add `__version__` (PR #4 open — coordinate) |

--- a/docs/INTERFACE-REVIEW-LEDGER.md
+++ b/docs/INTERFACE-REVIEW-LEDGER.md
@@ -24,8 +24,8 @@
 | fastapi-query-optimizer | PR-open | #4 | — | ✅ metadata, relative imports; `__getattr__` kept (justified); Docker 179 pass |
 | django-pytest | PR-open | #28 | — | ✅ src/ migration + importlib.metadata + `__all__`; Docker 45 pass cov 85% |
 | fastapi-pytest | PR-open | #4 | — | ✅ importlib.metadata + relative imports + RUF022 `__all__`; Docker 135 pass cov 97% |
-| django-autoload | todo | — | — | add `__version__` |
-| fastapi-autoload | todo | — | — | reference |
+| django-autoload | PR-open | #17 | — | ✅ hatchling→setuptools backend + importlib.metadata; Docker 19 pass |
+| fastapi-autoload | PR-open | #4 | — | ✅ importlib.metadata; Docker 21 pass cov 96.7% |
 | django-app-forge | todo | — | — | flat→src/, add `__version__` (PR #4 open — coordinate) |
 | fastapi-app-forge | todo | — | — | reference |
 

--- a/docs/INTERFACE-REVIEW-LEDGER.md
+++ b/docs/INTERFACE-REVIEW-LEDGER.md
@@ -26,8 +26,8 @@
 | fastapi-pytest | PR-open | #4 | — | ✅ importlib.metadata + relative imports + RUF022 `__all__`; Docker 135 pass cov 97% |
 | django-autoload | PR-open | #17 | — | ✅ hatchling→setuptools backend + importlib.metadata; Docker 19 pass |
 | fastapi-autoload | PR-open | #4 | — | ✅ importlib.metadata; Docker 21 pass cov 96.7% |
-| django-app-forge | todo | — | — | flat→src/, add `__version__` (PR #4 open — coordinate) |
-| fastapi-app-forge | todo | — | — | reference |
+| django-app-forge | PR-open | #29 | — | ✅ src/ migration + importlib.metadata; Docker 32 pass cov 93% |
+| fastapi-app-forge | PR-open | #4 | — | ✅ importlib.metadata; Docker 95 pass cov 96.2% |
 
 ## Phase 2 — Other libs (chrysa-lib first: extract shared enums)
 

--- a/docs/PUBLIC-API-CONTRACT.md
+++ b/docs/PUBLIC-API-CONTRACT.md
@@ -27,7 +27,10 @@ is enforced uniformly across mirror families so that
 ## C2 — `__all__` is mandatory and sorted
 
 - Every public `__init__.py` declares `__all__`.
-- `__all__` is **alphabetically sorted** and contains **only** the
+- `__all__` is **sorted per ruff `RUF022`** (isort-style: PascalCase
+  names first A–Z, then dunders like `__version__`, then lowercase
+  callables). Run `ruff check --fix` to canonicalise — do not hand-sort,
+  the tool's order is the standard. `__all__` contains **only** the
   stable public surface (no private helpers, no re-exported stdlib).
 - Anything not in `__all__` is private and may change without a major bump.
 

--- a/templates/mcp/mcp.base.json
+++ b/templates/mcp/mcp.base.json
@@ -1,15 +1,21 @@
 {
   "mcpServers": {
     "github": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }
     },
     "notion": {
+      "args": [
+        "-y",
+        "@notionhq/notion-mcp-server"
+      ],
       "command": "npx",
-      "args": ["-y", "@notionhq/notion-mcp-server"],
       "env": {
         "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ${NOTION_API_KEY}\", \"Notion-Version\": \"2022-06-28\"}"
       }

--- a/templates/mcp/mcp.lib.json
+++ b/templates/mcp/mcp.lib.json
@@ -1,22 +1,31 @@
 {
   "mcpServers": {
+    "context7": {
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ],
+      "command": "npx"
+    },
     "github": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }
     },
     "notion": {
+      "args": [
+        "-y",
+        "@notionhq/notion-mcp-server"
+      ],
       "command": "npx",
-      "args": ["-y", "@notionhq/notion-mcp-server"],
       "env": {
         "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ${NOTION_API_KEY}\", \"Notion-Version\": \"2022-06-28\"}"
       }
-    },
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@latest"]
     }
   }
 }

--- a/templates/mcp/mcp.web.json
+++ b/templates/mcp/mcp.web.json
@@ -1,22 +1,31 @@
 {
   "mcpServers": {
     "github": {
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }
     },
     "notion": {
+      "args": [
+        "-y",
+        "@notionhq/notion-mcp-server"
+      ],
       "command": "npx",
-      "args": ["-y", "@notionhq/notion-mcp-server"],
       "env": {
         "OPENAPI_MCP_HEADERS": "{\"Authorization\": \"Bearer ${NOTION_API_KEY}\", \"Notion-Version\": \"2022-06-28\"}"
       }
     },
     "playwright": {
-      "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
+      "args": [
+        "-y",
+        "@playwright/mcp@latest"
+      ],
+      "command": "npx"
     }
   }
 }


### PR DESCRIPTION
## Context
Follow-up to #99 (merged). Refines the Public API Contract and advances the interface review ledger.

## Changes
- **C2** — specify `__all__` ordering follows ruff `RUF022` (PascalCase, then dunders, then lowercase); canonicalised by `ruff check --fix`, not hand-sorted.
- **Ledger** — `*-pytest` family marked PR-open (django-pytest#28, fastapi-pytest#4).