### PR TITLE
chore(ci): bump canonical action pins to match fleet (kill sync downgrade)

### DIFF
--- a/workflows/ci-node.yml
+++ b/workflows/ci-node.yml
@@ -51,7 +51,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
-            - uses: actions/checkout@v6.0.2
+            - uses: actions/checkout@v6.0.3
             - uses: actions/setup-node@v4
               with:
                   node-version: "22"
@@ -76,10 +76,10 @@ jobs:
             contents: read
             pull-requests: read
         steps:
-            - uses: actions/checkout@v6.0.2
+            - uses: actions/checkout@v6.0.3
               with:
                   fetch-depth: 0
-            - uses: chrysa/github-actions/sonar-scan-node@v1.0.12
+            - uses: chrysa/github-actions/sonar-scan-node@v1.1.3
               with:
                   sonar-token: ${{ secrets.SONAR_TOKEN }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -50,7 +50,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
-            - uses: actions/checkout@v6.0.2
+            - uses: actions/checkout@v6.0.3
 
             - name: Run tests via Docker
               run: make docker-test
@@ -65,11 +65,11 @@ jobs:
             contents: read
             pull-requests: read
         steps:
-            - uses: actions/checkout@v6.0.2
+            - uses: actions/checkout@v6.0.3
               with:
                   fetch-depth: 0
 
-            - uses: chrysa/github-actions/sonar-scan-python@v1.0.12
+            - uses: chrysa/github-actions/sonar-scan-python@v1.1.3
               with:
                   python-version: "3.14"
                   sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Context
The distributed canonical `ci-python.yml` / `ci-node.yml` pinned `actions/checkout@v6.0.2` and `sonar-scan-{python,node}@v1.0.12`, but consumer repos were already on `v6.0.3` / `v1.1.3` (Dependabot). So every `distribute-standards` run produced a **regressive sync PR downgrading** those pins (5 such PRs were open and held: fastapi-{autoload,pytest,query-optimizer,traceid}#11, wsmqtt-monitor#13).

## Change
Bump canonical pins to `v6.0.3` / `v1.1.3` to match the fleet → future syncs are no-ops. Both target tags verified to exist (`actions/checkout@v6.0.3`, `chrysa/github-actions@v1.1.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)