### PR TITLE
chore(compliance): refresh GitVersion + cliff conformance ledgers

### DIFF
--- a/compliance/cliff-conformance.json
+++ b/compliance/cliff-conformance.json
@@ -3,64 +3,64 @@
   "canonical_sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
   "rows": [
     {
-      "note": "cluster:7f25ddb2",
+      "note": "-",
       "repo": "agent-config",
-      "sha": "7f25ddb2d316eeb2963b818a13c1739d1f1e91c5",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:ae958672",
+      "note": "-",
       "repo": "ai-aggregator",
-      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:da9d50eb",
+      "note": "-",
       "repo": "audit-platform",
-      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "automations",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:ae958672",
+      "note": "-",
       "repo": "catalog",
-      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:efae6e8b",
+      "note": "-",
       "repo": "cdn-explorer",
-      "sha": "efae6e8b80474af235859838df883006de126496",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:dad52a93",
+      "note": "-",
       "repo": "chrysa-lib",
-      "sha": "dad52a93b6a777df951b0a15c342010d75119b84",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:da9d50eb",
+      "note": "-",
       "repo": "chrysa-portfolio-viz",
-      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:7f25ddb2",
+      "note": "-",
       "repo": "chrysa-skills",
-      "sha": "7f25ddb2d316eeb2963b818a13c1739d1f1e91c5",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:7f25ddb2",
+      "note": "-",
       "repo": "claude-config",
-      "sha": "7f25ddb2d316eeb2963b818a13c1739d1f1e91c5",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -69,52 +69,52 @@
       "status": "ok"
     },
     {
-      "note": "cluster:bd3fa5a7",
+      "note": "-",
       "repo": "container-webview",
-      "sha": "bd3fa5a70c4fd1666b82ac4a24e5d5bd50cfeb60",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "D-D",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:dad52a93",
+      "note": "-",
       "repo": "dev-nexus",
-      "sha": "dad52a93b6a777df951b0a15c342010d75119b84",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:da9d50eb",
+      "note": "-",
       "repo": "devtool",
-      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "discord-bot-back",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:fef0de10",
+      "note": "-",
       "repo": "discordium",
-      "sha": "fef0de1043b8ad16a82c2167cf87c97fec55eff3",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:ae958672",
+      "note": "-",
       "repo": "diy-stream-deck",
-      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:9f4111a8",
+      "note": "-",
       "repo": "django-app-forge",
-      "sha": "9f4111a8d9d0d0817baf99e784fbc39018b4485e",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -129,16 +129,16 @@
       "status": "ok"
     },
     {
-      "note": "cluster:53002a29",
+      "note": "-",
       "repo": "django-query-optimizer",
-      "sha": "53002a2908721c2b9d97a5c2dae5f137b7b679d1",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:da9d50eb",
+      "note": "-",
       "repo": "django-query-optimizer-vscode",
-      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -147,16 +147,16 @@
       "status": "ok"
     },
     {
-      "note": "cluster:7c58ea1d",
+      "note": "-",
       "repo": "doc-gen",
-      "sha": "7c58ea1d6fe391c9660b0dbf860aae6eac1b6e96",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "epub-sorter",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -183,148 +183,148 @@
       "status": "ok"
     },
     {
-      "note": "cluster:8198437c",
+      "note": "-",
       "repo": "feedback-gateway",
-      "sha": "8198437c05ba09365bad0bceb41f2c1b04f24adb",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:312aa423",
+      "note": "-",
       "repo": "floating-agent",
-      "sha": "312aa423935c155b943aa1b77832a0988fa6ba27",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:d33333b6",
+      "note": "-",
       "repo": "game-solver-platform",
-      "sha": "d33333b69fccf7e5850c85ac972ddc477d409636",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:a0f7796d",
+      "note": "-",
       "repo": "gaming-os",
-      "sha": "a0f7796d7af04cb71dc3f0ec7d643d4c47f64117",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:ae958672",
+      "note": "-",
       "repo": "genealogy-validator",
-      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:da9d50eb",
+      "note": "-",
       "repo": "gestureOS",
-      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "github-actions",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:0b80b91d",
+      "note": "-",
       "repo": "guideline-checker",
-      "sha": "0b80b91d8262373397c36e0a94e3d41865c3f66e",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:ae958672",
+      "note": "-",
       "repo": "lifeos",
-      "sha": "ae958672248e48625795cdd193176b8fcedb174f",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "linkendin-resume",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:da9d50eb",
+      "note": "-",
       "repo": "link-reader-bot",
-      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:e080c5e4",
+      "note": "-",
       "repo": "mediavault",
-      "sha": "e080c5e439f4586ed773f49d70388fb1430712d5",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:63f080e7",
+      "note": "-",
       "repo": "mirrador",
-      "sha": "63f080e7423afaecf41fd835950d27dc5b52a90b",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "my-resume",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:737fcf53",
+      "note": "-",
       "repo": "orchestrator",
-      "sha": "737fcf538b7085d9f356eb24a09f5fedbed948c2",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:da9d50eb",
+      "note": "-",
       "repo": "paperclip",
-      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "PO-GO-DEX",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:04dba1b5",
+      "note": "-",
       "repo": "pre-commit-hooks-changelog",
-      "sha": "04dba1b59d6a7d9d901071995a28939b4ee7e4b1",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:8d89ec29",
+      "note": "-",
       "repo": "pre-commit-tools",
-      "sha": "8d89ec29d96ce6acb6799b4c83fff1daf7c9460c",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:ec45836e",
+      "note": "-",
       "repo": "project-init",
-      "sha": "ec45836e59d2989bc4890cea854917cdc6091211",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:7f25ddb2",
+      "note": "-",
       "repo": "quality-gatekeeper",
-      "sha": "7f25ddb2d316eeb2963b818a13c1739d1f1e91c5",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:1226a50c",
+      "note": "-",
       "repo": "satisfactory-automated_calculator",
-      "sha": "1226a50c24df1d7b5edc40bdfb4f3d38482c6add",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:da9d50eb",
+      "note": "-",
       "repo": "satisfactory-factory-manager",
-      "sha": "da9d50eb1a837235ef68cfd150860ae6ff75581d",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:1249a5b1",
+      "note": "-",
       "repo": "server",
-      "sha": "1249a5b10e1440f8ecbd190b8be5e4b9fe6f143f",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -333,34 +333,34 @@
       "status": "ok"
     },
     {
-      "note": "cluster:7f832b27",
+      "note": "-",
       "repo": "sport-intelligence-hub",
-      "sha": "7f832b27cb299a9af27367adf3c52a1166345b6a",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:8d772a27",
+      "note": "-",
       "repo": "studioverse",
-      "sha": "8d772a27bc092302d3ea2808caca897284c0ac29",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "usefull-containers",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:363bf921",
+      "note": "-",
       "repo": "windows-autonome",
-      "sha": "363bf921e2cd6f2138640d87be35d57702a68ce0",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
-      "note": "cluster:a947ecc8",
+      "note": "-",
       "repo": "windows-docker-state-notification",
-      "sha": "a947ecc8506ff376ec4d10229810bd5209b34569",
-      "status": "drift"
+      "sha": "6c85f2fb274c5fe0fbda55cecb569cd66fad5da9",
+      "status": "ok"
     },
     {
       "note": "-",

--- a/compliance/gitversion-conformance.json
+++ b/compliance/gitversion-conformance.json
@@ -15,16 +15,16 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "audit-platform",
-      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "automations",
-      "sha": "71cf1ea5b3851ace17d49579010eee58d9f927a5",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "mode:ContinuousDeployment",
@@ -39,10 +39,10 @@
       "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "chrysa-lib",
-      "sha": "4bdf94c8550213115b134bb469b3c8881e40253c",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -75,16 +75,16 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "D-D",
-      "sha": "0f8f787fca0ec866716f2bc3e5852adb29080b8c",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "dev-nexus",
-      "sha": "dadad3b54d4eeb90fd48543b9b92cc0e693e837e",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "mode:ContinuousDeployment",
@@ -93,10 +93,10 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "discord-bot-back",
-      "sha": "123aca9216beba0e57cc5081b97a555452a0ec05",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "mode:ContinuousDeployment",
@@ -135,10 +135,10 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "django-query-optimizer-vscode",
-      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -147,16 +147,16 @@
       "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "doc-gen",
-      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "epub-sorter",
-      "sha": "74d2c3ca3ff4dcc1ae033d6c8160077ac0a75d39",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -219,10 +219,10 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "github-actions",
-      "sha": "4bdf94c8550213115b134bb469b3c8881e40253c",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "mode:ContinuousDeployment",
@@ -237,10 +237,10 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "linkendin-resume",
-      "sha": "9a3f2d8b3a336fc699b51e0628dfc04b63e29cf2",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -261,28 +261,28 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "my-resume",
-      "sha": "c07002308333ef9a084101df8a0fd94b4aa63547",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "orchestrator",
-      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "paperclip",
-      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "PO-GO-DEX",
-      "sha": "f9c25b5080a830ff59d0038f513405440a146e80",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "mode:ContinuousDeployment",
@@ -291,10 +291,10 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "pre-commit-tools",
-      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "mode:ContinuousDeployment",
@@ -309,10 +309,10 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "satisfactory-automated_calculator",
-      "sha": "dade0ac4efb9e1a3a54eb0f2d790f0cd1727768c",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "mode:ContinuousDeployment",
@@ -321,10 +321,10 @@
       "status": "drift"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "server",
-      "sha": "a7291c041468fbf9a915ff2c4d4ff4ddf8be4e18",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "-",
@@ -333,34 +333,34 @@
       "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "sport-intelligence-hub",
-      "sha": "08575b4cc67066b4c692eae3ded7b4f485c336fd",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "studioverse",
-      "sha": "57f84f7cabc1fdffcd7e688cfb7b8632b8a93f15",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "usefull-containers",
-      "sha": "85a7762dd669892be10ff4fc04bd4397864d3c52",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "windows-autonome",
-      "sha": "92f46bf524a482388278559592d3ff60c0b03722",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
-      "note": "schema:GitHubFlow-v5",
+      "note": "-",
       "repo": "windows-docker-state-notification",
-      "sha": "6417937bfbe40307894d19239c24cba55ef9fe18",
-      "status": "incompatible"
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
     },
     {
       "note": "-",


### PR DESCRIPTION
Regenerated `compliance/{gitversion,cliff}-conformance.json` via `audit-canonical-conformance.sh` after the #127 fan-out merged fleet-wide.

## Result
- **cliff.toml: 61/61 `ok`** — fully converged.
- **GitVersion: 36 `ok`** — every P0 `GitHubFlow`-incompatible repo resolved. 25 repos remain `drift` (compatible schema, cosmetic/version drift — the explicitly-deprioritized tail in #127, never P0).

Refs chrysa/shared-standards#127