### PR TITLE
fix(ci-template): Sonar sources = ${PACKAGE}, not '.' (durable indexed-twice fix)

### DIFF
--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -77,6 +77,6 @@ jobs:
                   project-key: ${PROJECT_KEY}
                   organization: chrysa
                   project-name: ${REPO_NAME}
-                  sources: .
+                  sources: ${PACKAGE}
                   tests: ${TESTS}
                   coverage-report: coverage.xml


### PR DESCRIPTION
The distributed lean ci.yml sonar job hardcoded `sources: .`, so with `tests: ${TESTS}` SonarCloud double-indexes test files (`File ... can't be indexed twice`, exit 3) — and every distribute-standards sync re-applied it, reverting per-repo fixes. apply-repo-standard.sh already detects the package (`${PACKAGE}`) and substitutes it; use it for sonar sources (disjoint from tests). project-key already uses ${PROJECT_KEY}. Durable: future syncs now emit correct sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)