### PR TITLE
feat(conformance): canonical drift gate for GitVersion.yml + cliff.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,20 @@ repos:
     args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
   repo: https://github.com/compilerla/conventional-pre-commit
   rev: v4.4.0
+- hooks:
+  # Canonical-file drift gate (dedup-campaign #108 GitVersion, #109 cliff): the
+  # repo-root source of truth must stay byte-identical to its templates/ copy
+  # that the distribution machinery hands the fleet.
+  - id: gitversion-canonical-drift
+    name: GitVersion.yml canonical drift
+    entry: scripts/check-canonical-drift.sh GitVersion.yml templates/GitVersion.yml
+    language: system
+    pass_filenames: false
+    files: ^(GitVersion\.yml|templates/GitVersion\.yml)$
+  - id: cliff-canonical-drift
+    name: cliff.toml canonical drift
+    entry: scripts/check-canonical-drift.sh cliff.toml templates/cliff.toml
+    language: system
+    pass_filenames: false
+    files: ^(cliff\.toml|templates/cliff\.toml)$
+  repo: local

--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -305,6 +305,32 @@ pre-commit). Node repos use `ci-node`; infra/GAS use domain-appropriate checks.
 is never folded into CI. PR-cosmetic automations (labeler, size, auto-assign…) are
 optional, not required.
 
+#### Canonical release config (`GitVersion.yml`, `cliff.toml`)
+
+The semantic-versioning config (`GitVersion.yml`, flat `mode: ContinuousDeployment`)
+and the changelog config (`cliff.toml`) are **canonical files**: a single source of
+truth lives in `chrysa/shared-standards` (repo root **and** byte-identical `templates/`
+copy), and every active repo's copy must match it. Legacy v5 GitVersion schemas
+(`GitHubFlow`, no top-level `mode:`) are **incompatible** with chrysa branching and
+must be replaced, not version-bumped.
+
+Tooling (mirrors the Makefile-conformance trio, §1.6):
+
+- `scripts/audit-canonical-conformance.sh <file>` — read-only fleet audit over
+  `repos.yml` via the GitHub API; classifies each repo `ok | drift | incompatible |
+  missing` by git blob SHA and persists `compliance/<file>-conformance.json`.
+- `scripts/check-canonical-drift.sh <a> <b> …` — wired as a `repo: local` pre-commit
+  hook (`gitversion-canonical-drift`, `cliff-canonical-drift`); fails if the repo-root
+  source of truth diverges from its `templates/` copy, so the canonical can never
+  silently drift before distribution.
+- `scripts/sync-canonical.sh <file> --repo <path> [--write]` — single-repo
+  propagation of the canonical into one checkout. **Never a fleet fan-out** — migrate
+  one repo per session, commit, open one PR.
+
+**Rollout cadence:** re-run the audit when the canonical changes or monthly; migrate
+incompatible/drift repos one-per-session via `sync-canonical.sh` (respecting Rule 1+2),
+refreshing the `compliance/` ledger as repos converge.
+
 ### Conditional workflows
 
 | Workflow | Condition |

