### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.chrysa/STANDARDS.md
+++ b/.chrysa/STANDARDS.md
@@ -1,0 +1,92 @@
+<!--
+  CHRYSA TRANSVERSE STANDARDS — MANAGED FILE, DO NOT EDIT HERE.
+  Source of truth: chrysa/shared-standards/standards/STANDARDS.chrysa.md
+  Distributed to each repo as .chrysa/STANDARDS.md by the distribute-standards workflow.
+  Local CLAUDE.md imports it via `@.chrysa/STANDARDS.md`. Any manual edit will be
+  overwritten on the next sync — change the source repo and let the PR flow back.
+-->
+
+# chrysa — Transverse Standards
+
+These conventions are identical across every chrysa repo. Repo-specific rules live in the
+local `CLAUDE.md`; this file is the shared baseline imported by it.
+
+## Cross-cutting stack (settled ADRs — do not relitigate)
+
+| Layer            | Decision                                                        |
+|------------------|----------------------------------------------------------------|
+| Python           | 3.14 target (CI matrix 3.12 + 3.14)                            |
+| FastAPI          | >= 0.115 + Pydantic v2                                          |
+| Frontend         | React 19 + TypeScript + Vite 6                                  |
+| UI               | shadcn/ui + Tailwind CSS                                        |
+| State            | TanStack Query + Zustand                                        |
+| DB               | PostgreSQL 16 + Redis 7                                         |
+| ORM              | SQLAlchemy 2.0 async + Alembic                                  |
+| Auth             | 4 modes: Google OAuth2 · local (bcrypt) · LDAP · VCS OAuth      |
+| i18n             | react-i18next + fastapi-babel · FR + EN from V1                 |
+| Monorepo         | Turborepo + pnpm workspaces                                     |
+| Versioning       | GitVersion (semantic auto — never bump manually)               |
+| Quality CI       | SonarCloud (0 hotspot · rating A)                               |
+| Linting          | Ruff + Mypy (Python) · ESLint (TS)                             |
+| Pre-commit       | detect-secrets + ruff + mypy + commitlint                      |
+| Error handling   | withErrorHandling() → auto GitHub Issue on failure             |
+| Hosting          | Kimsufi · Docker Compose (local) · Nginx · Certbot · Tailscale  |
+| Monitoring       | Sentry + Uptime Kuma (self-hosted)                            |
+| Agents           | Claude API (primary) · Ollama (fallback)                       |
+| Orchestration    | LangGraph (stateful) · PydanticAI (structured outputs)         |
+
+## Non-negotiable conventions
+
+- **Language**: English — all code, comments, docs, instructions, and config files.
+- **Commits**: Conventional Commits (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`).
+- **Branches**: `feature/`, `bugfix/`, `chore/`, `hotfix/`, `release/` · default branch `develop`.
+- **Merge**: squash merge only · force push forbidden · auto-merge requires CI + owner.
+- **One PR per issue**, scoped tight. Every PR references an issue (`Closes/Fixes/Refs #N`).
+  Exception: label `hotfix`. The `enforce-issue-link` workflow is a blocking status check.
+- **Dark mode** mandatory from V1. **Accessibility** WCAG 2.1 AA.
+
+## Quality gates
+
+- Test coverage **>= 85%** by default. A repo may override upward, never below 80%.
+- Lint warnings: **0**. Mypy clean. SonarCloud rating **A**, 0 security hotspot.
+- Max function lines 50 · max file lines 500 · cyclomatic complexity heuristic <= 10.
+
+## Shared skills (load on demand from shared-standards/.claude/skills/)
+
+- `testing-pytest` — pytest DDD + pytest-mock + constants (writing tests)
+- `dockerfile-multistage` — 4-stage Python 3.14 containers (editing Dockerfile)
+- `api-design` — REST standards + FastAPI patterns (designing endpoints)
+- `async-patterns` — async FastAPI + SQLAlchemy async sessions (async code)
+- `clean-architecture` — FastAPI module/layer structure (adding a feature)
+- `error-handling` — FastAPI errors + Sentry + logging (handling errors)
+- `contract-testing` — library contract / breaking-change tests (@chrysa/* releases)
+- `agent-patterns` — LangGraph + PydanticAI + Claude API (building agents)
+- `ui-ux` — UX/UI/ergonomics + WCAG 2.1 AA + dark mode + i18n (human-facing surfaces)
+
+## Error handling pattern (all automations)
+
+```text
+try:    fn()
+except: gh issue create --title "[chrysa] failure" --label "chrysa-error"
+```
+
+## Observability — Sentry → GitHub issues (norm)
+
+Every status:dev repo ships a Sentry project, and **a new Sentry issue automatically opens a
+GitHub issue** via Sentry's native GitHub integration. No relay, no PAT in the repo — the
+integration owns the link, so a Sentry issue maps to exactly one GitHub issue (no duplicates).
+
+Mechanism: a per-project Sentry **issue alert rule** with
+condition `FirstSeenEventCondition` (a new issue is created) and action
+`GitHubCreateTicketAction` targeting `chrysa/<repo>`, labels `sentry`, `bug`.
+Provision it across all projects with
+`shared-standards/scripts/sentry-github-issues.sh` (idempotent, `--dry-run` first).
+
+Per-project activation checklist:
+
+1. Org GitHub integration installed once in Sentry (Settings → Integrations → GitHub) with
+   access to the chrysa repos.
+2. The repo has a Sentry project whose slug matches the repo name.
+3. The auto-issue alert rule exists (run the provisioning script, or add it in
+   Alerts → Create Alert → Issues → action "Create a GitHub issue").
+4. The GitHub repo has a `sentry` label (CI label sync provides it).

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Normalize line endings: treat all text as text, check out/in with LF.
+* text=auto eol=lf
+
+# Explicit text types
+*.py      text
+*.pyi     text
+*.md      text
+*.txt     text
+*.cfg     text
+*.ini     text
+*.toml    text
+*.yaml    text
+*.yml     text
+*.json    text
+*.js      text
+*.jsx     text
+*.ts      text
+*.tsx     text
+*.css     text
+*.html    text
+*.sh      text eol=lf
+Makefile  text
+Dockerfile text
+
+# Lockfiles & generated artefacts: keep diffs collapsed, exclude from language stats
+uv.lock           linguist-generated=true -diff
+poetry.lock       linguist-generated=true -diff
+package-lock.json linguist-generated=true -diff
+pnpm-lock.yaml    linguist-generated=true -diff
+yarn.lock         linguist-generated=true -diff
+
+# Binary assets — never normalize
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.pdf   binary
+*.svg   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary
+*.zip   binary
+*.gz    binary
+*.db    binary

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+config-variables:
+  - GITHUB_TOKEN
+self-hosted-runner:
+  labels:
+    - ubuntu-22.04
+    - ubuntu-24.04
+    - ubuntu-latest

--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -1,0 +1,28 @@
+"on":
+  pull_request:
+    paths:
+      - .github/actionlint.yaml
+      - .github/workflows/**
+  push:
+    branches:
+      - develop
+      - main
+      - master
+    paths:
+      - .github/workflows/**
+jobs:
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        uses: raven-actions/actionlint@3a24062651993d40fed1019b58ac6fbdfbf276cc
+        with:
+          matcher: true
+name: Actionlint
+permissions:
+  contents: read

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -1,0 +1,32 @@
+"on":
+  pull_request:
+    branches-ignore:
+      - develop
+      - main
+      - master
+    types:
+      - auto_merge_enabled
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+  schedule:
+    - cron: 0 0 * * *
+  workflow_call:
+  workflow_dispatch:
+jobs:
+  check_dependencies:
+    name: Check Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: gregsdennis/dependencies-action@v1.4.2
+      - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
+        with:
+          use-label: Blocked
+name: Check PR dependencies
+permissions:
+  contents: read
+  pull-requests: write
+run-name: ${{ github.workflow }} by ${{ github.actor }}

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -1,0 +1,66 @@
+# yamllint disable rule:line-length
+# (embedded github-script JS lines exceed the default 80-char limit)
+"on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  update-body:
+    if: contains(github.event.pull_request.body, '<!-- auto-changes-start -->')
+    name: Fill auto-changes section
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        name: Update PR body
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const baseRef = process.env.BASE_REF;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+
+            execSync(`git fetch origin ${baseRef} --depth=50`, { stdio: 'inherit' });
+
+            const rawLog = execSync(
+                `git log origin/${baseRef}..HEAD --oneline --no-merges --reverse`,
+                { encoding: 'utf8' }
+            ).trim();
+
+            const bullets = rawLog.length > 0
+                ? rawLog.split('\n').map(line => `- ${line}`).join('\n')
+                : '- _no commits yet_';
+
+            const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+            });
+
+            const marker = /<!-- auto-changes-start -->[\s\S]*?<!-- auto-changes-end -->/;
+            const replacement = `<!-- auto-changes-start -->\n${bullets}\n<!-- auto-changes-end -->`;
+            const updatedBody = pr.body.replace(marker, replacement);
+
+            if (updatedBody === pr.body) {
+                console.log('No change detected — skipping update.');
+                return;
+            }
+
+            await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                body: updatedBody,
+            });
+
+            console.log('PR body updated.');
+name: Update PR body
+permissions:
+  contents: read
+  pull-requests: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,3 +155,7 @@ This project is indexed by GitNexus as **shared-standards** (318 symbols, 312 re
 Shared skills from `shared-standards/.claude/skills/`:
 
 - `ui-ux/SKILL.md` — UX/UI/ergonomics across ALL surfaces (web, CLI, VS Code, Discord, desktop, game, agent) + WCAG 2.1 AA + dark mode + i18n FR+EN (load when building any human-facing surface)
+
+<!-- chrysa:standards-import:start -->
+@.chrysa/STANDARDS.md
+<!-- chrysa:standards-import:end -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to target
+
+Thanks for contributing. This repo follows the chrysa
+[Execution Standard](https://github.com/chrysa/shared-standards/blob/main/EXECUTION_STANDARD.md).
+
+## Prerequisites
+
+Install dev dependencies and pre-commit hooks:
+
+```bash
+make install
+```
+
+## Workflow
+
+1. **Branch** from `main` using a typed prefix: `feat/`, `fix/`, `chore/`,
+   `docs/`, `ci/`, `refactor/`, `test/`, `perf/`. Direct commits to `main` are
+   blocked (`no-commit-to-branch`).
+2. **Develop** using the `make` targets only — never call `pytest` / `ruff` /
+   `mypy` directly on the host: `make test`, `make test-cov`, `make lint`,
+   `make format`, `make typecheck`.
+3. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/):
+   `type(scope): subject` (allowed types: feat, fix, docs, style, refactor, test,
+   chore, perf, revert, ci). Commit messages are linted via `conventional-pre-commit`.
+4. **Verify** before pushing, then open a PR against `main`.
+
+Verification commands:
+
+```bash
+pre-commit run --all-files
+make test
+```
+
+CI (pre-commit, lint, test, sonar) must pass and one approval is required before merge.
+
+## Code standards
+
+- All committed files (code, comments, docs, config) are in **English**.
+- No hardcoded secrets — use env vars and keep `.env.example` in sync.
+- New behaviour ships with tests; keep coverage at or above the project threshold.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/`. Include reproduction
+steps, expected vs actual behaviour, and environment details.


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@299b6d23024d8e89119650ec44c622a4df833fda`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards