### PR TITLE
chore(compliance): refresh makefile-conformance ledger (2026-06-19)

### DIFF
--- a/compliance/makefile-conformance.json
+++ b/compliance/makefile-conformance.json
@@ -12,33 +12,33 @@
     },
     {
       "ci_runs_precommit": true,
-      "gate": "FAIL",
+      "gate": "warn",
       "has_makefile": true,
-      "hook_wired": false,
+      "hook_wired": true,
       "repo": "ai-aggregator",
       "template": "Makefile.with-sub-folder",
       "tier": "fullstack",
-      "tier_marker": false
+      "tier_marker": true
+    },
+    {
+      "ci_runs_precommit": true,
+      "gate": "warn",
+      "has_makefile": true,
+      "hook_wired": true,
+      "repo": "audit-platform",
+      "template": "Makefile.python",
+      "tier": "lib",
+      "tier_marker": true
     },
     {
       "ci_runs_precommit": true,
       "gate": "FAIL",
       "has_makefile": true,
       "hook_wired": false,
-      "repo": "audit-platform",
-      "template": "Makefile.python",
-      "tier": "lib",
-      "tier_marker": false
-    },
-    {
-      "ci_runs_precommit": true,
-      "gate": "ok",
-      "has_makefile": true,
-      "hook_wired": true,
       "repo": "automations",
       "template": "Makefile.basic",
       "tier": "lib",
-      "tier_marker": true
+      "tier_marker": false
     },
     {
       "ci_runs_precommit": true,
@@ -72,7 +72,7 @@
     },
     {
       "ci_runs_precommit": true,
-      "gate": "warn",
+      "gate": "FAIL",
       "has_makefile": true,
       "hook_wired": true,
       "repo": "chrysa-portfolio-viz",
@@ -134,7 +134,7 @@
       "ci_runs_precommit": true,
       "gate": "FAIL",
       "has_makefile": true,
-      "hook_wired": false,
+      "hook_wired": true,
       "repo": "dev-nexus",
       "template": "Makefile.with-sub-folder",
       "tier": "fullstack",
@@ -192,19 +192,19 @@
     },
     {
       "ci_runs_precommit": true,
-      "gate": "-",
-      "has_makefile": false,
+      "gate": "warn",
+      "has_makefile": true,
       "hook_wired": false,
       "repo": "django-autoload",
       "template": "Makefile.python",
       "tier": "lib",
-      "tier_marker": false
+      "tier_marker": true
     },
     {
       "ci_runs_precommit": true,
       "gate": "ok",
       "has_makefile": true,
-      "hook_wired": false,
+      "hook_wired": true,
       "repo": "django-pytest",
       "template": "Makefile.python",
       "tier": "lib",
@@ -254,7 +254,7 @@
       "ci_runs_precommit": true,
       "gate": "ok",
       "has_makefile": true,
-      "hook_wired": false,
+      "hook_wired": true,
       "repo": "feedback-gateway",
       "template": "Makefile.python",
       "tier": "lib",
@@ -297,7 +297,7 @@
       "hook_wired": true,
       "repo": "genealogy-validator",
       "template": "Makefile.python",
-      "tier": "lib",
+      "tier": "python-app",
       "tier_marker": true
     },
     {
@@ -364,7 +364,7 @@
       "ci_runs_precommit": true,
       "gate": "warn",
       "has_makefile": true,
-      "hook_wired": true,
+      "hook_wired": false,
       "repo": "mediavault",
       "template": "Makefile.with-sub-folder",
       "tier": "fullstack",
@@ -382,33 +382,33 @@
     },
     {
       "ci_runs_precommit": true,
-      "gate": "ok",
+      "gate": "FAIL",
       "has_makefile": true,
-      "hook_wired": true,
+      "hook_wired": false,
       "repo": "my-resume",
       "template": "Makefile.basic",
       "tier": "infra",
-      "tier_marker": true
+      "tier_marker": false
     },
     {
       "ci_runs_precommit": true,
-      "gate": "warn",
+      "gate": "FAIL",
       "has_makefile": true,
-      "hook_wired": true,
+      "hook_wired": false,
       "repo": "orchestrator",
       "template": "Makefile.basic",
       "tier": "infra",
-      "tier_marker": true
+      "tier_marker": false
     },
     {
       "ci_runs_precommit": true,
-      "gate": "warn",
+      "gate": "FAIL",
       "has_makefile": true,
-      "hook_wired": true,
+      "hook_wired": false,
       "repo": "paperclip",
       "template": "Makefile.basic",
       "tier": "infra",
-      "tier_marker": true
+      "tier_marker": false
     },
     {
       "ci_runs_precommit": true,
@@ -422,13 +422,13 @@
     },
     {
       "ci_runs_precommit": true,
-      "gate": "warn",
+      "gate": "FAIL",
       "has_makefile": true,
-      "hook_wired": true,
+      "hook_wired": false,
       "repo": "pre-commit-hooks-changelog",
       "template": "Makefile.python",
       "tier": "python-app",
-      "tier_marker": true
+      "tier_marker": false
     },
     {
       "ci_runs_precommit": true,
@@ -452,13 +452,13 @@
     },
     {
       "ci_runs_precommit": true,
-      "gate": "ok",
+      "gate": "FAIL",
       "has_makefile": true,
-      "hook_wired": true,
+      "hook_wired": false,
       "repo": "quality-gatekeeper",
       "template": "Makefile.python",
       "tier": "lib",
-      "tier_marker": true
+      "tier_marker": false
     },
     {
       "ci_runs_precommit": true,


### PR DESCRIPTION
## What
Refreshes `compliance/makefile-conformance.json` from a fleet re-run of `audit-makefile-conformance.sh` (55 repos).

## Snapshot
- **12 GATE=FAIL**: automations, chrysa-lib, chrysa-portfolio-viz, dev-nexus, linkendin-resume, my-resume, orchestrator, paperclip, pre-commit-hooks-changelog, quality-gatekeeper, satisfactory-automated_calculator, server
- **6 missing tier marker** (automations, my-resume, orchestrator, paperclip, pre-commit-hooks-changelog, quality-gatekeeper)
- **2 extra hook-unwired**: django-autoload, mediavault

Read-only audit; only the canonical tracking ledger changes. Full drift report (incl. hygiene + quality-gate surfaces) logged to the chrysa backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)