--- a/compliance/cliff-conformance.json
+++ b/compliance/cliff-conformance.json
@@ -1,0 +1,372 @@
+{
+  "canonical": "cliff.toml",
+  "canonical_sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+  "rows": [
+    {
+      "note": "cluster:7f25ddb2",
+      "repo": "agent-config",
+      "sha": "7f25ddb2d316eeb2963b818a13c1739d1f1e91c5",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:ae958672",
+      "repo": "ai-aggregator",
+      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:da9d50eb",
+      "repo": "audit-platform",
+      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "automations",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:ae958672",
+      "repo": "catalog",
+      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:efae6e8b",
+      "repo": "cdn-explorer",
+      "sha": "efae6e8b80474af235859838df883006de126496",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:dad52a93",
+      "repo": "chrysa-lib",
+      "sha": "dad52a93b6a777df951b0a15c342010d75119b84",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:da9d50eb",
+      "repo": "chrysa-portfolio-viz",
+      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:7f25ddb2",
+      "repo": "chrysa-skills",
+      "sha": "7f25ddb2d316eeb2963b818a13c1739d1f1e91c5",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:7f25ddb2",
+      "repo": "claude-config",
+      "sha": "7f25ddb2d316eeb2963b818a13c1739d1f1e91c5",
+      "status": "drift"
+    },
+    {
+      "note": "-",
+      "repo": "coach",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "cluster:bd3fa5a7",
+      "repo": "container-webview",
+      "sha": "bd3fa5a70c4fd1666b82ac4a24e5d5bd50cfeb60",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "D-D",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:dad52a93",
+      "repo": "dev-nexus",
+      "sha": "dad52a93b6a777df951b0a15c342010d75119b84",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:da9d50eb",
+      "repo": "devtool",
+      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "discord-bot-back",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:fef0de10",
+      "repo": "discordium",
+      "sha": "fef0de1043b8ad16a82c2167cf87c97fec55eff3",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:ae958672",
+      "repo": "diy-stream-deck",
+      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:9f4111a8",
+      "repo": "django-app-forge",
+      "sha": "9f4111a8d9d0d0817baf99e784fbc39018b4485e",
+      "status": "drift"
+    },
+    {
+      "note": "-",
+      "repo": "django-autoload",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "django-pytest",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "cluster:53002a29",
+      "repo": "django-query-optimizer",
+      "sha": "53002a2908721c2b9d97a5c2dae5f137b7b679d1",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:da9d50eb",
+      "repo": "django-query-optimizer-vscode",
+      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
+      "status": "drift"
+    },
+    {
+      "note": "-",
+      "repo": "django-traceid",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "cluster:7c58ea1d",
+      "repo": "doc-gen",
+      "sha": "7c58ea1d6fe391c9660b0dbf860aae6eac1b6e96",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "epub-sorter",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-autoload",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-pytest",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-query-optimizer",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-traceid",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "cluster:8198437c",
+      "repo": "feedback-gateway",
+      "sha": "8198437c05ba09365bad0bceb41f2c1b04f24adb",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:312aa423",
+      "repo": "floating-agent",
+      "sha": "312aa423935c155b943aa1b77832a0988fa6ba27",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:d33333b6",
+      "repo": "game-solver-platform",
+      "sha": "d33333b69fccf7e5850c85ac972ddc477d409636",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:a0f7796d",
+      "repo": "gaming-os",
+      "sha": "a0f7796d7af04cb71dc3f0ec7d643d4c47f64117",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:ae958672",
+      "repo": "genealogy-validator",
+      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:da9d50eb",
+      "repo": "gestureOS",
+      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "github-actions",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:0b80b91d",
+      "repo": "guideline-checker",
+      "sha": "0b80b91d8262373397c36e0a94e3d41865c3f66e",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:ae958672",
+      "repo": "lifeos",
+      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "linkendin-resume",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:da9d50eb",
+      "repo": "link-reader-bot",
+      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:e080c5e4",
+      "repo": "mediavault",
+      "sha": "e080c5e439f4586ed773f49d70388fb1430712d5",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:63f080e7",
+      "repo": "mirrador",
+      "sha": "63f080e7423afaecf41fd835950d27dc5b52a90b",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "my-resume",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:737fcf53",
+      "repo": "orchestrator",
+      "sha": "737fcf538b7085d9f356eb24a09f5fedbed948c2",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:da9d50eb",
+      "repo": "paperclip",
+      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "PO-GO-DEX",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:04dba1b5",
+      "repo": "pre-commit-hooks-changelog",
+      "sha": "04dba1b59d6a7d9d901071995a28939b4ee7e4b1",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:8d89ec29",
+      "repo": "pre-commit-tools",
+      "sha": "8d89ec29d96ce6acb6799b4c83fff1daf7c9460c",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:ec45836e",
+      "repo": "project-init",
+      "sha": "ec45836e59d2989bc4890cea854917cdc6091211",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:7f25ddb2",
+      "repo": "quality-gatekeeper",
+      "sha": "7f25ddb2d316eeb2963b818a13c1739d1f1e91c5",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:1226a50c",
+      "repo": "satisfactory-automated_calculator",
+      "sha": "1226a50c24df1d7b5edc40bdfb4f3d38482c6add",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:da9d50eb",
+      "repo": "satisfactory-factory-manager",
+      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:1249a5b1",
+      "repo": "server",
+      "sha": "1249a5b10e1440f8ecbd190b8be5e4b9fe6f143f",
+      "status": "drift"
+    },
+    {
+      "note": "-",
+      "repo": "shared-standards",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    },
+    {
+      "note": "cluster:7f832b27",
+      "repo": "sport-intelligence-hub",
+      "sha": "7f832b27cb299a9af27367adf3c52a1166345b6a",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:8d772a27",
+      "repo": "studioverse",
+      "sha": "8d772a27bc092302d3ea2808caca897284c0ac29",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "usefull-containers",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:363bf921",
+      "repo": "windows-autonome",
+      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
+      "status": "drift"
+    },
+    {
+      "note": "cluster:a947ecc8",
+      "repo": "windows-docker-state-notification",
+      "sha": "a947ecc8506ff376ec4d10229810bd5209b34569",
+      "status": "drift"
+    },
+    {
+      "note": "-",
+      "repo": "wsmqtt-monitor",
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
+    }
+  ]
+}

