### PR TITLE
design(standards): replace uniform Neon Brutalist with 4 personas

### DIFF
--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -1,91 +1,181 @@
-# chrysa Design System — "Neon Brutalist"
+# chrysa Design System — Personas
 
 > The **visual layer** for every chrysa web surface. Companion to
 > `docs/UX-UI-GUIDELINES.md` (which owns ergonomics, a11y, i18n, the four states)
-> and the `ui-ux` skill. This document owns the *look*: one token contract, one
-> aesthetic DNA, per-app accent.
+> and the `ui-ux` skill. This document owns the *look*: one token contract, **four
+> aesthetic personas**, per-app accent.
 >
-> **Status:** adopted 2026-06 (ecosystem-wide re-skin, all GUI frontends).
+> **Status:** adopted 2026-06. **Supersedes** the single "Neon Brutalist" DNA
+> (2026-06, ecosystem re-skin) after the [2026-06 design audit](audits/DESIGN-AUDIT-2026-06.md)
+> found that one uniform aesthetic + accent-only differentiation gave every app the
+> same identity and forced genres that fight brutalism (a résumé, content tools)
+> into it. See [ADR 0002](adr/0002-design-personas.md).
 > **Distribution:** tokens + primitives live in `chrysa-lib` → `@chrysa/ui`.
 > Tailwind repos consume the `@theme` mapping; SCSS/Bootstrap repos consume the
 > same CSS custom properties.
 
 ---
 
-## 0. Why a system
+## 0. Why a system, why personas
 
-The frontends had diverged across ~6 styling stacks with no shared identity.
-Rather than unify the *stack* (high-churn migration), we unify the **token
-contract + visual DNA**: every app speaks the same semantic vocabulary and wears
-the same aesthetic, while keeping its own CSS stack and its own accent hue.
+The frontends had diverged across ~6 styling stacks with no shared identity. The
+first answer (one aesthetic, one accent per app) over-corrected: it unified the
+*skin* so hard that a CI dashboard, a doc generator, and a résumé became the same
+product in different highlighter colors — and the two apps with real identity
+(`sport-intelligence-hub`, `discordium`) got there by routing *around* the system.
 
----
-
-## 1. Aesthetic DNA — the rules
-
-Neon Brutalist. Loud structure, flat fills, one acid accent. The rules below are
-**RULE** (binding); deviations need a documented reason in `<repo>/DECISIONS.md`.
-
-1. **Radius 0.** No rounded corners anywhere (`--radius: 0px`).
-2. **Borders are structure.** Every surface, input and button has a `2px solid`
-   border in the `border` token (which equals the foreground — loud, not subtle).
-3. **Hard offset shadows, never blur.** `--shadow: 4px 4px 0 #000`. Shadow is the
-   border's twin; interactive elements "press" into it on hover/active.
-4. **No gradients, no glow.** Flat fills only.
-5. **Mono-forward.** JetBrains Mono for data, labels, and UI chrome; Space Grotesk
-   for display headings only. No third family.
-6. **Accent is a block, not text.** The acid hue fills a region with `accent-ink`
-   text on top — never thin acid text on a dark background (keeps WCAG AA).
-7. **Loud labels.** Uppercase + `letter-spacing` for eyebrows, KPI labels, buttons.
-8. **One accent per app.** A single acid hue carries identity; everything else is
-   the shared neutral frame.
+The fix keeps the part that worked — **one semantic token contract + per-app
+accent + the ergonomics/a11y floor** — and replaces the single DNA with **four
+personas**. A persona is a genre-appropriate bundle of *typography, density,
+radius, depth, and motion*. **Identity = persona + accent**, never accent alone.
+Apps in the same genre *should* feel related; the bug was cross-genre apps feeling
+identical.
 
 ---
 
