### PR TITLE
fix(distribute): substitute real repo name in Sonar CI block

### DIFF
--- a/.github/workflows/distribute-standards.yml
+++ b/.github/workflows/distribute-standards.yml
@@ -86,6 +86,8 @@ jobs:
                   echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
             - name: Apply standards
+              env:
+                  REPO_NAME: ${{ matrix.repo }}
               run: |
                   chmod +x shared-standards/scripts/*.sh
                   flags=""

--- a/scripts/apply-repo-standard.sh
+++ b/scripts/apply-repo-standard.sh
@@ -65,7 +65,7 @@ repo_is_public() { [[ "$(repo_field "$1" public)" == "true" ]]; }
 
 # Detect the top-level python package dir (has __init__.py, not tests/build/venv).
 detect_package() {
-    local repo="$1" name; name="$(basename "$repo")"
+    local repo="$1" name; name="${REPO_NAME:-$(basename "$repo")}"
     local d
     for d in "$repo"/*/; do
         d="${d%/}"; local b; b="$(basename "$d")"
@@ -84,7 +84,7 @@ deploy_file() {
 }
 
 deploy_hygiene() {
-    local repo="$1" name; name="$(basename "$repo")"
+    local repo="$1" name; name="${REPO_NAME:-$(basename "$repo")}"
     deploy_file "$TPL/.editorconfig"  "$repo/.editorconfig"
     deploy_file "$TPL/.gitattributes" "$repo/.gitattributes"
     if $DRY_RUN; then
@@ -108,7 +108,7 @@ deploy_hygiene() {
 # Release tooling + repo meta. Create-if-absent only — never clobber an existing
 # CHANGELOG (real history), opencode.json, AGENTS.md, etc.
 deploy_release_tooling() {
-    local repo="$1" name; name="$(basename "$repo")"
+    local repo="$1" name; name="${REPO_NAME:-$(basename "$repo")}"
     local pairs=(
         "CHANGELOG.md:CHANGELOG.md"
         "cliff.toml:cliff.toml"
@@ -148,7 +148,7 @@ ci_is_canonical() {
 }
 
 deploy_stack_ci() {
-    local repo="$1" name; name="$(basename "$repo")"
+    local repo="$1" name; name="${REPO_NAME:-$(basename "$repo")}"
     local tpl dest="$repo/.github/workflows/ci.yml"
     local pkg sources tests project_key
     if ci_is_canonical "$dest"; then
@@ -167,7 +167,7 @@ deploy_stack_ci() {
         warn "no python/node stack detected · CI skipped"
         return
     fi
-    project_key="chrysa_${name}"
+    project_key="${PROJECT_KEY:-chrysa_${name}}"
     if $DRY_RUN; then
         info "[dry-run] would write ci.yml from $(basename "$tpl") (pkg=$pkg key=$project_key)"
         return
@@ -222,7 +222,7 @@ merge_precommit() {
 }
 
 apply_one() {
-    local repo="$1" name; name="$(basename "$repo")"
+    local repo="$1" name; name="${REPO_NAME:-$(basename "$repo")}"
     [[ -d "$repo" ]]      || { err "$repo absent"; return 2; }
     [[ -d "$repo/.git" ]] || { warn "$name: not a git repo · skip"; return 0; }
     log "═══ $name ═══"


### PR DESCRIPTION
## Problem

The `distribute-standards` workflow checks every target repo out into a fixed directory named `target` (`path: target`). `apply-repo-standard.sh` derived `name` from `basename "$repo"` = `target` for **all** repos, so the generated `ci.yml` Sonar block shipped literal placeholders:

```yaml
project-key: chrysa_target
project-name: target
```

Every `chore: sync chrysa shared standards` PR therefore tried to **regress** each repo's correct per-repo Sonar key back to the placeholder (re-introducing the `indexed twice` / wrong-project defect). The current 32-repo sync wave all carry this regression.

## Fix

- Honor the **already-documented** `REPO_NAME` / `PROJECT_KEY` env overrides in `apply-repo-standard.sh` (header advertised them; code ignored them).
- Export `REPO_NAME: ${{ matrix.repo }}` from the *Apply standards* step so substitution uses the authoritative repo name.
- `PACKAGE`/`sources` auto-detection unchanged.

Result: `project-key: chrysa_<repo>`, `project-name: <repo>`. Fallback to `basename` preserved when env unset.

After merge, re-run the distributor to regenerate the sync PRs cleanly; the current 32 regressive ones should be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)