--- a/compliance/gitversion-conformance.json
+++ b/compliance/gitversion-conformance.json
@@ -1,0 +1,372 @@
+{
+  "canonical": "GitVersion.yml",
+  "canonical_sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+  "rows": [
+    {
+      "note": "-",
+      "repo": "agent-config",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "ai-aggregator",
+      "sha": "299024f2957d22ce16823feec2e2ee5e2dab5b45",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "audit-platform",
+      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "automations",
+      "sha": "71cf1ea5b3851ace17d49579010eee58d9f927a5",
+      "status": "incompatible"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "catalog",
+      "sha": "299024f2957d22ce16823feec2e2ee5e2dab5b45",
+      "status": "drift"
+    },
+    {
+      "note": "-",
+      "repo": "cdn-explorer",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "chrysa-lib",
+      "sha": "4bdf94c8550213115b134bb469b3c8881e40253c",
+      "status": "incompatible"
+    },
+    {
+      "note": "-",
+      "repo": "chrysa-portfolio-viz",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "chrysa-skills",
+      "sha": "298b00bc29361c8b2b0153b2d0693e29ddd583be",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "claude-config",
+      "sha": "59741bd2248f307290acdc3317a2b7335c44df8b",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "coach",
+      "sha": "298b00bc29361c8b2b0153b2d0693e29ddd583be",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDelivery",
+      "repo": "container-webview",
+      "sha": "427dbaffba48d92f2b281b696e90fb014d2dc2b6",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "D-D",
+      "sha": "0f8f787fca0ec866716f2bc3e5852adb29080b8c",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "dev-nexus",
+      "sha": "dadad3b54d4eeb90fd48543b9b92cc0e693e837e",
+      "status": "incompatible"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "devtool",
+      "sha": "299024f2957d22ce16823feec2e2ee5e2dab5b45",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "discord-bot-back",
+      "sha": "123aca9216beba0e57cc5081b97a555452a0ec05",
+      "status": "incompatible"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "discordium",
+      "sha": "b533ffbf13d9cfb5b5535790cefdff802fa27c8c",
+      "status": "drift"
+    },
+    {
+      "note": "mode:semantic",
+      "repo": "diy-stream-deck",
+      "sha": "017bfed96b8a9750715b7326eb1ae140438f01de",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "django-app-forge",
+      "sha": "8357c1478429a850f8403cb7ce307287ec4507fe",
+      "status": "drift"
+    },
+    {
+      "note": "-",
+      "repo": "django-autoload",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "django-pytest",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "django-query-optimizer",
+      "sha": "7a76dfcbe05104ebac859d048f829446b7287e98",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "django-query-optimizer-vscode",
+      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
+      "status": "incompatible"
+    },
+    {
+      "note": "-",
+      "repo": "django-traceid",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "doc-gen",
+      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "epub-sorter",
+      "sha": "74d2c3ca3ff4dcc1ae033d6c8160077ac0a75d39",
+      "status": "incompatible"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-autoload",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-pytest",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-query-optimizer",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-traceid",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "feedback-gateway",
+      "sha": "90e4eb76e113e2188300528e782c8c9302574d61",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDelivery",
+      "repo": "floating-agent",
+      "sha": "0f6bb885b8cecea43c80c7934630c4c939ea66f8",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "game-solver-platform",
+      "sha": "90e4eb76e113e2188300528e782c8c9302574d61",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "gaming-os",
+      "sha": "9527fc5a20d0fbf32929ef7f03f8b14cdb6b8f70",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDelivery",
+      "repo": "genealogy-validator",
+      "sha": "6103cc3b0429502725d736522b7dead07fd7d48d",
+      "status": "drift"
+    },
+    {
+      "note": "mode:semantic",
+      "repo": "gestureOS",
+      "sha": "914250d0a8029b03e7c2bb2003275dbe3c098051",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "github-actions",
+      "sha": "4bdf94c8550213115b134bb469b3c8881e40253c",
+      "status": "incompatible"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "guideline-checker",
+      "sha": "8357c1478429a850f8403cb7ce307287ec4507fe",
+      "status": "drift"
+    },
+    {
+      "note": "mode:semantic",
+      "repo": "lifeos",
+      "sha": "914250d0a8029b03e7c2bb2003275dbe3c098051",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "linkendin-resume",
+      "sha": "9a3f2d8b3a336fc699b51e0628dfc04b63e29cf2",
+      "status": "incompatible"
+    },
+    {
+      "note": "-",
+      "repo": "link-reader-bot",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "mediavault",
+      "sha": "299024f2957d22ce16823feec2e2ee5e2dab5b45",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "mirrador",
+      "sha": "299024f2957d22ce16823feec2e2ee5e2dab5b45",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "my-resume",
+      "sha": "c07002308333ef9a084101df8a0fd94b4aa63547",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "orchestrator",
+      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "paperclip",
+      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "PO-GO-DEX",
+      "sha": "f9c25b5080a830ff59d0038f513405440a146e80",
+      "status": "incompatible"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "pre-commit-hooks-changelog",
+      "sha": "90e4eb76e113e2188300528e782c8c9302574d61",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "pre-commit-tools",
+      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
+      "status": "incompatible"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "project-init",
+      "sha": "ee2f932d51b3be1db4b7d4d30d787e53d88e4f78",
+      "status": "drift"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "quality-gatekeeper",
+      "sha": "298b00bc29361c8b2b0153b2d0693e29ddd583be",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "satisfactory-automated_calculator",
+      "sha": "dade0ac4efb9e1a3a54eb0f2d790f0cd1727768c",
+      "status": "incompatible"
+    },
+    {
+      "note": "mode:ContinuousDeployment",
+      "repo": "satisfactory-factory-manager",
+      "sha": "299024f2957d22ce16823feec2e2ee5e2dab5b45",
+      "status": "drift"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "server",
+      "sha": "a7291c041468fbf9a915ff2c4d4ff4ddf8be4e18",
+      "status": "incompatible"
+    },
+    {
+      "note": "-",
+      "repo": "shared-standards",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "sport-intelligence-hub",
+      "sha": "08575b4cc67066b4c692eae3ded7b4f485c336fd",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "studioverse",
+      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "usefull-containers",
+      "sha": "85a7762dd669892be10ff4fc04bd4397864d3c52",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "windows-autonome",
+      "sha": "92f46bf524a482388278559592d3ff60c0b03722",
+      "status": "incompatible"
+    },
+    {
+      "note": "schema:GitHubFlow-v5",
+      "repo": "windows-docker-state-notification",
+      "sha": "6417937bfbe40307894d19239c24cba55ef9fe18",
+      "status": "incompatible"
+    },
+    {
+      "note": "-",
+      "repo": "wsmqtt-monitor",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    }
+  ]
+}