-## 2. Token contract
+## 1. The four personas
+
+Each persona fixes five axes. The axes are **tokens** (§3) so a repo adopts a
+persona by setting one block, and all components inherit.
+
+| Axis | **Console** | **Arcade** | **Editorial** | **Signal** |
+|---|---|---|---|---|
+| **Genre** | dev tools, dashboards, data utilities | games & playful surfaces | personal / portfolio / content | live data, sport, scoreboards |
+| **Display font** | Space Grotesk | Chakra Petch / heavy grotesk | Fraunces / Newsreader (serif) | Space Grotesk |
+| **Body font** | Inter / system sans | Inter | the serif's sans companion (e.g. Inter) | Inter |
+| **Data font** | JetBrains Mono | JetBrains Mono | JetBrains Mono (figures) | JetBrains Mono (tabular) |
+| **Radius** | `4px` | `0–2px` | `10px` | `6px` |
+| **Depth** | hairline border + small soft shadow | hard offset shadow (the "press") | soft blurred shadow | border + medium shadow |
+| **Border** | `1px` | `2px` (structural) | `1px` | `1px` |
+| **Density** | compact (control `h-9`) | normal (`h-10`) | comfortable (`h-11`, generous spacing) | compact, tabular |
+| **Case** | labels uppercase, body normal | uppercase-forward | all normal case | labels uppercase, figures tabular |
+| **Motion** | quick fade/press (120ms) | expressive press-translate + accent pulse | calm fade/slide (200–260ms) | live-update flash, value count |
+| **Accent use** | small fills + focus + key numbers | large saturated blocks | restrained, one warm accent | semantic + per-entity palette |
+
+Brutalism is **not deleted** — it survives as **Arcade**, where loud structure
+fits. The other three genres get type/density/depth tuned to how they're read.
+
+Persona rules are **RULE** (binding); deviations need a documented reason in
+`<repo>/DECISIONS.md`.
+
+---
+
+## 2. App → persona map
+
+16 web frontends (`my-resume` has no shippable frontend; dropped). One accent each
+(§4). Migration is one repo per session (rule 1+2); deltas in §8.
+
+| App | Persona | Accent | Current `main` | Migration weight |
+|---|---|---|---|---|
+| dev-nexus | Console | cyan | brutalist | light (relax radius/border, add body sans) |
+| devtool | Console | cyan | brutalist | light |
+| container-webview | Console | cyan | brutalist | light |
+| cdn-explorer | Console | magenta | brutalist | light |
+| audit-platform | Console | azure | brutalist | light |
+| doc-gen | Console | violet | brutalist | medium (content density) |
+| mirrador | Console | orange | brutalist | light |
+| chrysa-portfolio-viz | Console | chrome | brutalist | light |
+| ai-aggregator | Console | violet | **soft slop** | medium (drop Inter-as-brand, adopt Console) |
+| link-reader-bot | Console | magenta | brutalist | light |
+| satisfactory-factory-manager | Console | orange | brutalist | light (dense planner; keep industrial orange) |
+| gaming-os | **Arcade** | lime | brutalist | minimal (already close) |
+| studioverse | **Arcade** | lime | brutalist | minimal |
+| discordium | **Arcade** | per-theme | 4 in-app themes | keep themes; map chrome to Arcade |
+| linkendin-resume | **Editorial** | warm amber | brutalist | **heavy** (full re-skin; pilot) |
+| sport-intelligence-hub | **Signal** | per-team | bespoke (untouched) | none (it *is* the Signal reference) |
+
+`sport-intelligence-hub` is the canonical Signal implementation — formalize its
+existing tokens, don't rebuild them.
+
+---
+
+## 3. Token contract
 
 The single source of truth. Names are **semantic roles**, never raw colors. Dark
-is canonical; light is provided and must meet the same contrast bar.
+is canonical; light meets the same contrast bar. The **neutral frame is shared by
+all personas**; the **persona block** sets the five axes.
 
 ```css
-/* @chrysa/ui — tokens.css */
+/* @chrysa/ui — tokens.css : shared neutral frame (all personas) */
 :root {                         /* dark — canonical */
   --bg:         #0e0e10;
   --surface:    #18181b;
-  --surface-2:  #242428;
-  --fg:         #fafafa;
-  --muted:      #a1a1aa;
-  --border:     #fafafa;        /* FG-colored, deliberately loud */
-  --accent:     #c8ff00;        /* acid lime — PER-APP override */
+  --surface-2:  #242428;        /* must differ >=4% L from --surface */
+  --fg:         #fafafa;        /* 18:1 on --bg */
+  --muted:      #a1a1aa;        /* 7:1 on --bg */
+  --border:     #2e2e33;        /* hairline default; personas may raise to --fg */
+  --accent:     #c8ff00;        /* PER-APP override (§4) */
   --accent-ink: #0e0e10;        /* text/icon ON an accent block */
   --signal:     #22c55e;
   --warning:    #fbbf24;
   --danger:     #ff4d4d;
   --ring:       var(--accent);
-  --radius:     0px;
-  --shadow:     4px 4px 0 #000000;
-  --font-display: "Space Grotesk", system-ui, sans-serif;
-  --font-mono:    "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
 }
 
 :root.light {
   --bg:#fafafa; --surface:#ffffff; --surface-2:#f0f0f0;
-  --fg:#0e0e10; --muted:#52525b; --border:#0e0e10;
+  --fg:#0e0e10; --muted:#52525b; --border:#d4d4d8;
   --accent:#a3e000; --accent-ink:#0e0e10;
   --signal:#15803d; --warning:#b45309; --danger:#dc2626;
-  --shadow:4px 4px 0 #0e0e10;
+}
+
+/* --- PERSONA BLOCK: pick ONE. Sets the five axes. --- */
+
+/* Console */
+:root[data-persona="console"] {
+  --radius: 4px;
+  --border-weight: 1px;
+  --shadow: 0 1px 3px rgb(0 0 0 / 0.24), 0 1px 2px rgb(0 0 0 / 0.16);
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-body:    "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, monospace;
+  --density: 2.25rem;           /* control height (h-9) */
+  --motion: 120ms;
+}
+
+/* Arcade — brutalism lives here */
+:root[data-persona="arcade"] {
+  --radius: 2px;
+  --border-weight: 2px;
+  --border: var(--fg);          /* loud structural border */
+  --shadow: 4px 4px 0 #000000;  /* hard offset; light: 4px 4px 0 var(--fg) */
+  --font-display: "Chakra Petch", "Space Grotesk", sans-serif;
+  --font-body:    "Inter", system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, monospace;
+  --density: 2.5rem;            /* h-10 */
+  --motion: 100ms;
+}
+
+/* Editorial */
+:root[data-persona="editorial"] {
+  --radius: 10px;
+  --border-weight: 1px;
+  --shadow: 0 4px 24px rgb(0 0 0 / 0.18);
+  --font-display: "Fraunces", "Newsreader", Georgia, serif;
+  --font-body:    "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, monospace;
+  --density: 2.75rem;          /* h-11, generous */
+  --motion: 220ms;
+}
+
+/* Signal */
+:root[data-persona="signal"] {
+  --radius: 6px;
+  --border-weight: 1px;
+  --shadow: 0 2px 8px rgb(0 0 0 / 0.28);
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-body:    "Inter", system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, monospace;
+  --density: 2.25rem;
+  --motion: 140ms;
 }
 ```
 
