### PR TITLE
docs(skill): document D-0004 private-distribution fetch (BuildKit secret)

### DIFF
--- a/.claude/skills/dockerfile-multistage/SKILL.md
+++ b/.claude/skills/dockerfile-multistage/SKILL.md
@@ -85,3 +85,35 @@ build-all:
 - Installer pip dans le stage `production`
 - Créer ou activer un venv (`virtualenv`, `python -m venv`, `pip install --user`)
 - Copier `pyproject.toml`/`setup.py` dans `production`
+
+## Private chrysa-lib distribution fetch (D-0004)
+
+A package that depends on a private `chrysa-lib` distribution via a `git+https` pin
+(e.g. `chrysa-codegen @ git+https://github.com/chrysa/chrysa-lib@<sha>#subdirectory=...`)
+cannot install in a vanilla Docker build: pip shells out to `git`, which has no credential
+and fails with `could not read Username for 'https://github.com'`.
+
+Per chrysa-lib `DECISIONS.md` D-0004, fetch the private dependency with a BuildKit secret —
+never an `ARG`/`ENV`/`COPY` (those persist the token in an image layer).
+
+`Dockerfile.test`:
+```dockerfile
+# syntax=docker/dockerfile:1
+RUN --mount=type=secret,id=ghtoken,required=true \
+    git config --global url."https://x-access-token:$(cat /run/secrets/ghtoken)@github.com/".insteadOf "https://github.com/" \
+ && pip install --no-cache-dir -e ".[dev]" \
+ && rm -f /root/.gitconfig
+```
+The token is mounted (never written to a layer); the `rm -f /root/.gitconfig` in the same
+`RUN` guarantees the rewritten URL (which embeds the token) does not survive in the layer.
+
+`make docker-test` target:
+```makefile
+docker-test: ## Run tests in Docker (CI parity; private dep fetch via D-0004 BuildKit secret)
+	GH_TOKEN="$${GH_TOKEN:-$${GITHUB_TOKEN:-$$(gh auth token 2>/dev/null)}}" \
+		DOCKER_BUILDKIT=1 docker build -f Dockerfile.test --secret id=ghtoken,env=GH_TOKEN -t <image>-test .
+	docker run --rm <image>-test
+```
+Local dev resolves the token from `gh auth token`; CI passes its `GH_TOKEN`/`GITHUB_TOKEN`.
+Defer to a private PyPI index when a private distribution reaches >=3 consumers or needs
+independent semver (D-0004 revisit trigger).


### PR DESCRIPTION
Propagation of chrysa-lib ADR D-0004: documents the BuildKit-secret + `git url.insteadOf` pattern for fetching private `chrysa-lib` distributions in `Dockerfile.test` and the `docker-test` Make target, so future consumers inherit it via the dockerfile-multistage skill.

Refs chrysa/chrysa-lib#113