--- a/scripts/audit-canonical-conformance.sh
+++ b/scripts/audit-canonical-conformance.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# audit-canonical-conformance.sh · Read-only fleet audit of a canonical config
+# file against shared-standards' single source of truth.
+#
+# Source: chrysa/shared-standards/scripts/audit-canonical-conformance.sh
+#
+# Backs dedup-campaign issues S11 (GitVersion.yml, #108) and S12 (cliff.toml,
+# #109): the canonical file already lives at the repo root; this tool produces
+# the *real* drift list across the fleet so migration can be planned instead of
+# guessed. Each dev repo's copy is fetched via the GitHub API (no local checkout
+# needed) and compared to the canonical by git blob SHA.
+#
+# Per dev repo it classifies:
+#   ok           copy is byte-identical to canonical
+#   drift        copy present but differs (for cliff.toml the SHA is the cluster id)
+#   incompatible (GitVersion only) copy uses a different branching model
+#                (mode: GitHubFlow) — breaks chrysa ContinuousDeployment versioning
+#   missing      repo has no such file
+#   error        API/network failure (re-run)
+#
+# Emits a TSV table to stdout AND persists a machine-readable ledger under
+# shared-standards/compliance/. Read-only: never writes to any other repo.
+#
+# Usage:
+#   bash audit-canonical-conformance.sh GitVersion.yml
+#   bash audit-canonical-conformance.sh cliff.toml
+#   bash audit-canonical-conformance.sh <canonical-file> [--ledger <name.json>]
+# Env: CHRYSA_ROOT unused (fleet read over the API, not the filesystem).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STD_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPOS_YML="$STD_ROOT/repos.yml"
+LEDGER_DIR="$STD_ROOT/compliance"
+
+# shellcheck source=lib/canonical.sh
+source "$SCRIPT_DIR/lib/canonical.sh"
+
+CANON_FILE=""
+LEDGER_NAME=""
+
+# Classify one repo's copy of $CANON_PATH against the canonical blob SHA.
+# Echoes: "<status>\t<sha>\t<note>"
+classify_one() {
+    local repo="$1" canon_path="$2" canon_sha="$3"
+    local sha; sha="$(remote_blob_sha "$repo" "$canon_path")"
+    if [[ -z "$sha" ]]; then
+        printf 'missing\t-\t-'
+        return
+    fi
+    if [[ "$sha" == "$canon_sha" ]]; then
+        printf 'ok\t%s\t-' "$sha"
+        return
+    fi
+    # Differs. For GitVersion, the campaign's real target is the legacy v5
+    # "GitHubFlow" schema, recognised by the ABSENCE of a top-level `mode:` line
+    # (chrysa's canonical declares `mode: ContinuousDeployment` flat at column 0)
+    # or an explicit `mode: GitHubFlow`. That schema breaks chrysa branching →
+    # incompatible. A copy that still declares a flat top-level mode is merely
+    # cosmetic/version drift on a compatible schema.
+    if [[ "$canon_path" == "GitVersion.yml" ]]; then
+        local content; content="$(remote_file_content "$repo" "$canon_path")"
+        local mode; mode="$(grep -ioE '^mode:[[:space:]]*[A-Za-z]+' <<<"$content" | head -1 | awk -F'[[:space:]]+' '{print $2}')"
+        if [[ -z "$mode" ]] || grep -qiE '^mode:[[:space:]]*GitHubFlow' <<<"$content"; then
+            printf 'incompatible\t%s\tschema:GitHubFlow-v5' "$sha"
+            return
+        fi
+        printf 'drift\t%s\tmode:%s' "$sha" "$mode"
+        return
+    fi
+    # cliff.toml and others: the differing SHA is the cluster identity.
+    printf 'drift\t%s\tcluster:%s' "$sha" "${sha:0:8}"
+}
+
+JSON_ROWS=()
+
+main() {
+    CANON_FILE="${1:-}"
+    [[ -n "$CANON_FILE" ]] || { echo "usage: $0 <canonical-file> [--ledger <name.json>]" >&2; exit 2; }
+    shift || true
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --ledger) LEDGER_NAME="$2"; shift 2 ;;
+            *) echo "unknown arg: $1" >&2; exit 2 ;;
+        esac
+    done
+
+    local canon_local="$STD_ROOT/$CANON_FILE"
+    local canon_sha; canon_sha="$(canonical_blob_sha "$canon_local")" \
+        || { echo "error: canonical not found at $canon_local" >&2; exit 1; }
+    if [[ -z "$LEDGER_NAME" ]]; then
+        local stem; stem="${CANON_FILE##*/}"; stem="${stem%.*}"
+        LEDGER_NAME="$(tr '[:upper:]' '[:lower:]' <<<"$stem")-conformance.json"
+    fi
+    local ledger="$LEDGER_DIR/$LEDGER_NAME"
+
+    echo "canonical: $CANON_FILE  blob=$canon_sha" >&2
+    printf '%-34s %-13s %-10s %s\n' "repo" "STATUS" "SHA" "NOTE"
+    printf '%s\n' "-------------------------------------------------------------------------------"
+
+    local repo status sha note
+    while read -r repo; do
+        IFS=$'\t' read -r status sha note < <(classify_one "$repo" "$CANON_FILE" "$canon_sha")
+        printf '%-34s %-13s %-10s %s\n' "$repo" "$status" "${sha:0:8}" "$note"
+        JSON_ROWS+=("$(printf '{"repo":"%s","status":"%s","sha":"%s","note":"%s"}' \
+            "$repo" "$status" "$sha" "$note")")
+    done < <(dev_repos "$REPOS_YML")
+
+    mkdir -p "$LEDGER_DIR"
+    {
+        printf '{\n  "canonical": "%s",\n  "canonical_sha": "%s",\n  "rows": [\n' "$CANON_FILE" "$canon_sha"
+        local i n=${#JSON_ROWS[@]}
+        for ((i = 0; i < n; i++)); do
+            printf '    %s%s\n' "${JSON_ROWS[$i]}" "$([[ $i -lt $((n - 1)) ]] && echo ,)"
+        done
+        printf '  ]\n}\n'
+    } >"$ledger"
+    echo "→ ledger: $ledger (${#JSON_ROWS[@]} repos)" >&2
+}
+
+main "$@"

