### PR TITLE
chore(baseline): bump pre-commit-tools to v0.1.1-95 (makefile-check fix)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
   - id: react-no-async-in-useeffect
   - id: react-direct-dom
   repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-94
+  rev: v0.1.1-95
 - hooks:
   - id: gitleaks
   repo: https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
Baseline pinned v0.1.1-94, whose makefile-check can't resolve `include $(shell find ... *.Makefile)` → false 'tier missing required targets'. v0.1.1-95 has the include-resolution fix. Bumping the baseline so 'sync shared standards' PRs stop reverting consumer rev bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)