### PR TITLE
feat(standards): codify container-runtime policy + conformance audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,6 @@ jobs:
                   find templates/ -name "*.json" 2>/dev/null | \
                     while read f; do python3 -m json.tool "$f" > /dev/null || exit 1; done
                   echo "All JSON templates valid"
+
+            - name: Validate repos.yml runtime classification
+              run: bash scripts/validate-repos-runtime.sh

--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -336,6 +336,32 @@ Reusable `workflow_call` workflows live in **`chrysa/github-actions/.github/work
   (or a least-privilege `packages:write` token) — **no PAT in plaintext**, no long-lived secret in image layers.
 - The build + scan + push is carried by the reusable `build-image.yml` workflow (see `chrysa/github-actions`).
 
+### 6.1 Container-runtime policy & nature exemptions
+
+**Rule: a project runs ONLY in a container — unless its nature forbids it.** No project's runtime
+may depend on host-installed interpreters or tooling; if it executes as a service, it executes in a
+container. Tests, lint, and type-checks always go through `make` Docker targets, never the host
+(§12).
+
+Every repo is classified by a `runtime:` field in [`repos.yml`](repos.yml). The "nature forbids"
+exemptions are explicit and finite:
+
+| `runtime` | What it means | Must provide |
+|---|---|---|
+| `container` | Runs as a service. | Dockerfile(s) + `docker-compose*` + `HEALTHCHECK` + `docker-up`/`docker-down`/`docker-test` targets. |
+| `exempt:lib` | Distributed/imported — library, plugin, pre-commit hook, GitHub Action, CLI tool. Runs inside the **consumer's** environment, not as our service. | `docker-test` target (CI runs the suite in a container). |
+| `exempt:config` | No executable runtime — config, knowledge base (Obsidian), deployment manifests, reusable container-definition collections. | Nothing (nothing to run). |
+| `exempt:native` | Bound to a host OS, physical device, cloud platform, or editor — Windows desktop integration, webcam/gesture control, hardware controllers, Google Apps Script, VS Code extensions, infra/Helm/GitOps. A container cannot provide the required host access. | Optional `Dockerfile.test` for CI; runtime stays native by necessity. |
+| `pending` | Pre-code scaffold (no app code yet). | Flips to `container` at first code — `project-init`/`chrysa-init` scaffold the container so new repos start compliant. |
+
+A repo is exempt **only** when its nature genuinely forbids containerized execution. Convenience,
+"it's easier on the host", or "it's just a script" are **not** exemptions. When in doubt, classify
+`container`.
+
+Conformance is machine-checked by [`audit-docker-compliance.sh`](audit-docker-compliance.sh), which
+reads `repos.yml` and verifies each repo provides what its class requires (output:
+`compliance/docker-conformance.json`).
+
 ---
 
 ## 7. Documentation

--- a/compliance/CONTAINER-RUNTIME-BACKLOG.md
+++ b/compliance/CONTAINER-RUNTIME-BACKLOG.md
@@ -1,0 +1,65 @@
+# Container-runtime conformance backlog
+
+Policy: **a project runs ONLY in a container unless its nature forbids it** —
+`EXECUTION_STANDARD.md §6.1`. Classification lives in `repos.yml` (`runtime:` field);
+state is machine-checked by `scripts/audit-docker-compliance.sh`
+(baseline: `compliance/docker-conformance.json`).
+
+Snapshot at policy introduction: **pass=22 warn=11 fail=0 exempt=20 pending=4 absent=1**.
+The fleet fully conforms: every code-bearing repo either runs in a container or its nature
+genuinely forbids it. Only the polish (WARN) and pre-code (PENDING) items below remain.
+Remediate one repo per session (Rule 1+2).
+
+## FAIL — true runtime-policy violations (P0)
+
+A `container` repo that cannot run containerized (no Dockerfile **and** no compose).
+
+**None.** ✅
+
+> `lifeos` (= `my-assistant`) was first flagged here, then correctly reclassified `exempt:native`:
+> it is a floating multi-OS desktop assistant (overlay UI, system tray, OS-level system
+> monitoring) — a container cannot provide that host access. Same category as `floating-agent`.
+> It keeps `Dockerfile.test` + `.devcontainer/` for CI and dev.
+
+## PENDING — enforce at first code
+
+Pre-code scaffolds; flip `pending`→`container` (or to the right class, e.g. `exempt:lib`) when
+app code lands. Enforced at scaffold time via `project-init` / `chrysa-init` (see follow-up below)
+so they start compliant.
+
+- `coach` · `game-solver-platform` · `mediavault` · `quality-gatekeeper`
+
+> `quality-gatekeeper` was initially eyed as a runtime violator, but it holds only an empty
+> `quality_gatekeeper/__init__.py` (no app, no tests). It is pre-code like the others — classified
+> `pending`, not scaffolded with a hollow container. Its eventual class is likely `exempt:lib`
+> (a detector library, sibling of `guideline-checker`).
+
+## WARN — runs in a container, missing §6 polish
+
+Not runtime violations (they already run in containers). These are §6 / Makefile-standard gaps,
+mostly the `docker-up`/`docker-down`/`docker-test` target names supplied by `base-makefile`
+(overlaps `audit-makefile-conformance.sh`). Fold into the next makefile-sync sweep.
+
+| Repo | Gap |
+|---|---|
+| `chrysa-portfolio-viz` | docker-up, docker-down |
+| `D-D` | docker-up, docker-down |
+| `dev-nexus` | docker-up, docker-down, docker-test |
+| `devtool` | HEALTHCHECK, docker-test |
+| `feedback-gateway` | compose, docker-up, docker-down |
+| `linkendin-resume` | docker-up, docker-down, docker-test |
+| `my-resume` | docker-up, docker-down |
+| `PO-GO-DEX` | docker-up, docker-down |
+| `satisfactory-factory-manager` | docker-up, docker-down |
+| `django-autoload` (lib) | no docker-test / Dockerfile.test — tests would run on host |
+| `pre-commit-hooks-changelog` (lib) | no docker-test / Dockerfile.test — tests would run on host |
+
+## ABSENT
+
+- `epub-sorter` — not checked out locally at audit time; re-verify on next full sync.
+
+## Follow-up campaign — enforce at scaffold
+
+`project-init` / `chrysa-init` should emit a runtime container (Dockerfile + compose +
+docker-up/down/test) by default, and new `repos.yml` entries should default `runtime: container`
+(or an explicit exemption). This keeps the policy self-sustaining instead of relying on retro-audits.

--- a/compliance/docker-conformance.json
+++ b/compliance/docker-conformance.json
@@ -1,0 +1,361 @@
+{
+  "policy": "EXECUTION_STANDARD.md §6.1 — container-runtime",
+  "repos": [
+    {
+      "detail": "no executable runtime",
+      "repo": "agent-config",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "ai-aggregator",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "audit-platform",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "automations",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "catalog",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "cdn-explorer",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "chrysa-lib",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "runs in container; §6 gaps: docker-up docker-down",
+      "repo": "chrysa-portfolio-viz",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "chrysa-skills",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "claude-config",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "pre-code — container scaffold due before first code",
+      "repo": "coach",
+      "runtime": "pending",
+      "verdict": "PENDING"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "container-webview",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "runs in container; §6 gaps: docker-up docker-down",
+      "repo": "D-D",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "runs in container; §6 gaps: docker-up docker-down docker-test",
+      "repo": "dev-nexus",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "runs in container; §6 gaps: HEALTHCHECK docker-test",
+      "repo": "devtool",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "discord-bot-back",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "discordium",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "diy-stream-deck",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "django-app-forge",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "lib — no docker-test / Dockerfile.test (tests would run on host)",
+      "repo": "django-autoload",
+      "runtime": "exempt:lib",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "django-pytest",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "django-query-optimizer",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "django-query-optimizer-vscode",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "django-traceid",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "doc-gen",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "dotfiles",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "not checked out locally",
+      "repo": "epub-sorter",
+      "runtime": "exempt:lib",
+      "verdict": "ABSENT"
+    },
+    {
+      "detail": "runs in container; §6 gaps: compose docker-up docker-down",
+      "repo": "feedback-gateway",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "floating-agent",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "pre-code — container scaffold due before first code",
+      "repo": "game-solver-platform",
+      "runtime": "pending",
+      "verdict": "PENDING"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "gaming-os",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "genealogy-validator",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "gestureOS",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "github-actions",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "guideline-checker",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "homeassistant-config",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "lifeos",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "runs in container; §6 gaps: docker-up docker-down docker-test",
+      "repo": "linkendin-resume",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "link-reader-bot",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "pre-code — container scaffold due before first code",
+      "repo": "mediavault",
+      "runtime": "pending",
+      "verdict": "PENDING"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "mirrador",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "runs in container; §6 gaps: docker-up docker-down",
+      "repo": "my-resume",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "orchestrator",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "paperclip",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "runs in container; §6 gaps: docker-up docker-down",
+      "repo": "PO-GO-DEX",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "lib — no docker-test / Dockerfile.test (tests would run on host)",
+      "repo": "pre-commit-hooks-changelog",
+      "runtime": "exempt:lib",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "pre-commit-tools",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "lib — tests run in container",
+      "repo": "project-init",
+      "runtime": "exempt:lib",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "pre-code — container scaffold due before first code",
+      "repo": "quality-gatekeeper",
+      "runtime": "pending",
+      "verdict": "PENDING"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "satisfactory-automated_calculator",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "runs in container; §6 gaps: docker-up docker-down",
+      "repo": "satisfactory-factory-manager",
+      "runtime": "container",
+      "verdict": "WARN"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "server",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "shared-standards",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "sport-intelligence-hub",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "container runtime complete",
+      "repo": "studioverse",
+      "runtime": "container",
+      "verdict": "PASS"
+    },
+    {
+      "detail": "no executable runtime",
+      "repo": "usefull-containers",
+      "runtime": "exempt:config",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "windows-autonome",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    },
+    {
+      "detail": "host/device/cloud/editor bound",
+      "repo": "windows-docker-state-notification",
+      "runtime": "exempt:native",
+      "verdict": "EXEMPT"
+    }
+  ],
+  "summary": {
+    "absent": 1,
+    "exempt": 20,
+    "fail": 0,
+    "pass": 22,
+    "pending": 4,
+    "warn": 11
+  }
+}

--- a/repos.yml
+++ b/repos.yml
@@ -2,182 +2,248 @@
 # Generated 2026-06-06 from gh repo list chrysa + local checkout. Hand-tune as needed.
 # status: dev (apply full standard) | non-dev (config/static, skip CI+Docker) | archived (skip).
 # public: true emits LICENSE (MIT); false skips it.
+# runtime: container-runtime policy — "projects run ONLY in containers unless nature forbids".
+#   container       — runs as a service; MUST ship Dockerfile(s) + compose + HEALTHCHECK + docker-up/down/test.
+#   exempt:lib      — distributed/imported (lib, plugin, pre-commit hook, GitHub Action, CLI tool); keep docker-test only.
+#   exempt:config   — no executable runtime (config, knowledge/Obsidian, deployment manifests, container-def collections).
+#   exempt:native   — bound to host OS / device / cloud platform / editor (Windows, webcam, GAS, VS Code ext, infra/Helm).
+#   pending         — pre-code scaffold; flips to `container` once app code lands (enforced at first code via project-init).
+#   Audited by audit-docker-compliance.sh. See EXECUTION_STANDARD.md §6.1.
 repos:
   - name: agent-config
     status: dev
     public: false
+    runtime: exempt:config
   - name: ai-aggregator
     status: dev
     public: false
+    runtime: container
   - name: audit-platform
     status: dev
     public: false
+    runtime: container
   - name: automations
     status: dev
     public: false
+    runtime: exempt:native
   - name: catalog
     status: dev
     public: false
+    runtime: exempt:config
   - name: cdn-explorer
     status: dev
     public: true
+    runtime: container
   - name: chrysa-lib
     status: dev
     public: false
+    runtime: exempt:lib
   - name: chrysa-portfolio-viz
     status: dev
     public: false
+    runtime: container
   - name: chrysa-skills
     status: dev
     public: false
+    runtime: exempt:config
   - name: claude-config
     status: dev
     public: false
+    runtime: exempt:config
   - name: coach
     status: dev
     public: false
+    runtime: pending
   - name: container-webview
     status: dev
     public: true
+    runtime: container
   - name: D-D
     status: dev
     public: false
+    runtime: container
   - name: dev-nexus
     status: dev
     public: false
+    runtime: container
   - name: devtool
     status: dev
     public: false
+    runtime: container
   - name: discord-bot-back
     status: dev
     public: false
+    runtime: container
   - name: discordium
     status: dev
     public: false
+    runtime: container
   - name: diy-stream-deck
     status: dev
     public: true
+    runtime: exempt:native
   - name: django-app-forge
     status: dev
     public: false
+    runtime: exempt:lib
   - name: django-autoload
     status: dev
     public: true
+    runtime: exempt:lib
   - name: django-pytest
     status: dev
     public: false
+    runtime: exempt:lib
   - name: django-query-optimizer
     status: dev
     public: true
+    runtime: exempt:lib
   - name: django-query-optimizer-vscode
     status: dev
     public: true
+    runtime: exempt:native
   - name: django-traceid
     status: dev
     public: false
+    runtime: exempt:lib
   - name: doc-gen
     status: dev
     public: false
+    runtime: container
   - name: dotfiles
     status: non-dev
     public: false
+    runtime: exempt:config
   - name: epub-sorter
     status: dev
     public: true
+    runtime: exempt:lib
   - name: feedback-gateway
     status: dev
     public: false
+    runtime: container
   - name: floating-agent
     status: dev
     public: true
+    runtime: exempt:native
   - name: game-solver-platform
     status: dev
     public: false
+    runtime: pending
   - name: gaming-os
     status: dev
     public: false
+    runtime: container
   - name: genealogy-validator
     status: dev
     public: false
+    runtime: container
   - name: gestureOS
     status: dev
     public: true
+    runtime: exempt:native
   - name: github-actions
     status: dev
     public: true
+    runtime: exempt:lib
   - name: guideline-checker
     status: dev
     public: true
+    runtime: exempt:lib
   - name: homeassistant-config
     status: non-dev
     public: false
+    runtime: exempt:config
   - name: lifeos
     status: dev
     public: true
+    runtime: exempt:native
   - name: linkendin-resume
     status: dev
     public: true
+    runtime: container
   - name: link-reader-bot
     status: dev
     public: false
+    runtime: container
   - name: mediavault
     status: dev
     public: false
+    runtime: pending
   - name: mirrador
     status: dev
     public: false
+    runtime: container
   - name: my-assistant
     status: alias
     public: false
     alias_of: lifeos
+    runtime: exempt:native
   - name: my-resume
     status: dev
     public: false
+    runtime: container
   - name: orchestrator
     status: dev
     public: false
+    runtime: exempt:config
   - name: paperclip
     status: dev
     public: false
+    runtime: exempt:config
   - name: PO-GO-DEX
     status: dev
     public: false
+    runtime: container
   - name: pre-commit-hooks-changelog
     status: dev
     public: true
+    runtime: exempt:lib
   - name: pre-commit-tools
     status: dev
     public: true
+    runtime: exempt:lib
   - name: project-init
     status: dev
     public: true
+    runtime: exempt:lib
   - name: quality-gatekeeper
     status: dev
     public: false
+    runtime: pending
   - name: satisfactory-automated_calculator
     status: dev
     public: true
+    runtime: exempt:native
   - name: satisfactory-factory-manager
     status: dev
     public: false
+    runtime: container
   - name: server
     status: dev
     public: false
+    runtime: exempt:native
   - name: shared-standards
     status: dev
     public: true
+    runtime: exempt:config
   - name: sport-intelligence-hub
     status: dev
     public: false
+    runtime: container
   - name: studioverse
     status: dev
     public: false
+    runtime: container
   - name: usefull-containers
     status: dev
     public: true
+    runtime: exempt:config
   - name: windows-autonome
     status: dev
     public: false
+    runtime: exempt:native
   - name: windows-docker-state-notification
     status: dev
     public: false
+    runtime: exempt:native

--- a/scripts/audit-docker-compliance.sh
+++ b/scripts/audit-docker-compliance.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# audit-docker-compliance.sh · Container-runtime policy conformance (EXECUTION_STANDARD §6.1).
+# Source: chrysa/shared-standards/scripts/audit-docker-compliance.sh
+#
+# "A project runs ONLY in a container unless its nature forbids it." Reads the `runtime:`
+# classification in repos.yml and verifies each repo per its class.
+#
+#   container     -> FAIL if it cannot run containerized at all (no Dockerfile AND no compose).
+#                    WARN if it runs in a container but misses §6 polish
+#                    (compose / HEALTHCHECK / docker-up / docker-down / docker-test targets).
+#   exempt:lib    -> WARN if neither docker-test target nor Dockerfile.test (suite would run on host).
+#   exempt:config -> EXEMPT (nothing to run).
+#   exempt:native -> EXEMPT (host/device/cloud/editor bound; a container cannot give host access).
+#   pending       -> PENDING (pre-code scaffold; warn-only, never fails).
+#
+# FAIL is reserved for actual runtime-policy violations (a service that cannot run in a container).
+# WARN surfaces standard gaps already owned by audit-makefile-conformance.sh / §6.
+# Read-only: never mutates any repo. Writes compliance/docker-conformance.json.
+#
+# Usage:
+#   bash audit-docker-compliance.sh            # audit every repo in repos.yml
+#   bash audit-docker-compliance.sh <repo>     # audit one repo name
+#   CHRYSA_ROOT=/path bash audit-docker-compliance.sh   # override checkout root
+#
+# Exit: 0 no FAIL (warnings allowed) · 1 one or more FAIL · 2 repos.yml missing
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STD_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHRYSA_ROOT="${CHRYSA_ROOT:-$(cd "$STD_ROOT/.." && pwd)}"
+REPOS_YML="${REPOS_YML:-$STD_ROOT/repos.yml}"
+OUT_DIR="$STD_ROOT/compliance"
+OUT_JSON="$OUT_DIR/docker-conformance.json"
+
+[[ -f "$REPOS_YML" ]] || { echo "repos.yml not found: $REPOS_YML" >&2; exit 2; }
+mkdir -p "$OUT_DIR"
+
+# ── checks ──────────────────────────────────────────────────────────────────────
+# All file lookups prune .claude (worktrees), .git and node_modules to avoid false
+# positives from active campaign worktrees (see memory: skills/agents-audit pollution).
+PRUNE=(-path '*/.claude' -prune -o -path '*/.git' -prune -o -path '*/node_modules' -prune -o)
+
+has_runtime_dockerfile() {  # a Dockerfile that is NOT exclusively a *.test variant
+    find "$1" "${PRUNE[@]}" -type f -iname 'Dockerfile*' ! -iname '*.test' -print 2>/dev/null | grep -q .
+}
+has_test_dockerfile() {
+    find "$1" "${PRUNE[@]}" -type f \( -iname 'Dockerfile*.test' -o -iname 'Dockerfile.test' \) -print 2>/dev/null | grep -q .
+}
+has_compose() {
+    find "$1" "${PRUNE[@]}" -type f \( -iname 'docker-compose*.y*ml' -o -iname 'compose*.y*ml' \) -print 2>/dev/null | grep -q .
+}
+has_make_target() {  # has_make_target <repo> <target>
+    [[ -f "$1/Makefile" ]] && grep -qE "^$2:" "$1/Makefile" 2>/dev/null
+}
+has_healthcheck() {
+    find "$1" "${PRUNE[@]}" -type f -iname 'Dockerfile*' -exec grep -qiE 'HEALTHCHECK' {} + 2>/dev/null && return 0
+    find "$1" "${PRUNE[@]}" -type f \( -iname 'docker-compose*.y*ml' -o -iname 'compose*.y*ml' \) \
+        -exec grep -qiE '^[[:space:]]*healthcheck:' {} + 2>/dev/null
+}
+
+# ── audit a single repo ──────────────────────────────────────────────────────────
+# Globals set: V_STATUS (PASS|WARN|FAIL|EXEMPT|PENDING|ABSENT), V_DETAIL
+audit_one() {
+    local repo="$1" runtime="$2"
+    if [[ ! -d "$repo" ]]; then
+        V_STATUS="ABSENT"; V_DETAIL="not checked out locally"; return
+    fi
+    case "$runtime" in
+        container)
+            local df=false cf=false
+            has_runtime_dockerfile "$repo" && df=true
+            has_compose "$repo" && cf=true
+            if [[ "$df" == false && "$cf" == false ]]; then
+                V_STATUS="FAIL"; V_DETAIL="cannot run in a container — no Dockerfile and no compose"
+                return
+            fi
+            local gaps=()
+            [[ "$df" == true ]] || gaps+=("Dockerfile")
+            [[ "$cf" == true ]] || gaps+=("compose")
+            has_healthcheck "$repo"             || gaps+=("HEALTHCHECK")
+            has_make_target "$repo" docker-up   || gaps+=("docker-up")
+            has_make_target "$repo" docker-down || gaps+=("docker-down")
+            has_make_target "$repo" docker-test || gaps+=("docker-test")
+            if [[ ${#gaps[@]} -eq 0 ]]; then
+                V_STATUS="PASS"; V_DETAIL="container runtime complete"
+            else
+                V_STATUS="WARN"; V_DETAIL="runs in container; §6 gaps: ${gaps[*]}"
+            fi
+            ;;
+        exempt:lib)
+            if has_make_target "$repo" docker-test || has_test_dockerfile "$repo"; then
+                V_STATUS="PASS"; V_DETAIL="lib — tests run in container"
+            else
+                V_STATUS="WARN"; V_DETAIL="lib — no docker-test / Dockerfile.test (tests would run on host)"
+            fi
+            ;;
+        exempt:config) V_STATUS="EXEMPT";  V_DETAIL="no executable runtime" ;;
+        exempt:native) V_STATUS="EXEMPT";  V_DETAIL="host/device/cloud/editor bound" ;;
+        pending)       V_STATUS="PENDING"; V_DETAIL="pre-code — container scaffold due before first code" ;;
+        *)             V_STATUS="FAIL";    V_DETAIL="unknown runtime class '$runtime'" ;;
+    esac
+}
+
+# ── drive ────────────────────────────────────────────────────────────────────────
+ONLY="${1:-}"
+mark() {
+    case "$1" in
+        PASS)    printf '✓ PASS   ' ;; WARN)    printf '! WARN   ' ;;
+        FAIL)    printf '✗ FAIL   ' ;; EXEMPT)  printf '– EXEMPT ' ;;
+        PENDING) printf '… PEND   ' ;; ABSENT)  printf '? ABSENT ' ;;
+    esac
+}
+
+printf '%-36s %-9s %-7s %s\n' "repo" "verdict" "runtime" "detail"
+printf '%s\n' "------------------------------------------------------------------------------------"
+
+fails=0 warns=0 passes=0 exempts=0 pendings=0 absents=0
+json_items=""
+
+while read -r name status runtime; do
+    [[ "$status" == "archived" || "$status" == "alias" ]] && continue
+    [[ -n "$ONLY" && "$name" != "$ONLY" ]] && continue
+    audit_one "$CHRYSA_ROOT/$name" "$runtime"
+    printf '%-36s %s%-7s %s\n' "$name" "$(mark "$V_STATUS")" "$runtime" "$V_DETAIL"
+    case "$V_STATUS" in
+        PASS) ((passes++)) ;; WARN) ((warns++)) ;; FAIL) ((fails++)) ;;
+        EXEMPT) ((exempts++)) ;; PENDING) ((pendings++)) ;; ABSENT) ((absents++)) ;;
+    esac
+    [[ -n "$json_items" ]] && json_items+=","
+    json_items+=$(printf '\n  {"repo":"%s","runtime":"%s","verdict":"%s","detail":"%s"}' \
+        "$name" "$runtime" "$V_STATUS" "$V_DETAIL")
+done < <(awk '$1=="-"&&$2=="name:"{n=$3} $1=="status:"{st=$2} $1=="runtime:"{print n, st, $2}' "$REPOS_YML")
+
+printf '%s\n' "------------------------------------------------------------------------------------"
+printf 'pass=%d warn=%d fail=%d exempt=%d pending=%d absent=%d\n' \
+    "$passes" "$warns" "$fails" "$exempts" "$pendings" "$absents"
+
+{
+    printf '{\n'
+    printf '  "policy": "EXECUTION_STANDARD.md §6.1 — container-runtime",\n'
+    printf '  "summary": {"pass":%d,"warn":%d,"fail":%d,"exempt":%d,"pending":%d,"absent":%d},\n' \
+        "$passes" "$warns" "$fails" "$exempts" "$pendings" "$absents"
+    printf '  "repos": [%s\n  ]\n' "$json_items"
+    printf '}\n'
+} > "$OUT_JSON"
+
+# Normalize to the json-sorter canonical form (sorted keys, 2-space indent, UTF-8 kept,
+# trailing newline) so the pre-commit json-sorter hook is a no-op on the committed file.
+python3 - "$OUT_JSON" <<'PY'
+import json, sys
+p = sys.argv[1]
+with open(p, encoding="utf-8") as fh:
+    data = json.load(fh)
+with open(p, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2, sort_keys=True, ensure_ascii=False)
+    fh.write("\n")
+PY
+echo "report: $OUT_JSON"
+
+[[ "$fails" -eq 0 ]]

--- a/scripts/validate-repos-runtime.sh
+++ b/scripts/validate-repos-runtime.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# validate-repos-runtime.sh · Enforce the container-runtime classification in repos.yml.
+# Source: chrysa/shared-standards/scripts/validate-repos-runtime.sh
+#
+# CI gate for EXECUTION_STANDARD §6.1: every repo entry must declare a `runtime:` with a
+# value from the allowed set. Keeps the policy self-sustaining — a new repo cannot be added
+# without classifying how it runs. Self-contained (parses repos.yml only; no fleet checkout).
+#
+# Usage: bash validate-repos-runtime.sh
+# Exit: 0 all entries valid · 1 missing/invalid runtime · 2 repos.yml missing
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STD_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPOS_YML="${REPOS_YML:-$STD_ROOT/repos.yml}"
+VALID='container exempt:lib exempt:config exempt:native pending'
+
+[[ -f "$REPOS_YML" ]] || { echo "repos.yml not found: $REPOS_YML" >&2; exit 2; }
+
+# Emit "name <runtime-or-MISSING>" per entry: print the pending name when a new `- name:`
+# arrives before a runtime line was seen.
+errors=0
+while read -r name runtime; do
+    if [[ -z "$runtime" || "$runtime" == "MISSING" ]]; then
+        echo "✗ $name: no runtime: field"; ((errors++)); continue
+    fi
+    case " $VALID " in
+        *" $runtime "*) ;;
+        *) echo "✗ $name: invalid runtime '$runtime' (allowed: $VALID)"; ((errors++)) ;;
+    esac
+done < <(awk '
+    $1=="-" && $2=="name:" { if (n != "") print n, (rt=="" ? "MISSING" : rt); n=$3; rt="" }
+    $1=="runtime:"         { rt=$2 }
+    END                    { if (n != "") print n, (rt=="" ? "MISSING" : rt) }
+' "$REPOS_YML")
+
+if [[ "$errors" -eq 0 ]]; then
+    echo "✓ repos.yml: every entry has a valid runtime classification"
+    exit 0
+fi
+echo "FAILED: $errors classification error(s)" >&2
+exit 1


### PR DESCRIPTION
Closes #124

## Why

Directive: **projects must run ONLY in containers, unless the project's nature forbids it.**

§6 already mandated Docker, but the policy was neither classified per repo nor auditable — "unless nature forbids" was undefined. This codifies it and makes drift machine-checkable.

## What

- **`repos.yml`** — new `runtime:` class on every repo: `container` | `exempt:lib` | `exempt:config` | `exempt:native` | `pending`.
- **`EXECUTION_STANDARD.md §6.1`** — the policy + the finite set of nature exemptions (convenience is never one).
- **`scripts/audit-docker-compliance.sh`** — read-only fleet audit. `FAIL` only when a service genuinely cannot run in a container (no Dockerfile **and** no compose); `WARN` for §6 polish gaps; `EXEMPT`/`PENDING` reported, never fail. Prunes `.claude` worktrees to avoid false positives.
- **`scripts/validate-repos-runtime.sh` + CI step** — gates every `repos.yml` entry on a valid `runtime:` class, so a new repo cannot merge unclassified. Keeps the policy self-sustaining.
- **`compliance/`** — baseline `docker-conformance.json` + `CONTAINER-RUNTIME-BACKLOG.md`.

## Baseline — the fleet already conforms

`pass=22 warn=11 fail=0 exempt=20 pending=4 absent=1` (audit exits 0).

Every code-bearing repo either runs in a container or its nature genuinely forbids it:
- **`lifeos` (= `my-assistant`)** — floating multi-OS desktop assistant (overlay UI, system tray, OS-level monitoring); a container can't give that host access → `exempt:native`, same as `floating-agent`.
- **`quality-gatekeeper`** — only an empty `__init__.py` (no app, no tests) → `pending`, not scaffolded with a hollow container. Likely `exempt:lib` later (sibling of `guideline-checker`).
- 11 `WARN`s are §6 polish (mostly `docker-up`/`docker-down` names from `base-makefile`) — already run in containers; folded into the next makefile-sync sweep.

## Follow-up

`project-init` / `chrysa-init` should default new repos to a runtime container so the policy stays self-sustaining (see backlog doc).

## Verify

- `bash scripts/validate-repos-runtime.sh` -> all entries valid (runs in CI).
- `bash scripts/audit-docker-compliance.sh` -> `fail=0`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)