### PR TITLE
ci: pin gregsdennis/dependencies-action to @v1.4.1

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,7 +16,7 @@ jobs:
 
         steps:
             - name: Check dependencies
-              uses: gregsdennis/dependencies-action@main
+              uses: gregsdennis/dependencies-action@v1.4.1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Pins third-party `gregsdennis/dependencies-action` from `@main` to release tag `@v1.4.1`. Completes the Pin GitHub Actions item of the Standards compliance backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)