-### 2.1 Tailwind v4 mapping (1:1)
-
-Tokens map **one-to-one** to the Tailwind theme so utilities are generated
-directly — no parallel color scale to maintain.
+### 3.1 Tailwind v4 mapping (1:1)
 
 ```css
 /* index.css (Tailwind repos) */
 @import "tailwindcss";
-
 @theme inline {
   --color-bg: var(--bg);             --color-surface: var(--surface);
   --color-surface-2: var(--surface-2);
@@ -95,104 +185,120 @@ directly — no parallel color scale to maintain.
   --color-signal: var(--signal);     --color-warning: var(--warning);
   --color-danger: var(--danger);     --color-ring: var(--ring);
   --radius-card: var(--radius);
-  --shadow-brutal: var(--shadow);
+  --shadow-card: var(--shadow);
   --font-display: var(--font-display);
+  --font-body: var(--font-body);
   --font-mono: var(--font-mono);
 }
 ```
 
 Generated utilities: `bg-surface`, `text-fg`, `text-muted`, `border-border`,
-`bg-accent`, `text-accent-ink`, `text-signal`, `shadow-brutal`, `font-mono`,
-`font-display`, `rounded-card` (= 0).
+`bg-accent`, `text-accent-ink`, `shadow-card`, `font-display`, `font-body`,
+`font-mono`, `rounded-card`.
 
-### 2.2 Spacing & type scale
+### 3.2 Spacing & type scale
 
-- Spacing: 4/8px rhythm (Tailwind default scale). Sections `space-y-6`+.
-- Type scale (fixed): `text-xs` label → `text-sm` body-dense → `text-base` body →
-  `text-lg`/`text-xl` section → `text-2xl`+ page title. KPI values larger, mono.
+- Spacing: 4/8px rhythm (Tailwind default). Console/Signal sections `space-y-4`;
+  Editorial `space-y-8`+.
+- Type scale: `text-xs` label → `text-sm` body-dense → `text-base` body →
+  `text-lg`/`text-xl` section → `text-2xl`+ page title. Editorial bumps body to
+  `text-base`/`text-lg` with `leading-relaxed`.
 
 ---
 
-## 3. Per-app accent
+## 4. Per-app accent
 
-Each app overrides **only** `--accent` (`--ring` follows). One acid hue each:
+Each app overrides **only** `--accent` (`--ring` follows). This table is
+**authoritative** — adding/changing an accent is a PR to this section, not an
+ad-hoc repo choice.
 
-| App family | `--accent` |
+| App | `--accent` (dark / light) |
 |---|---|
-| gaming-os / studioverse | `#c8ff00` acid lime |
-| dev-nexus / devtool / container-webview | `#00e5ff` cyan |
-| ai-aggregator / doc-gen | `#b388ff` electric violet |
-| satisfactory-factory-manager / mirrador | `#ff8a00` industrial orange |
-| cdn-explorer / link-reader-bot | `#ff4dff` magenta |
-| sport-intelligence-hub | per-team (existing palette) |
-| discordium | keeps its 4 in-app themes |
+| gaming-os / studioverse | `#c8ff00` / `#a3e000` acid lime |
+| dev-nexus / devtool / container-webview | `#00e5ff` / `#0891b2` cyan |
+| ai-aggregator / doc-gen | `#b388ff` / `#7c3aed` electric violet |
+| satisfactory-factory-manager / mirrador | `#ff8a00` / `#c2410c` industrial orange |
+| cdn-explorer / link-reader-bot | `#ff4dff` / `#c026d3` magenta |
+| audit-platform | `#00b3ff` / `#0088cc` azure |
+| chrysa-portfolio-viz | `#d4d4d8` / `#52525b` chrome |
+| linkendin-resume | `#f0a830` / `#b45309` warm amber (Editorial — not acid) |
+| sport-intelligence-hub | per-team palette (existing) |
+| discordium | per-theme (Discorde / Ordre / Vide / Néon) |
 
-Light-mode accent should be a slightly darker variant of the same hue to preserve
-fill contrast with `accent-ink`.
-
----
-
-## 4. Component conventions
-
-Primitives ship from `@chrysa/ui`; SCSS repos mirror them with the same classes.
-
-**Button** — flat fill, 2px border, hard shadow that presses on interaction.
-```tsx
-<button class="border-2 border-border bg-accent text-accent-ink font-mono font-semibold
-  uppercase tracking-wide px-4 h-10 shadow-brutal
-  hover:translate-x-[3px] hover:translate-y-[3px] hover:shadow-none
-  active:translate-x-[3px] active:translate-y-[3px] active:shadow-none
-  transition-[transform,box-shadow] duration-100
-  focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring
-  disabled:opacity-50 disabled:pointer-events-none" />
-```
-Variants: `bg-accent` (primary, one per region), `bg-surface` (secondary),
-`bg-danger text-fg` (destructive). Secondary/ghost keep the border + shadow.
-
-- **Card / Panel** — `border-2 border-border bg-surface shadow-brutal`, radius 0.
-- **StatCard** — uppercase mono label, oversized mono value, optional accent corner block.
-- **Badge** — square (no pill), `border-2`, solid tone fill, label + icon.
-- **Input / Select / Textarea** — `border-2 border-border bg-bg`, accent border on
-  focus (`focus:border-accent`), no soft ring.
-- **Table / List** — `border-2` outer, `divide-y-2 divide-border` rows. Header row mono uppercase.
-- **Overlay (dialog/sheet)** — `border-2`, `shadow-brutal`, focus-trapped, `Esc` closes.
+**RULE** Accent is a **fill with `accent-ink` text** — never thin acid text on
+`--bg`. Verify fill contrast ≥ 4.5:1 (large UI ≥ 3:1) for each app accent in both
+themes. Editorial uses its accent sparingly (links, one CTA), not as large blocks.
 
 ---
 
