### PR TITLE
style(audit-main.sh): strip trailing whitespace + fix EOF (pre-commit)

### DIFF
--- a/scripts/audit-main.sh
+++ b/scripts/audit-main.sh
@@ -30,28 +30,28 @@ conformant_count=0
 while IFS='|' read -r repo_name default_branch visibility; do
   ((row_count++))
   printf "\r[%d/%d] %s" "$row_count" "$total_repos" "$repo_name" >&2
-  
+
   # Fetch tree for repo (suppress errors for empty repos)
   tree_output=$(gh api "repos/chrysa/$repo_name/git/trees/$default_branch?recursive=1" 2>/dev/null | jq -r '.tree[].path // empty' || true)
-  
+
   if [ -z "$tree_output" ]; then
     error_repos_list="$error_repos_list$repo_name"$'\n'
     continue
   fi
-  
+
   # Build set of found files
   found=""
   has_workflows=0
   has_tests=0
   has_ci=0
-  
+
   while IFS= read -r path; do
     found="$found|$path"
     [[ "$path" =~ ^\.github/workflows/.*\.yml$ ]] && has_workflows=1
     [[ "$path" =~ (^|/)tests?/ || "$path" =~ (^|/)test_.*\.py$ || "$path" =~ \.test\. || "$path" =~ _test\.(py|go|ts|js)$ ]] && has_tests=1
     [[ "$path" =~ ^\.github/workflows/(ci|.*ci.*\.yml)$ ]] && has_ci=1
   done <<< "$tree_output"
-  
+
   # Archetype: no-package repos (config/meta or non-dev) are exempt from
   # pyproject/tests/release.yml (EXECUTION_STANDARD §2 archetype exemption).
   runtime=$(repo_runtime "$repo_name")
@@ -99,12 +99,12 @@ while IFS='|' read -r repo_name default_branch visibility; do
   if ! $no_package; then
     [[ $has_tests -eq 0 ]] && gaps+=("tests/")
   fi
-  
+
   # PUBLIC repos need LICENSE
   if [[ "$visibility" == "PUBLIC" ]]; then
     [[ ! "$found" =~ \|LICENSE ]] && gaps+=("LICENSE")
   fi
-  
+
   # HYGIENE files
   [[ ! "$found" =~ \|\.gitignore ]] && gaps+=(".gitignore")
   [[ ! "$found" =~ \|\.gitattributes ]] && gaps+=(".gitattributes")
@@ -113,29 +113,29 @@ while IFS='|' read -r repo_name default_branch visibility; do
   [[ ! "$found" =~ \|\.github/CODEOWNERS ]] && gaps+=(".github/CODEOWNERS")
   [[ ! "$found" =~ \|CONTRIBUTING\.md ]] && gaps+=("CONTRIBUTING.md")
   [[ ! "$found" =~ \|AGENTS\.md ]] && gaps+=("AGENTS.md")
-  
+
   # CANONICAL
   [[ ! "$found" =~ \.chrysa/STANDARDS\.md ]] && gaps+=(".chrysa/STANDARDS.md")
-  
+
   # WORKFLOW-specific (no-package archetypes have nothing to release)
   if ! $no_package; then
     [[ ! "$found" =~ \|\.github/workflows/release\.yml ]] && gaps+=("workflows/release.yml")
   fi
-  
+
   gap_count=${#gaps[@]}
   [[ $gap_count -eq 0 ]] && ((conformant_count++))
-  
+
   # Build JSON result
   gap_json=$(printf '%s\n' "${gaps[@]}" | jq -Rs . | jq -s . | tr -d '\n')
-  
+
   result=$(cat <<RESULT
 {"name":"$repo_name","branch":"$default_branch","visibility":"$visibility","gap_count":$gap_count,"gaps":$gap_json}
 RESULT
 )
-  
+
   current=$(cat "$RESULTS_FILE")
   echo "$current" | jq --argjson r "$result" '. += [$r]' > "$RESULTS_FILE"
-  
+
 done < "$REPOS_FILE"
 
 echo "" >&2
@@ -147,4 +147,3 @@ if [ -n "$error_repos_list" ]; then
 fi
 
 echo "Results saved to $RESULTS_FILE"
-


### PR DESCRIPTION
## Context

`scripts/audit-main.sh` carries trailing whitespace + a missing final newline, so the
`Lint & validate` job's `pre-commit/action` run modifies it (`trailing-whitespace`,
`end-of-file-fixer`) and exits non-zero — the repo's own CI is red.

## Change

Apply the two auto-fix hooks' output to `scripts/audit-main.sh`. Whitespace-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