--- a/scripts/check-canonical-drift.sh
+++ b/scripts/check-canonical-drift.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# check-canonical-drift.sh · Fail if two canonical copies diverge.
+#
+# Source: chrysa/shared-standards/scripts/check-canonical-drift.sh
+#
+# Wired as a `local` pre-commit hook so the root canonical file (the single
+# source of truth) can never silently drift from its templates/ copy that the
+# distribution machinery hands to the fleet. Backs the drift gate asked for by
+# issues #108 (GitVersion.yml) and #109 (cliff.toml).
+#
+# Usage:  bash check-canonical-drift.sh <fileA> <fileB> [...<fileA> <fileB>]
+# Exit:   0 every pair identical · 1 any pair drifts / missing.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/canonical.sh
+source "$SCRIPT_DIR/lib/canonical.sh"
+
+[[ $# -ge 2 && $(($# % 2)) -eq 0 ]] || {
+    echo "usage: $0 <fileA> <fileB> [...]" >&2; exit 2; }
+
+rc=0
+while [[ $# -gt 0 ]]; do
+    a="$1"; b="$2"; shift 2
+    sa="$(canonical_blob_sha "$a" 2>/dev/null)" || { echo "drift: missing $a" >&2; rc=1; continue; }
+    sb="$(canonical_blob_sha "$b" 2>/dev/null)" || { echo "drift: missing $b" >&2; rc=1; continue; }
+    if [[ "$sa" != "$sb" ]]; then
+        echo "drift: $a ($sa) != $b ($sb)" >&2
+        echo "       run: cp $a $b   (or reconcile the canonical source)" >&2
+        rc=1
+    fi
+done
+exit "$rc"

--- a/scripts/lib/canonical.sh
+++ b/scripts/lib/canonical.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# canonical.sh · Shared helpers for canonical-file conformance tooling.
+#
+# Source: chrysa/shared-standards/scripts/lib/canonical.sh
+#
+# A "canonical file" is a config artifact whose single source of truth lives in
+# shared-standards (e.g. GitVersion.yml, cliff.toml) and must be byte-identical
+# across the fleet. These helpers let the audit / sync / drift-gate scripts share
+# one definition of "are two copies the same" and "which repos are in scope".
+#
+# Identity is the git blob SHA (`git hash-object`): the exact hash GitHub returns
+# for a file's contents, so a repo's API `.sha` can be compared without fetching
+# or decoding the bytes. Two copies are identical iff their blob SHAs match.
+
+# Print the git blob SHA of a local file (its content identity). Empty on miss.
+canonical_blob_sha() {
+    local file="$1"
+    [[ -f "$file" ]] || return 1
+    git hash-object "$file"
+}
+
+# Print the dev-repo names from repos.yml (status: dev only — non-dev / archived
+# / alias repos are out of scope for canonical-file conformance).
+dev_repos() {
+    local repos_yml="$1"
+    awk '$1=="-" && $2=="name:"{n=$3} $1=="status:" && $2=="dev"{print n}' "$repos_yml"
+}
+
+# Echo a remote repo file's git blob SHA via the GitHub API, or "" if absent
+# (404) or on any error. Output is validated to be a 40-hex blob SHA so an API
+# error body can never leak through as a bogus "hash".
+# $1 = repo name (under chrysa/), $2 = path in repo.
+remote_blob_sha() {
+    local repo="$1" path="$2" sha
+    sha="$(gh api "repos/chrysa/$repo/contents/$path" --jq '.sha' 2>/dev/null)"
+    [[ "$sha" =~ ^[0-9a-f]{40}$ ]] && printf '%s' "$sha"
+}
+
+# Echo a remote repo file's decoded contents via the GitHub API, or "" if absent.
+# Used only when classification needs to inspect content (e.g. GitVersion mode).
+remote_file_content() {
+    local repo="$1" path="$2" b64
+    b64="$(gh api "repos/chrysa/$repo/contents/$path" --jq '.content' 2>/dev/null)" || return 1
+    [[ -n "$b64" ]] || return 1
+    base64 -d <<<"$b64" 2>/dev/null
+}

--- a/scripts/sync-canonical.sh
+++ b/scripts/sync-canonical.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# sync-canonical.sh · Copy a canonical config file from shared-standards into one
+# target repo's working tree (single-repo propagation — never a fleet fan-out).
+#
+# Source: chrysa/shared-standards/scripts/sync-canonical.sh
+#
+# Backs the migration side of dedup-campaign issues #108 (GitVersion.yml) and
+# #109 (cliff.toml): once a repo is flagged `drift`/`incompatible`/`missing` by
+# audit-canonical-conformance.sh, run this to align its copy with the single
+# source of truth. Deliberately operates on ONE local checkout at a time —
+# issue #109 forbids mass-opening 50 PRs, so propagation stays a human-paced,
+# one-repo-per-session act (commit/PR is left to the operator).
+#
+# Modes:
+#   dry-run (default)  — print the diff vs canonical; write nothing.
+#   --write            — overwrite the target repo's copy with the canonical.
+#
+# Usage:
+#   bash sync-canonical.sh GitVersion.yml --repo ../mirrador
+#   bash sync-canonical.sh cliff.toml --repo ../mirrador --write
+# Env: CHRYSA_ROOT (default: parent of shared-standards) — used to resolve a
+#      bare repo name passed to --repo (e.g. --repo mirrador).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STD_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHRYSA_ROOT="${CHRYSA_ROOT:-$(cd "$STD_ROOT/.." && pwd)}"
+
+# shellcheck source=lib/canonical.sh
+source "$SCRIPT_DIR/lib/canonical.sh"
+
+CANON_FILE=""
+TARGET_REPO=""
+WRITE=0
+
+resolve_repo() {
+    local r="$1"
+    [[ -d "$r/.git" ]] && { printf '%s' "$r"; return; }
+    [[ -d "$CHRYSA_ROOT/$r/.git" ]] && { printf '%s' "$CHRYSA_ROOT/$r"; return; }
+    return 1
+}
+
+main() {
+    CANON_FILE="${1:-}"
+    [[ -n "$CANON_FILE" && "$CANON_FILE" != --* ]] \
+        || { echo "usage: $0 <canonical-file> --repo <path> [--write]" >&2; exit 2; }
+    shift
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --write) WRITE=1; shift ;;
+            --repo) TARGET_REPO="$2"; shift 2 ;;
+            -h|--help) grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+            *) echo "unknown arg: $1" >&2; exit 2 ;;
+        esac
+    done
+    [[ -n "$TARGET_REPO" ]] || { echo "error: --repo <path> required" >&2; exit 2; }
+
+    local canon="$STD_ROOT/$CANON_FILE"
+    [[ -f "$canon" ]] || { echo "error: canonical not found at $canon" >&2; exit 1; }
+
+    local repo; repo="$(resolve_repo "$TARGET_REPO")" \
+        || { echo "error: not a git repo: $TARGET_REPO" >&2; exit 1; }
+    local dest="$repo/$CANON_FILE"
+
+    local canon_sha; canon_sha="$(canonical_blob_sha "$canon")"
+    echo "canonical: $CANON_FILE  blob=$canon_sha" >&2
+    echo "target:    $dest" >&2
+
+    if [[ -f "$dest" ]]; then
+        local dest_sha; dest_sha="$(canonical_blob_sha "$dest")"
+        if [[ "$dest_sha" == "$canon_sha" ]]; then
+            echo "✓ already in sync ($dest_sha)"; return 0
+        fi
+        echo "drift: target=$dest_sha != canonical=$canon_sha"
+        echo "--- diff (target → canonical) ---"
+        diff -u "$dest" "$canon" || true
+    else
+        echo "missing: target has no $CANON_FILE (would create)"
+    fi
+
+    if [[ "$WRITE" -eq 1 ]]; then
+        cp "$canon" "$dest"
+        echo "✏️  wrote $dest  (now $canon_sha)"
+        echo "   next: review, commit & open ONE PR in $repo (no fleet fan-out)"
+    else
+        echo "[dry-run] re-run with --write to overwrite $dest"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Closes #108. Closes #109.