-## 5. Accessibility (brutalism is not an excuse)
+## 5. Component conventions
 
-Inherits the WCAG 2.1 AA floor from `UX-UI-GUIDELINES.md` §6. Brutalist-specific:
+Primitives ship from `@chrysa/ui` and read the tokens, so the same component
+renders per-persona automatically. SCSS/Bootstrap repos mirror them with the same
+classes + tokens.
 
-- **RULE** Accent only as a fill with `accent-ink` text — never acid text on `bg`.
-  Verify fill contrast ≥ 4.5:1 (large UI ≥ 3:1) for every app accent.
-- **RULE** `signal`/`warning`/`danger` always pair color with an icon + text.
-- **RULE** Focus = a 2px offset outline in `ring` (accent). Visible on every
-  interactive element; never `outline: none` without it.
-- **RULE** Honor `prefers-reduced-motion` — the press-translate is the only motion
-  and must be disabled there.
-- Borders/shadows are decorative; semantics live in real HTML elements + ARIA.
+- **Button** — `border-[length:var(--border-weight)] border-border rounded-card`,
+  `bg-accent text-accent-ink` (primary, one per region), height `var(--density)`.
+  Console/Editorial/Signal: subtle `shadow-card`, `hover:brightness-110`,
+  `active:scale-[0.98]`. Arcade: `shadow-card` (hard) that presses on
+  hover/active (`translate-x-[3px] translate-y-[3px] shadow-none`).
+- **Card / Panel** — `border-[length:var(--border-weight)] border-border
+  bg-surface rounded-card shadow-card`. Nested surface uses `--surface-2`.
+- **StatCard** — mono value (`font-mono`), label `text-xs` (uppercase in
+  Console/Signal, normal in Editorial), optional accent corner.
+- **Badge** — `rounded-card`, solid tone fill, label + icon.
+- **Input / Select / Textarea** — `border-[length:var(--border-weight)]
+  border-border bg-bg`, `focus:border-accent`, focus ring = `--ring`.
+- **Table / List** — `divide-y divide-border`, header row `font-mono` uppercase
+  (Console/Signal). Signal tables use tabular figures.
+- **Overlay (dialog/sheet)** — `shadow-card`, focus-trapped, `Esc` closes.
 
 ---
 
-## 6. Adoption checklist (per repo)
+## 6. Accessibility (binding floor, all personas)
+
+Inherits WCAG 2.1 AA from `UX-UI-GUIDELINES.md` §6. Persona-independent rules —
+these are the **display/ergonomics fixes** from the audit, now mechanical:
+
+- **RULE** Accent only as a fill with `accent-ink` text; fill + every text/bg pair
+  carries a stated, AA-verified ratio. Shared frame: `--fg` 18:1, `--muted` 7:1.
+- **RULE** **Body text is `--font-body` in normal case.** Mono is for data/labels,
+  never paragraphs; uppercase is for short labels, never sentences.
+- **RULE** No reflex font as the **display/brand** face (Inter, DM Sans, Outfit…).
+  Inter is allowed as `--font-body` only.
+- **RULE** No gradient text, no glow. Flat fills.
+- **RULE** Adjacent nested surfaces must differ — `--surface` vs `--surface-2`
+  ≥ 4% lightness step, or a real `--shadow`.
+- **RULE** Focus = 2px offset outline in `--ring` on every interactive element;
+  never `outline:none` without a replacement.
+- **RULE** Honor `prefers-reduced-motion` — disable press-translate, pulse, and
+  live-flash animations there.
+
+---
+
+## 7. Adoption checklist (per repo)
 
 A frontend conforms when:
 
-- [ ] Token contract present (light + dark), no hard-coded hex in components — §2
-- [ ] Tailwind `@theme` maps 1:1 (Tailwind repos) / same CSS vars (SCSS repos) — §2.1
-- [ ] Radius 0, 2px borders, hard offset shadows, no gradients/glow — §1
-- [ ] Mono-forward type, Space Grotesk display only — §1
-- [ ] One per-app accent, used as fill blocks — §3
-- [ ] Primitives styled per §4; four states still handled (per UX-UI-GUIDELINES §5)
-- [ ] WCAG AA verified in both themes, accent fill contrast checked — §5
-- [ ] `DESIGN.md` in the repo references this system + records the app accent
+- [ ] Shared neutral frame present (light + dark), no hard-coded hex in components — §3
+- [ ] **One `data-persona` set** per §2; five axes inherited (not re-declared) — §1, §3
+- [ ] Tailwind `@theme` maps 1:1 / same CSS vars (SCSS) — §3.1
+- [ ] Body is `--font-body` normal-case; display font is non-reflex; mono = data — §6
+- [ ] One per-app accent from §4, used per persona's accent rule
+- [ ] Primitives per §5; four states still handled (UX-UI-GUIDELINES §5)
+- [ ] WCAG AA verified both themes; accent fill + text/bg ratios stated — §6
+- [ ] `DESIGN.md` in the repo names its persona + accent and links this system
 
 ---
 
