### PR TITLE
docs(standards): persona is the surface, the layout serves the project

### DIFF
--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -58,6 +58,29 @@ fits. The other three genres get type/density/depth tuned to how they're read.
 Persona rules are **RULE** (binding); deviations need a documented reason in
 `<repo>/DECISIONS.md`.
 
+### 1.1 Persona is the surface — the layout serves the project
+
+A persona governs the **surface only**: typography, density, radius, depth, motion,
+and accent. It deliberately makes same-genre apps *feel related*. It does **not**
+prescribe a layout. Eleven apps share the Console persona; that is correct — and it
+is also why surface conformance alone is not done.
+
+> **RULE** Persona ≠ interface. Each app's **information architecture** — its primary
+> view, the object it puts at the center, the primary action, and the right density —
+> is **designed for that app's job**, not inherited. Same-genre apps share the token
+> contract; **they never share the layout.** A log-proxy inspector, a content feed and
+> a tree browser are all Console, and must not be the same screen in three accents.
+
+> **RULE** "Stat-cards on top + one flat table" is **not** a default. Reaching for it
+> without a reason is the smell this rule exists to catch. The right primary view comes
+> from the app's job-to-be-done (`mirrador` → a request inspector; a reader → a reading
+> column; a browser → a tree/detail split).
+
+The IA layer lives in `docs/UX-UI-GUIDELINES.md` (§1 core principles, §3 layout) and
+is captured per repo as a short **IA brief** in `<repo>/DESIGN.md` (§7). Surface
+migration (the persona token sweep) and the IA pass are **two distinct steps**: a repo
+is not done when it merely wears the right tokens.
+
 ---
 
 ## 2. App → persona map
@@ -287,6 +310,8 @@ A frontend conforms when:
 - [ ] One per-app accent from §4, used per persona's accent rule
 - [ ] Primitives per §5; four states still handled (UX-UI-GUIDELINES §5)
 - [ ] WCAG AA verified both themes; accent fill + text/bg ratios stated — §6
+- [ ] **IA brief in `DESIGN.md`** — names the job-to-be-done, the primary view, and the
+      primary action; the layout serves the job, not a generic stat-cards + table shell — §1.1
 - [ ] `DESIGN.md` in the repo names its persona + accent and links this system
 
 ---

--- a/docs/UX-UI-GUIDELINES.md
+++ b/docs/UX-UI-GUIDELINES.md
@@ -10,8 +10,10 @@
 >
 > Companion skill module: `.claude/skills/ui-ux/SKILL.md` (auto-invoked when building any UI/UX).
 > Audit of adoption per project: `docs/UX-UI-SKILLS-AUDIT.md`.
-> **Visual layer (the *look*): `docs/DESIGN-SYSTEM.md`** — the "Neon Brutalist" token
-> contract + aesthetic DNA all web frontends adopt. This file owns ergonomics; that one owns visuals.
+> **Visual layer (the *look*): `docs/DESIGN-SYSTEM.md`** — the four-persona token
+> contract (Console / Arcade / Editorial / Signal) + per-app accent all web frontends adopt.
+> That file owns the **surface**; this file owns **ergonomics and information architecture**.
+> Persona ≠ interface: the persona is shared, the layout is designed per app (§3.0, DESIGN-SYSTEM §1.1).
 
 ---
 
@@ -119,6 +121,24 @@ Use shadcn/ui's semantic CSS-variable convention. Components reference roles, ne
 ---
 
 ## 3. Layout & responsive
+
+### 3.0 Information architecture — the layout serves the project
+
+The persona (DESIGN-SYSTEM §1.1) sets the surface; **the layout is designed for what the
+app does.** Same-genre apps (e.g. the eleven Console apps) share tokens, never the screen.
+
+- **RULE** Before building, write a one-paragraph **IA brief** in `<repo>/DESIGN.md`:
+  - **Job-to-be-done** — what the user came to do (one sentence).
+  - **Primary object** — the thing the screen is *about* (a request, an article, a file tree…).
+  - **Primary view** — the layout that puts that object at the center (inspector, reading
+    column, tree+detail, board…), derived from the job — not a default.
+  - **Primary action** — the one action the view optimizes for (§1.2: one primary action per view).
+  - **Density** — chosen for the data (scannable log vs. comfortable reading), within the persona.
+- **RULE** "Stat-cards row + one flat table" is **not** a default layout. Use it only when the
+  job genuinely is a metrics overview; otherwise it is the smell this rule catches.
+- **PREFER** a layout metaphor the domain already owns (a proxy → a network/request inspector;
+  a content aggregator → a feed/reader; a CDN browser → a file tree). Distinctiveness should
+  come from *serving the job*, not from decoration.
 
 - **RULE** Mobile-first. Design the 360px viewport first, enhance upward with `sm md lg xl 2xl`.
 - **RULE** No horizontal scroll at any breakpoint ≥ 320px.


### PR DESCRIPTION
## Why

The 4-persona system ([#101]) fixed *cross-genre* uniformity but left *same-genre* apps looking identical: **11 of 16 frontends are Console**, and the campaign migrated tokens only — producing near-identical Console shells (stat-cards + flat table). User directive (2026-06-12):

> *"Les interfaces doivent être ergonomiques et lisibles. Je ne veux pas la même interface sur toutes les apps. Le design doit servir le projet."*

## What

Codifies **persona = surface, IA = per-app** as a binding, checkable rule.

- **DESIGN-SYSTEM.md §1.1** — new RULE: persona ≠ interface. Each app's information architecture (primary view / object / action / density) is designed for its job; same-genre apps share tokens, **never** the layout. "Stat-cards + flat table" is explicitly not a default.
- **DESIGN-SYSTEM.md §7** — adoption checklist gains an IA-brief item.
- **UX-UI-GUIDELINES.md §3.0** — new IA section with the per-app IA-brief rubric.
- **UX-UI-GUIDELINES.md header** — fixes a stale "Neon Brutalist" reference to the four-persona contract; clarifies surface (DESIGN-SYSTEM) vs IA (this file).

## Pilot

mirrador → request-inspector master/detail layout. **Gated on its surface PR #133** (Console tokens) merging first to avoid colliding with the persona-migration track. Plan: per-app IA pass rolls across the remaining Console repos one per session after the pilot proves out.

Draft — doctrine review before the mirrador pilot lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)