### PR TITLE
chore(repos): reconcile repos.yml with GitHub truth

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -34,6 +34,10 @@ repos:
     status: dev
     public: true
     runtime: container
+  - name: chrysa-knowledge
+    status: non-dev
+    public: false
+    runtime: exempt:config
   - name: chrysa-lib
     status: dev
     public: false
@@ -117,6 +121,22 @@ repos:
   - name: epub-sorter
     status: dev
     public: true
+    runtime: exempt:lib
+  - name: fastapi-autoload
+    status: dev
+    public: false
+    runtime: exempt:lib
+  - name: fastapi-pytest
+    status: dev
+    public: false
+    runtime: exempt:lib
+  - name: fastapi-query-optimizer
+    status: dev
+    public: false
+    runtime: exempt:lib
+  - name: fastapi-traceid
+    status: dev
+    public: false
     runtime: exempt:lib
   - name: feedback-gateway
     status: dev
@@ -247,3 +267,7 @@ repos:
     status: dev
     public: false
     runtime: exempt:native
+  - name: wsmqtt-monitor
+    status: dev
+    public: false
+    runtime: container


### PR DESCRIPTION
Adds 6 repos absent from the source-of-truth matrix (found via GitHub-truth audit):

- `fastapi-autoload`, `fastapi-pytest`, `fastapi-query-optimizer`, `fastapi-traceid` — Python libs → `status: dev`, `runtime: exempt:lib`
- `wsmqtt-monitor` — Django app (compose) → `status: dev`, `runtime: container`
- `chrysa-knowledge` — Obsidian prose vault → `status: non-dev`, `runtime: exempt:config`

Without these, distribute-standards.yml never targeted them, so they could not receive `.chrysa/STANDARDS.md` or the canonical set. Enables the conformance fan-out to cover the full fleet.

Note: `my-assistant` remains in repos.yml but no longer exists on GitHub (renamed/archived) — left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)