-## 7. Rollout
+## 8. Rollout
 
-- **Foundation:** this doc + `@chrysa/ui` token file & Tailwind preset (`chrysa-lib`).
-- **Re-skin:** all 17 GUI frontends adopt Neon Brutalist (campaign
-  `design_campaign_2026_06`), including the 3 already redesigned
-  (gaming-os, ai-aggregator, studioverse) which were shipped on a softer look.
-- Per-repo work tracked in DB Tâches under the campaign Epic.
+- **Foundation:** this doc + `templates/design-tokens.css` (shared frame + the four
+  persona blocks) + `@chrysa/ui` primitives reading the axis tokens.
+- **Migration:** per §2, one repo per session (rule 1+2). **Pilot: linkendin-resume
+  → Editorial** (worst current clash; proves a persona yields a visibly different,
+  better result than uniform brutalism). Then the Console batch (lightest deltas),
+  then Arcade (gaming-os/studioverse already close), then formalize Signal
+  (sport-intelligence-hub) and Arcade-map discordium.
+- Per-repo work tracked under the campaign Epic
+  (`37759293e35e81e1973ce30839822b79`), retitled from "Neon Brutalist re-skin".

--- a/docs/adr/0002-design-personas.md
+++ b/docs/adr/0002-design-personas.md
@@ -1,0 +1,80 @@
+# ADR 0002 — Design personas replace the single "Neon Brutalist" DNA
+
+- **Status:** Accepted
+- **Date:** 2026-06-12
+- **Context:** Design audit 2026-06 (`docs/audits/DESIGN-AUDIT-2026-06.md`),
+  supersedes the visual layer of ADR-less campaign `design_campaign_2026_06`
+  (Notion epic `37759293e35e81e1973ce30839822b79`)
+
+## Context
+
+The 2026-06 ecosystem re-skin adopted one aesthetic DNA — "Neon Brutalist" (radius
+0, 2px foreground-colored borders, hard offset shadows, Space Grotesk + JetBrains
+Mono, uppercase labels) — for all web frontends, with **only the accent hue varying
+per app**. 13 of 16 frontends shipped it on `main`.
+
+A portfolio review found this is the root of the reported identity / display /
+ergonomics problems:
+
+- **Identity:** accent-hue-only differentiation is too thin. A résumé
+  (`linkendin-resume`), a CI dashboard (`dev-nexus`), a doc generator (`doc-gen`)
+  and a CDN explorer were the same product in different highlighter colors. The two
+  apps with genuine identity — `sport-intelligence-hub` (bespoke F1 palette) and
+  `discordium` (4 themed skins) — achieved it by routing *around* the uniform system,
+  which is the clearest signal that the system was mis-specified.
+- **Display:** loud borders + hard shadows + acid fills are high-noise; acid-accent
+  fills are contrast-fragile (a white-on-yellow bug shipped and was patched
+  reactively).
+- **Ergonomics:** uppercase-mono body copy, radius 0, and press-translate as the
+  only affordance optimize "loud structure" over reading and discoverability —
+  actively wrong for content/personal genres.
+
+Brutalism is not bad; applying it to *every* genre is.
+
+## Decision
+
+1. **Keep the backbone.** The semantic token contract, per-app accent mechanism,
+   the WCAG 2.1 AA floor + four-states (`UX-UI-GUIDELINES.md`), the no-hardcoded-hex
+   discipline, and the primitive component contracts are retained unchanged.
+2. **Replace the single DNA with four personas** — **Console** (dev tools /
+   dashboards), **Arcade** (games; brutalism lives here), **Editorial** (personal /
+   portfolio / content), **Signal** (live data / sport). Each persona fixes five
+   axes: display+body+data typography, radius, depth, border weight, density, and
+   motion. **Identity = persona + accent**, never accent alone.
+3. **Tokenize the persona axes.** `templates/design-tokens.css` ships the shared
+   neutral frame + four `:root[data-persona="…"]` blocks. A repo adopts a persona
+   by setting `data-persona` on `<html>`; components inherit. No parallel skin.
+4. **Bake the audit's display/ergonomics fixes into binding rules** (DESIGN-SYSTEM
+   §6): body is `--font-body` in normal case (mono = data only); no reflex font as
+   the display/brand face (Inter allowed for body only); no gradient text/glow;
+   nested surfaces must differ ≥4% L or carry a shadow; every accent fill + text/bg
+   pair states an AA-verified ratio.
+5. **The §4 accent table is authoritative.** Accents are added/changed by PR to
+   DESIGN-SYSTEM.md, not ad hoc per repo (closes the azure/yellow drift).
+6. **Migrate one repo per session** (rule 1+2). **Pilot: `linkendin-resume` →
+   Editorial** — the worst current clash; it proves a persona produces a visibly
+   different, better result than uniform brutalism before the batch rolls.
+
+## Consequences
+
+- Apps in the same genre (most are Console) still feel related — intended. The fix
+  targets *cross-genre* sameness, not all similarity.
+- `sport-intelligence-hub` becomes the canonical **Signal** reference (formalize its
+  existing tokens; do not rebuild). `gaming-os`/`studioverse` are near-conformant
+  **Arcade** already (minimal migration). `discordium` keeps its 4 in-app themes,
+  mapping chrome to Arcade.
+- One new token axis set per persona (`--radius`, `--border-weight`, `--shadow`,
+  `--font-display`/`--font-body`/`--font-mono`, `--density`, `--motion`). `@chrysa/ui`
+  primitives must read these instead of hard-coding brutalist values.
+- The brutalist campaign's *merged* work is not reverted wholesale: Arcade apps keep
+  most of it; Console/Editorial/Signal apps relax it per the migration weights in §2.
+- The Notion epic is retitled from "Neon Brutalist re-skin" to "Design personas
+  migration"; per-app tasks are re-scoped to a target persona.
+
+## Alternatives considered
+
+- **Fix display/ergonomics bugs only, keep uniform brutalism.** Rejected: leaves the
+  identity root cause (one skin) intact.
+- **Fully bespoke design per app.** Rejected: maximizes identity but abandons shared
+  tooling, multiplies maintenance across 16 repos, and re-creates the pre-2026-06
+  divergence the system was built to solve.

