### PR TITLE
docs(standard): add fastapi-app-generator as canonical FastAPI backend scaffolder

### DIFF
--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -17,6 +17,7 @@ sources — they never fork them or hand-roll an equivalent.
 |---|---|---|---|
 | Makefile contract | [`Forge-Stack-Workshop/base-makefile`](https://github.com/Forge-Stack-Workshop/base-makefile) | every repo (all tiers) | §1.6 |
 | React / Vite frontend | [`Forge-Stack-Workshop/react-app-generator`](https://github.com/Forge-Stack-Workshop/react-app-generator) | `fullstack` repos + standalone web apps | `copilot-instructions/react19.md` |
+| FastAPI backend modules | [`Forge-Stack-Workshop/fastapi-app-generator`](https://github.com/Forge-Stack-Workshop/fastapi-app-generator) | FastAPI services | `copilot-instructions/fastapi.md` |
 
 - **base-makefile** owns the §1 Makefile contract; every repo's `Makefile` is generated
   from the matching tiered template — see §1.6 for template selection, tooling, and the
@@ -25,6 +26,10 @@ sources — they never fork them or hand-roll an equivalent.
   non-negotiable baseline already wired (i18n FR+EN, dark mode, WCAG 2.1 AA). New
   frontends are produced by the generator, never copied from a sibling repo or
   bootstrapped with `create-react-app` / bare `vite`.
+- **fastapi-app-generator** scaffolds FastAPI modules (router / schemas / models /
+  service / dependencies + Alembic stub) from a YAML spec via its `fastapi-app-generator`
+  CLI. New backend modules are generated from a spec, not hand-copied from a sibling
+  service. (Sibling of the Django-side `chrysa/django-app-forge`.)
 
 Conformance is checked by `makefile-check` (chrysa/pre-commit-tools) for the Makefile
 contract; frontend origin is asserted at scaffold time by `project-init`. Deviations from

--- a/copilot-instructions/fastapi.md
+++ b/copilot-instructions/fastapi.md
@@ -4,6 +4,13 @@
 
 Extends [base.md](base.md). Read base rules first; rules here take precedence where they conflict.
 
+## Scaffolding
+
+New FastAPI modules (router / schemas / models / service / dependencies + Alembic stub)
+**must** be generated from a YAML spec with `Forge-Stack-Workshop/fastapi-app-generator`
+(`fastapi-app-generator` CLI). Never hand-copy a module from a sibling service or
+hand-roll the boilerplate. Keep generated modules consistent with the layout below.
+
 ## Project layout
 
 ```


### PR DESCRIPTION
Follow-up to #105. Completes §0 Canonical Scaffolding Sources: alongside `base-makefile` (makefile) and `react-app-generator` (frontend), declares [`Forge-Stack-Workshop/fastapi-app-generator`](https://github.com/Forge-Stack-Workshop/fastapi-app-generator) the canonical source for FastAPI backend modules (router/schemas/models/service/deps + Alembic stub from a YAML spec).

- EXECUTION_STANDARD §0: new table row + bullet.
- `copilot-instructions/fastapi.md`: new **Scaffolding** section mirroring react19.md's Bootstrap mandate.

The generator repo was relocated chrysa → Forge-Stack-Workshop and renamed (fastapi-app-forge → fastapi-app-generator) to sit beside its sibling generators; main is standards-compliant (lib tier, 95 tests @96.9%).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)