### PR TITLE
chore(workflows): pin chrysa/github-actions reusable workflows to v1.2.1

### DIFF
--- a/templates/workflows-process/dependabot-auto-merge.yml
+++ b/templates/workflows-process/dependabot-auto-merge.yml
@@ -18,4 +18,4 @@ concurrency:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@main
+    uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@v1.2.1

--- a/workflows/quality-gate-check.yml
+++ b/workflows/quality-gate-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/quality-gate-check.yml@main
+        uses: chrysa/github-actions/.github/workflows/quality-gate-check.yml@v1.2.1

--- a/workflows/release.yml
+++ b/workflows/release.yml
@@ -55,7 +55,7 @@ permissions:
 jobs:
     lint:
         name: Lint gate (pre-commit replay)
-        uses: chrysa/github-actions/.github/workflows/lint-python.yml@main
+        uses: chrysa/github-actions/.github/workflows/lint-python.yml@v1.2.1
         with:
             python-version: '3.14'
             extras: dev


### PR DESCRIPTION
Pins the three canonical workflow refs that still used `@main` to the `v1.2.1` tag:
- `workflows/quality-gate-check.yml`
- `workflows/release.yml` (lint-python)
- `templates/workflows-process/dependabot-auto-merge.yml`

Hardens the supply chain at source — every repo receiving these via distribution now uses an immutable ref. Closes the recurring "pin GitHub Actions" standards-backlog item at its origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)