--- a/docs/audits/DESIGN-AUDIT-2026-06.md
+++ b/docs/audits/DESIGN-AUDIT-2026-06.md
@@ -1,0 +1,107 @@
+# Design Audit — chrysa frontends (2026-06)
+
+> Portfolio-wide review triggered by the report that the apps have problems of
+> **identity, display, and ergonomics**. This audit establishes the factual base
+> for the pivot recorded in [ADR 0002](../adr/0002-design-personas.md) and the
+> rewritten [DESIGN-SYSTEM.md](../DESIGN-SYSTEM.md).
+>
+> **Method:** remote-first. Every row reflects the repo's **default branch
+> (`main`) on GitHub**, verified via `gh pr list --state merged` + reading the
+> token/theme file on `main` — *not* the local checkout (local working copies were
+> on stale feature branches showing a pre-campaign look, e.g. gaming-os on
+> `feat/in-app-bug-report` still rendered the old soft violet theme while `main`
+> is brutalist lime).
+>
+> **Visual capture deferred:** screenshots were not taken. The 13 brutalist apps
+> are uniform *by specification* (token spot-checks on `main` matched
+> DESIGN-SYSTEM.md §1 exactly), so the diagnosis is structural, not pixel-level.
+> Per-app screenshots belong to each app's own redesign session.
+
+## 1. The core finding
+
+The active **"Neon Brutalist" campaign re-skinned 13 of 16 frontends to one
+identical aesthetic** (radius 0, 2px foreground-colored borders, hard offset
+shadows, Space Grotesk + JetBrains Mono, uppercase labels). **The only thing that
+varies per app is the accent hue.** Accent-hue-only is too thin to carry identity:
+a résumé, a CI dashboard, a doc generator, and a CDN explorer are visually the
+same product in different highlighter colors.
+
+The two apps with the **strongest identity were never touched by the campaign** —
+`sport-intelligence-hub` (bespoke F1 surface ramp + per-team palette + live/finished
+states) and `discordium` (four themed cosmic skins). They prove the point: identity
+came from purpose-built design, and the uniform system would have *erased* it.
+
+So the complaint decomposes as:
+- **Identity** → 13 apps share one skin; accent-only differentiation. Plus genre
+  clashes (brutalism on a résumé).
+- **Display** → loud borders + hard shadows + acid fills = high visual noise;
+  acid-accent fills are contrast-fragile (a white-on-yellow bug already shipped and
+  was patched reactively in linkendin-resume). Two directions live simultaneously
+  (brutalist `main` vs soft stale branches) → inconsistent reality.
+- **Ergonomics** → uppercase-mono body copy, radius 0, press-translate as the only
+  affordance; optimized for "loud structure" over reading and discoverability.
+
+## 2. Truth table (verified on `main`)
+
+Score 0–3 (higher = better). **Id** = identity, **Di** = display, **Er** = ergonomics.
+
+| App | Stack | Look on `main` | Accent | Id | Di | Er | Note |
+|---|---|---|---|:--:|:--:|:--:|---|
+| gaming-os | React+Tailwind v4 | Brutalist (#148) | lime | 2 | 2 | 1 | brutalism partly fits arcade genre |
+| studioverse | React+Tailwind | Brutalist (#83) | lime | 2 | 2 | 1 | same skin as gaming-os |
+| ai-aggregator | React+SCSS | **Soft slop** (#159) | indigo/violet | 1 | 2 | 2 | Inter + #4f46e5/#7c3aed, soft radii — generic SaaS, not brutalist |
+| mirrador | React+Tailwind | Brutalist (#116) | orange | 1 | 2 | 1 | |
+| link-reader-bot | React+Tailwind | Brutalist (#79) | magenta | 1 | 2 | 1 | |
+| dev-nexus | React+plain CSS | Brutalist (#256) | cyan | 1 | 2 | 2 | density suits a dev dashboard |
+| devtool | React+Bootstrap | Brutalist (#93) | cyan | 1 | 2 | 2 | |
+| doc-gen | React+Tailwind | Brutalist (#145) | violet | 1 | 2 | 1 | content tool wearing structure-loud skin |
+| cdn-explorer | React+plain CSS | Brutalist (#82) | magenta | 1 | 2 | 2 | |
+| container-webview | React+SCSS | Brutalist (#161) | cyan | 1 | 2 | 2 | |
+| satisfactory-factory-manager | React+SCSS | Brutalist (#147) | orange | 2 | 2 | 1 | industrial orange partly fits the game |
+| audit-platform | React+plain CSS | Brutalist (#57) | azure | 1 | 2 | 2 | azure accent not in §3 table |
+| linkendin-resume | React+plain CSS | Brutalist (#201) | yellow | **0** | 1 | 1 | **worst genre clash: a résumé in acid-yellow radius-0 brutalism**; white-on-yellow contrast bug history |
+| chrysa-portfolio-viz | React | Brutalist (#130) | chrome | 1 | 2 | 2 | |
+| sport-intelligence-hub | React+Tailwind | **Bespoke F1** (untouched) | per-team | **3** | **3** | **3** | surface ramp 0–4, ink ramp, team colors, live/finished — best identity in the portfolio |
+| discordium | React | **4 themed skins** (deferred) | per-theme | 3 | 2 | 2 | Discorde/Ordre/Vide/Néon; real identity via themes |
+| my-resume | — | **no frontend** | — | — | — | — | docs/agent-config repo only; drop from the 17 → 16 real frontends |
+
+## 3. Cross-cutting defect catalog
+
+1. **Identity-by-accent-only** (root cause of "identité"). 13 apps, one skin, one
+   variable. Fix: a per-genre **persona layer** (ADR 0002).
+2. **Genre mismatch.** Brutalism applied to genres it fights — most acutely a
+   résumé (`linkendin-resume`) and content/landing surfaces. Fix: personas map app
+   genre → appropriate type/density/depth.
+3. **Reflex fonts in the soft holdout.** `ai-aggregator` ships **Inter** as its
+   face + indigo/violet — the textbook AI-slop look. Fix: persona-defined pairings,
+   Inter allowed for *body* only, never as the brand/display face.
+4. **Uppercase-mono body.** Mono + uppercase used beyond labels hurts reading speed.
+   Fix: body is always a readable sans/serif in normal case; mono reserved for data.
+5. **Contrast-fragile acid fills.** Acid accents as fills need per-app verification;
+   the white-on-yellow bug shipped because the rule wasn't enforced mechanically.
+   Fix: every accent fill + text/bg pair carries a stated, AA-verified ratio.
+6. **Two live directions at once.** `main` is brutalist; stale local branches and
+   the session primer still describe the soft look → the "display inconsistency" is
+   partly an artifact of nobody trusting a single source of truth. Fix: this audit +
+   the rewritten spec are the single truth; verify `main` before judging a repo.
+7. **Best identities bypassed the system.** `sport-intelligence-hub` and
+   `discordium` earned their identity *outside* the uniform DNA. A system that the
+   best work has to route around is mis-specified. Fix: the persona layer makes
+   purpose-built identity the default path, not the exception.
+8. **Undocumented accent drift.** `audit-platform` introduced an azure accent not in
+   DESIGN-SYSTEM.md §3; linkendin yellow likewise. Accents are being added ad hoc.
+   Fix: §3 accent table is authoritative; additions are PRs to it.
+
+## 4. What carries over vs. what changes
+
+**Keep (the backbone is sound):** the semantic token vocabulary, the per-app accent
+mechanism, the WCAG AA floor and four-states from `UX-UI-GUIDELINES.md`, the
+"tokens not hardcoded hex" discipline, the primitive component contracts.
+
+**Change:** replace the single "Neon Brutalist" aesthetic DNA with a **4-persona
+layer** (Console / Arcade / Editorial / Signal). Identity becomes **persona +
+accent**. See [DESIGN-SYSTEM.md](../DESIGN-SYSTEM.md) and
+[ADR 0002](../adr/0002-design-personas.md). Per-app migration is one repo per
+session (rule 1+2); `linkendin-resume` → Editorial is the recommended pilot because
+it is the worst current clash and proves the persona produces a visibly different,
+better result.

--- a/templates/design-tokens.css
+++ b/templates/design-tokens.css
@@ -1,13 +1,18 @@
 /*
- * chrysa Design System — "Neon Brutalist" token contract.
+ * chrysa Design System — token contract (Personas).
  * Spec: docs/DESIGN-SYSTEM.md
  *
- * Drop this into a frontend's global stylesheet. Override ONLY --accent
- * (and it propagates to --ring) with the app's hue from DESIGN-SYSTEM.md §3.
- * SCSS/Bootstrap repos: import as-is. Tailwind v4 repos: also add the
- * `@theme inline` block below so utilities are generated.
+ * Two layers:
+ *   1. Shared neutral frame  — same for every app (colors + a11y floor).
+ *   2. Persona block         — pick ONE; sets radius/border/depth/type/density/motion.
+ *
+ * Adopt by: (a) keeping the frame, (b) setting data-persona on <html>, (c) overriding
+ * ONLY --accent with the app's hue from DESIGN-SYSTEM.md §4.
+ * SCSS/Bootstrap repos: import as-is. Tailwind v4 repos: add the `@theme inline`
+ * block at the bottom so utilities are generated.
  */
 
+/* ---- 1. Shared neutral frame (all personas) ---- */
 :root {
   /* dark — canonical */
   --bg: #0e0e10;
@@ -15,17 +20,13 @@
   --surface-2: #242428;
   --fg: #fafafa;
   --muted: #a1a1aa;
-  --border: #fafafa;
-  --accent: #c8ff00; /* PER-APP OVERRIDE */
+  --border: #2e2e33;
+  --accent: #c8ff00; /* PER-APP OVERRIDE — §4 */
   --accent-ink: #0e0e10;
   --signal: #22c55e;
   --warning: #fbbf24;
   --danger: #ff4d4d;
   --ring: var(--accent);
-  --radius: 0px;
-  --shadow: 4px 4px 0 #000000;
-  --font-display: "Space Grotesk", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
 }
 
 :root.light {
@@ -34,13 +35,62 @@
   --surface-2: #f0f0f0;
   --fg: #0e0e10;
   --muted: #52525b;
-  --border: #0e0e10;
+  --border: #d4d4d8;
   --accent: #a3e000; /* PER-APP OVERRIDE (darker variant for fill contrast) */
   --accent-ink: #0e0e10;
   --signal: #15803d;
   --warning: #b45309;
   --danger: #dc2626;
-  --shadow: 4px 4px 0 #0e0e10;
+}
+
+/* ---- 2. Persona blocks — set <html data-persona="…">. Pick ONE. ---- */
+
+:root[data-persona="console"] {
+  --radius: 4px;
+  --border-weight: 1px;
+  --shadow: 0 1px 3px rgb(0 0 0 / 0.24), 0 1px 2px rgb(0 0 0 / 0.16);
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
+  --density: 2.25rem;
+  --motion: 120ms;
+}
+
+:root[data-persona="arcade"] {
+  --radius: 2px;
+  --border-weight: 2px;
+  --border: var(--fg); /* loud structural border (brutalism) */
+  --shadow: 4px 4px 0 #000000;
+  --font-display: "Chakra Petch", "Space Grotesk", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
+  --density: 2.5rem;
+  --motion: 100ms;
+}
+:root.light[data-persona="arcade"] {
+  --shadow: 4px 4px 0 var(--fg);
+}
+
+:root[data-persona="editorial"] {
+  --radius: 10px;
+  --border-weight: 1px;
+  --shadow: 0 4px 24px rgb(0 0 0 / 0.18);
+  --font-display: "Fraunces", "Newsreader", Georgia, serif;
+  --font-body: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
+  --density: 2.75rem;
+  --motion: 220ms;
+}
+
+:root[data-persona="signal"] {
+  --radius: 6px;
+  --border-weight: 1px;
+  --shadow: 0 2px 8px rgb(0 0 0 / 0.28);
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
+  --density: 2.25rem;
+  --motion: 140ms;
 }
 
 /* --- Tailwind v4 only: generate semantic utilities (bg-surface, text-fg, …) ---
@@ -59,8 +109,9 @@
   --color-danger: var(--danger);
   --color-ring: var(--ring);
   --radius-card: var(--radius);
-  --shadow-brutal: var(--shadow);
+  --shadow-card: var(--shadow);
   --font-display: var(--font-display);
+  --font-body: var(--font-body);
   --font-mono: var(--font-mono);
 }
 */


### PR DESCRIPTION
## Why

A portfolio design audit (triggered by a report of identity / display / ergonomics problems across the apps) found the root cause is the current design system itself: the **Neon Brutalist** campaign re-skinned **13 of 16 frontends to one identical aesthetic**, varying only the accent hue. Accent-hue-only is too thin to carry identity — a résumé, a CI dashboard, and a CDN explorer became the same product in different highlighter colors. The two apps with genuine identity (`sport-intelligence-hub`, `discordium`) achieved it by routing *around* the system.

Full diagnosis + scorecards: `docs/audits/DESIGN-AUDIT-2026-06.md` (verified against each repo's `main`, not local checkouts).

## What changes

Pivot to a **persona layer** — `Console` (dev tools/dashboards), `Arcade` (games; brutalism lives here), `Editorial` (personal/portfolio), `Signal` (live data/sport). **Identity = persona + accent**, never accent alone.

- **Keeps the backbone:** semantic token contract, per-app accent, WCAG AA floor + four-states, primitive contracts.
- **`docs/DESIGN-SYSTEM.md`** — rewritten: persona table, app→persona map, per-app migration weights.
- **`templates/design-tokens.css`** — shared neutral frame + four `:root[data-persona]` blocks (radius / border / depth / type pairing / density / motion).
- **`docs/adr/0002-design-personas.md`** — decision + alternatives considered.
- Display/ergonomics fixes are now **binding rules** (§6): no reflex display font, Inter for body only, no gradient text, body never uppercase-mono, enforced surface separation + accent contrast.

## Rollout (not in this PR)

One repo per session (rule 1+2). **Pilot = `linkendin-resume` → Editorial** (worst current clash). Arcade apps (gaming-os/studioverse) are already near-conformant; `sport-intelligence-hub` becomes the canonical Signal reference (formalize, don't rebuild). Brutalist merged work is **not** reverted wholesale.

⚠️ **Parallel worker:** halt brutalist re-skin pushes — that direction is superseded by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)