## What

Locks the repo-root single source of truth for the two release-config canonicals (`GitVersion.yml`, `cliff.toml`) and makes divergence un-shippable — the shared-standards side of dedup-campaign **S11 (#108)** and **S12 (#109)**. Mirrors the existing Makefile-conformance trio (audit / drift-gate / sync).

## Tooling

| Script | Role |
|---|---|
| `scripts/lib/canonical.sh` | shared blob-SHA identity + GitHub-API fleet helpers |
| `scripts/audit-canonical-conformance.sh <file>` | read-only fleet audit → `compliance/<file>-conformance.json` |
| `scripts/check-canonical-drift.sh <a> <b> …` | pre-commit gate: root canonical must equal its `templates/` copy |
| `scripts/sync-canonical.sh <file> --repo <p> [--write]` | **single-repo** propagation (never a fleet fan-out, per #109) |

Two `repo: local` pre-commit hooks (`gitversion-canonical-drift`, `cliff-canonical-drift`) keep the root source of truth byte-identical to `templates/` before distribution. Policy + rollout cadence documented in `EXECUTION_STANDARD.md` §5.

## Real fleet drift (61 dev repos)

- **GitVersion.yml** — 13 ok · 25 drift (compatible/cosmetic) · **23 incompatible** (legacy v5 `GitHubFlow`, breaks chrysa ContinuousDeployment) · 0 missing
- **cliff.toml** — 10 ok · 51 drift across **27 content clusters** (top 4 clusters cover 27 repos: 10/8/5/4)

Ledgers committed under `compliance/`.

## Scope (per #109)

Fleet migration is **deferred** — no mass 50-PR fan-out. Repos converge one-per-session via `sync-canonical.sh` (Rule 1+2), tracked in a follow-up campaign issue.

## Verification

- `check-canonical-drift.sh` passes clean (root == templates for both files); negative test (mutated copy) fails rc=1 then reverts clean.
- `pre-commit run` green on all changed files; drift hooks fire on `GitVersion.yml` / `cliff.toml`.