### PR TITLE
fix(pre-commit-merge): never distribute repo:local hooks (fleet pre-commit red)

### DIFF
--- a/scripts/pre-commit-merge.py
+++ b/scripts/pre-commit-merge.py
@@ -146,6 +146,12 @@ GOVERNED = set().union(*HOOK_GROUPS.values())
 # older pins false-positive when an earlier auto-fixing hook reorders staged files.
 REV_ALIGNED_REPOS = {"https://github.com/chrysa/pre-commit-tools"}
 
+# `repo: local` hooks reference repo-relative scripts/files (e.g. the canonical-drift
+# gate runs scripts/check-canonical-drift.sh against templates/ copies that only exist
+# in shared-standards itself). They are self-only and must never be fanned out to the
+# fleet, or every consumer's pre-commit fails with "executable not found".
+NON_DISTRIBUTED_REPOS = {"local"}
+
 
 def enforced_ids(stacks: set[str]) -> set[str]:
     selected = set(HOOK_GROUPS["always"])
@@ -178,6 +184,8 @@ def missing_items(baseline: dict, target: dict, allowed: set[str]) -> list[str]:
     gaps: list[str] = []
     for brepo in baseline.get("repos", []):
         url = brepo.get("repo")
+        if url in NON_DISTRIBUTED_REPOS:
+            continue
         wanted = enforced_hooks(brepo, allowed)
         if not wanted:
             continue
@@ -207,6 +215,8 @@ def merge(baseline: dict, target: dict, allowed: set[str]) -> dict:
     target_by_url = {r.get("repo"): r for r in target.get("repos", [])}
     for brepo in baseline.get("repos", []):
         url = brepo.get("repo")
+        if url in NON_DISTRIBUTED_REPOS:
+            continue
         wanted = enforced_hooks(brepo, allowed)
         if not wanted:
             continue


### PR DESCRIPTION
## Context

Every consumer repo that adopted the shared `.pre-commit-config.yaml` baseline inherited two
`repo: local` hooks — `gitversion-canonical-drift` and `cliff-canonical-drift`. These are
**shared-standards-internal**: they run `scripts/check-canonical-drift.sh` (which sources
`scripts/lib/canonical.sh`) to assert the root canonical `GitVersion.yml`/`cliff.toml` match the
`templates/` copies handed to the fleet. Consumers have none of those files, so their pre-commit
fails on every run with `Executable scripts/check-canonical-drift.sh not found` — fleet-wide red
`Pre-commit`/`Lint` jobs.

Root cause: `pre-commit-merge.py` treats any hook **not** in the stack `HOOK_GROUPS` as universally
enforced (`hook_enforced` returns True for non-GOVERNED ids), so the `local` self-only hooks were
fanned out everywhere.

## Change

Add `NON_DISTRIBUTED_REPOS = {"local"}` and skip those repos in both `missing_items` and `merge`.
`local` hooks are inherently repo-relative and must never be distributed.

## Verification

Merging the baseline into an empty target now yields **0** `canonical-drift` occurrences (was 2),
and `--check` against a target lacking only the local hooks passes (rc=0). Other baseline items
(5 enforced repos/hooks) still merge as before.

Follow-up: strip the already-leaked `local` canonical-drift hooks from existing consumer configs
(separate fan-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
