### PR TITLE
docs(standard): mandate base-makefile + react-app-generator as canonical scaffolding sources

### DIFF
--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -1,15 +1,41 @@
 # Chrysa — Execution Standard
 
-**Version 1.6 — 2026-06-12**
+**Version 1.6 — 2026-06-13**
 
 This document defines the **mandatory execution conventions** for every chrysa project.
 All repos scaffolded with `project-init` must comply. Deviations require a documented ADR.
 
 ---
 
+## 0. Canonical Scaffolding Sources (Mandatory)
+
+Every **active** chrysa project derives its build tooling and frontend from two
+canonical generators in the `Forge-Stack-Workshop` org. Projects **extend** these
+sources — they never fork them or hand-roll an equivalent.
+
+| Concern | Canonical source | Applies to | Detail |
+|---|---|---|---|
+| Makefile contract | [`Forge-Stack-Workshop/base-makefile`](https://github.com/Forge-Stack-Workshop/base-makefile) | every repo (all tiers) | §1.6 |
+| React / Vite frontend | [`Forge-Stack-Workshop/react-app-generator`](https://github.com/Forge-Stack-Workshop/react-app-generator) | `fullstack` repos + standalone web apps | `copilot-instructions/react19.md` |
+
+- **base-makefile** owns the §1 Makefile contract; every repo's `Makefile` is generated
+  from the matching tiered template — see §1.6 for template selection, tooling, and the
+  pinned baseline release.
+- **react-app-generator** scaffolds every React 19 + Vite frontend with the
+  non-negotiable baseline already wired (i18n FR+EN, dark mode, WCAG 2.1 AA). New
+  frontends are produced by the generator, never copied from a sibling repo or
+  bootstrapped with `create-react-app` / bare `vite`.
+
+Conformance is checked by `makefile-check` (chrysa/pre-commit-tools) for the Makefile
+contract; frontend origin is asserted at scaffold time by `project-init`. Deviations from
+either source require a documented ADR.
+
+---
+
 ## 1. Makefile Required Targets
 
-Every chrysa project **must** expose a uniform Makefile contract. Target **names are
+Every chrysa project **must** expose a uniform Makefile contract, generated from the
+canonical `Forge-Stack-Workshop/base-makefile` templates (see §0). Target **names are
 invariant** (no `fmt`/`type-check`/`tests` variants — see §1.4). The required set is
 **tiered by repo archetype**: a small core that every repo has, plus additions per tier.
 

--- a/copilot-instructions/base.md
+++ b/copilot-instructions/base.md
@@ -51,6 +51,11 @@ Your role is to write clean, maintainable, idiomatic, and secure code.
 - Pin image versions explicitly (e.g. `python:3.14-slim`, not `python:latest`).
 - Non-root user in the final stage (`USER nonroot` or equivalent).
 
+### Build / Makefile
+- **Canonical source: `Forge-Stack-Workshop/base-makefile`** — every repo's `Makefile` is generated from its tiered templates (`Makefile.basic` / `Makefile.python` / `Makefile.with-sub-folder`). Extend with project-specific targets; never fork the contract or hand-roll equivalents.
+- Target names are invariant (`install`, `lint`, `format`, `test`, `build`, `clean`, `pre-commit`, …). No `fmt`/`tests`/`type-check` variants.
+- Declare the tier on line 1: `# makefile-tier: lib | python-app | fullstack | infra`.
+
 ## Architecture
 
 ### Backoffice


### PR DESCRIPTION
## What

Formalizes both `Forge-Stack-Workshop` generators as the **mandatory canonical scaffolding sources** for every active chrysa project.

- **EXECUTION_STANDARD.md** — new **§0 Canonical Scaffolding Sources** declaring `base-makefile` (Makefile contract, all tiers) and `react-app-generator` (React/Vite frontends) authoritative. Cross-refs §1.6 (makefile detail, already present) and `react19.md` (frontend). §1 intro now points at §0.
- **copilot-instructions/base.md** — new `### Build / Makefile` block mandating derivation from `base-makefile` with invariant target names + tier marker.

## Why

Until now the makefile mandate lived in §1.6 and the frontend mandate only in `react19.md`. §0 puts both canonical sources at the same authority level in one place, so 'all active projects depend on base-makefile + react-app-generator' is stated once, unambiguously.

## Scope

Docs/standards only. No code, no tooling change. Enforcement unchanged (`makefile-check` + `project-init` scaffold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)