### PR TITLE
feat(sonar): file findings as GitHub issues + fix coverage upload

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -66,6 +66,10 @@
   color: "362d59"
   description: "Auto-created from a Sentry issue"
 
+- name: "sonar"
+  color: "4c9bd6"
+  description: "Raised from a SonarCloud finding"
+
 - name: "standards-sync"
   color: "5319e7"
   description: "Automated chrysa shared-standards distribution"

--- a/docs/audits/sonar-findings-20260622.json
+++ b/docs/audits/sonar-findings-20260622.json
@@ -1,0 +1,312 @@
+{
+  "agent-config": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **18** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_agent-config`](https://sonarcloud.io/project/issues?id=chrysa_agent-config&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 11 | `scripts/notion_roadmap_sync.py:269` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 6 | `skills/read/scripts/fetch_feishu.py:99` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 1 | `scripts/generate_agents_md.py:135` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_agent-config&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 17,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "ai-aggregator": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_ai-aggregator`](https://sonarcloud.io/project/issues?id=chrysa_ai-aggregator&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S8409` | CODE_SMELL | BLOCKER | 2 | `api/routers/health.py:14` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_ai-aggregator&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 2,
+      "high": 0,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "cdn-explorer": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_cdn-explorer`](https://sonarcloud.io/project/issues?id=chrysa_cdn-explorer&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/crawler.py:104` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_cdn-explorer&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "chrysa-lib": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_chrysa-lib`](https://sonarcloud.io/project/issues?id=chrysa_chrysa-lib&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S6418` | VULNERABILITY | BLOCKER | 1 | `packages/python/auth/tests/test_jwt.py:9` |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `packages/typescript/api/src/client.ts:24` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_chrysa-lib&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "claude-config": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **12** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_claude-config`](https://sonarcloud.io/project/issues?id=chrysa_claude-config&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 4 | `multi-machine/snapshot/configure.sh:247` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 4 | `claude/hooks/prompt-validator.py:513` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 3 | `claude/hooks/prompt-validator.py:65` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 1 | `claude/hooks/error-tracker.py:71` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_claude-config&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 11,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "coach": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_coach`](https://sonarcloud.io/project/issues?id=chrysa_coach&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:216` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:222` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_coach&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 2,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "container-webview": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_container-webview`](https://sonarcloud.io/project/issues?id=chrysa_container-webview&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `code/src/domain/health/deriveHealth.ts:30` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/app/routers/metrics.py:51` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_container-webview&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 2,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "D-D": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_D-D`](https://sonarcloud.io/project/issues?id=chrysa_D-D&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `css:S4657` | BUG | CRITICAL | 1 | `code/src/app.css:33` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_D-D&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "dev-nexus": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **26** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_dev-nexus`](https://sonarcloud.io/project/issues?id=chrysa_dev-nexus&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S8410` | CODE_SMELL | BLOCKER | 14 | `backend/src/app/api/v1/auth.py:21` |\n| `python:S8409` | CODE_SMELL | BLOCKER | 8 | `backend/src/app/api/v1/auth.py:28` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 2 | `docker-compose.yml:9` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `backend/src/app/api/v1/projects.py:50` |\n| `python:S2208` | CODE_SMELL | CRITICAL | 1 | `backend/alembic/env.py:13` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_dev-nexus&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 24,
+      "high": 2,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "discord-bot-back": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_discord-bot-back`](https://sonarcloud.io/project/issues?id=chrysa_discord-bot-back&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `githubactions:S7630` | VULNERABILITY | BLOCKER | 1 | `.github/workflows/enforce-feature-branch.yml:16` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_discord-bot-back&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 0,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "discordium": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **10** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_discordium`](https://sonarcloud.io/project/issues?id=chrysa_discordium&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 4 | `backend/app/db/base.py:19` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci.yml:83` |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 2 | `frontend/src/domain/queries.ts:52` |\n| `typescript:S2004` | CODE_SMELL | CRITICAL | 1 | `frontend/src/game/scenes/CombatScene.ts:93` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_discordium&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 3,
+      "high": 7,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "django-autoload": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_django-autoload`](https://sonarcloud.io/project/issues?id=chrysa_django-autoload&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `secrets:S6687` | VULNERABILITY | BLOCKER | 1 | `examples/demo/demo_project/settings.py:16` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_django-autoload&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 0,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "epub-sorter": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_epub-sorter`](https://sonarcloud.io/project/issues?id=chrysa_epub-sorter&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S2638` | CODE_SMELL | CRITICAL | 2 | `cli.py:23` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `gui.py:152` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_epub-sorter&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 3,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "floating-agent": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_floating-agent`](https://sonarcloud.io/project/issues?id=chrysa_floating-agent&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `floating_agent/plugins/notion.py:76` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_floating-agent&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "gaming-os": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **4** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_gaming-os`](https://sonarcloud.io/project/issues?id=chrysa_gaming-os&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci.yml:94` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `backend/app/routers/sessions.py:61` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_gaming-os&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 3,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "genealogy-validator": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **13** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_genealogy-validator`](https://sonarcloud.io/project/issues?id=chrysa_genealogy-validator&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 11 | `scripts/quality_gate.py:217` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:213` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 1 | `.vscode/PythonImportHelper-v2-Completion.json:1001` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_genealogy-validator&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 12,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "github-actions": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_github-actions`](https://sonarcloud.io/project/issues?id=chrysa_github-actions&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `githubactions:S7630` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci-fullstack.yml:107` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_github-actions&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 3,
+      "high": 0,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "guideline-checker": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **13** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_guideline-checker`](https://sonarcloud.io/project/issues?id=chrysa_guideline-checker&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 10 | `guideline_checker/guidelines.py:191` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 2 | `guideline_checker/web/central.py:158` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `guideline_checker/reporters/html.py:371` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_guideline-checker&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 2,
+      "high": 11,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "linkendin-resume": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_linkendin-resume`](https://sonarcloud.io/project/issues?id=chrysa_linkendin-resume&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `app/src/components/contact/ContactModal.tsx:35` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_linkendin-resume&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "link-reader-bot": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_link-reader-bot`](https://sonarcloud.io/project/issues?id=chrysa_link-reader-bot&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 1 | `ui/src/pages/RecapPage.tsx:23` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/routers/webhooks.py:33` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_link-reader-bot&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 2,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "mediavault": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_mediavault`](https://sonarcloud.io/project/issues?id=chrysa_mediavault&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:202` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:206` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 1 | `.github/workflows/ci.yml:144` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_mediavault&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 2,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "mirrador": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **8** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_mirrador`](https://sonarcloud.io/project/issues?id=chrysa_mirrador&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 3 | `frontend/src/App.tsx:77` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/e2e.yml:27` |\n| `python:S6418` | VULNERABILITY | BLOCKER | 2 | `api/config.py:12` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_mirrador&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 5,
+      "high": 3,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "my-resume": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_my-resume`](https://sonarcloud.io/project/issues?id=chrysa_my-resume&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `css:S4657` | BUG | CRITICAL | 1 | `code/src/app.css:23` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_my-resume&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "PO-GO-DEX": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_PO-GO-DEX`](https://sonarcloud.io/project/issues?id=chrysa_PO-GO-DEX&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:202` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:206` |\n| `css:S4657` | BUG | CRITICAL | 1 | `code/src/app.css:33` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_PO-GO-DEX&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 3,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "pre-commit-hooks-changelog": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_pre-commit-hooks-changelog`](https://sonarcloud.io/project/issues?id=chrysa_pre-commit-hooks-changelog&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3516` | CODE_SMELL | BLOCKER | 1 | `pre_commit_hook/generate_changelog.py:81` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `formater.py:95` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_pre-commit-hooks-changelog&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "pre-commit-tools": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **7** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_pre-commit-tools`](https://sonarcloud.io/project/issues?id=chrysa_pre-commit-tools&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 5 | `pre_commit_hooks/makefile_check.py:178` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `pre_commit_hooks/makefile_check.py:152` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 1 | `pre_commit_hooks/requirements_sort.py:163` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_pre-commit-tools&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 6,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "satisfactory-automated_calculator": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **5** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_satisfactory-automated_calculator`](https://sonarcloud.io/project/issues?id=chrysa_satisfactory-automated_calculator&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `javascript:S3776` | CODE_SMELL | CRITICAL | 5 | `scripts/bottleneck-analyzer.js:105` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_satisfactory-automated_calculator&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 5,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "shared-standards": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **13** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_shared-standards`](https://sonarcloud.io/project/issues?id=chrysa_shared-standards&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 9 | `scripts/audit-docker-compliance.sh:107` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 3 | `scripts/pre-commit-merge.py:214` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:216` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_shared-standards&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 13,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "usefull-containers": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **4** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_usefull-containers`](https://sonarcloud.io/project/issues?id=chrysa_usefull-containers&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 2 | `pytest/docker-cmd.sh:27` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:202` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:206` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_usefull-containers&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 4,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "windows-autonome": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **8** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_windows-autonome`](https://sonarcloud.io/project/issues?id=chrysa_windows-autonome&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 3 | `scripts/scan/scan-debian.sh:60` |\n| `powershelldre:S8659` | CODE_SMELL | CRITICAL | 2 | `scripts/lib/software.ps1:12` |\n| `powershelldre:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/scan/scan-os.ps1:73` |\n| `json:S6418` | VULNERABILITY | BLOCKER | 1 | `annexes/vscode-settings.json:168` |\n| `secrets:S6690` | VULNERABILITY | BLOCKER | 1 | `annexes/vscode-settings.json:168` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_windows-autonome&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 2,
+      "high": 6,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "windows-docker-state-notification": {
+    "title": "SonarCloud: blocker & critical findings",
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_windows-docker-state-notification`](https://sonarcloud.io/project/issues?id=chrysa_windows-docker-state-notification&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S2190` | BUG | BLOCKER | 1 | `src/docker_notification.py:24` |\n| `python:S6903` | CODE_SMELL | CRITICAL | 1 | `src/docker_notification.py:25` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_windows-docker-state-notification&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 1,
+      "medium": 0,
+      "low": 0
+    }
+  }
+}

--- a/scripts/sonar-findings.py
+++ b/scripts/sonar-findings.py
@@ -7,7 +7,7 @@ Queries the SonarCloud REST API (sonarcloud.io, org `chrysa`) for unresolved iss
 given severities, grouped into ONE consolidated entry per active dev repo. Output matches the
 shape consumed by file-compliance-issues.sh:
 
-    { "<repo>": { "title": str, "body": markdown, "counts": {critical,high,med,low} }, ... }
+    { "<repo>": { "title": str, "body": markdown, "counts": {critical,high,medium,low} }, ... }
 
 Pipe the output into file-compliance-issues.sh to open one idempotent issue per repo:
 

--- a/scripts/sonar-findings.py
+++ b/scripts/sonar-findings.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""sonar-findings.py — emit a findings JSON of SonarCloud BLOCKER/CRITICAL issues per repo.
+
+Source: chrysa/shared-standards/scripts/sonar-findings.py
+
+Queries the SonarCloud REST API (sonarcloud.io, org `chrysa`) for unresolved issues of the
+given severities, grouped into ONE consolidated entry per active dev repo. Output matches the
+shape consumed by file-compliance-issues.sh:
+
+    { "<repo>": { "title": str, "body": markdown, "counts": {critical,high,med,low} }, ... }
+
+Pipe the output into file-compliance-issues.sh to open one idempotent issue per repo:
+
+    python3 scripts/sonar-findings.py --out docs/audits/sonar-findings-YYYYMMDD.json
+    bash scripts/file-compliance-issues.sh --findings=docs/audits/sonar-findings-YYYYMMDD.json \
+         --labels=sonar,chore
+
+Auth: SONAR_TOKEN env var (read-only; HTTP GET only — safe to run on host).
+
+Usage:
+    sonar-findings.py [--severities=BLOCKER,CRITICAL] [--only=repo,repo] [--out=PATH]
+
+Exit: 0 ok · 1 error · 2 missing dependency/token
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+
+API = "https://sonarcloud.io/api"
+ORG = os.environ.get("CHRYSA_ORG", "chrysa")
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+STD_ROOT = os.path.dirname(SCRIPT_DIR)
+
+# SonarCloud severity -> file-compliance-issues.sh counts bucket.
+SEV_BUCKET = {"BLOCKER": "critical", "CRITICAL": "high", "MAJOR": "medium", "MINOR": "low",
+              "INFO": "low"}
+MAX_DETAIL_ROWS = 50  # cap per-rule example detail in the issue body
+
+
+def _stderr(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def _api_get(path: str, params: dict, token: str) -> dict:
+    url = f"{API}/{path}?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url)
+    # SonarCloud accepts the token as HTTP Basic username with empty password.
+    auth = base64.b64encode(f"{token}:".encode()).decode()
+    req.add_header("Authorization", f"Basic {auth}")
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode())
+
+
+def list_dev_repos(only: str | None) -> list[str]:
+    cmd = [os.path.join(SCRIPT_DIR, "list-dev-repos.sh"), "--lines"]
+    if only:
+        cmd += ["--only", only]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    return [r.strip() for r in out.splitlines() if r.strip()]
+
+
+def project_key_map(token: str) -> dict[str, str]:
+    """Lowercased Sonar project key -> real key (keys diverge from repo case)."""
+    keys: dict[str, str] = {}
+    page = 1
+    while True:
+        d = _api_get("components/search_projects",
+                     {"organization": ORG, "ps": 200, "p": page}, token)
+        for c in d.get("components", []):
+            keys[c["key"].lower()] = c["key"]
+        paging = d.get("paging", {})
+        if paging.get("pageIndex", page) * paging.get("pageSize", 200) >= paging.get("total", 0):
+            break
+        page += 1
+    return keys
+
+
+def fetch_issues(key: str, severities: str, token: str) -> list[dict]:
+    issues: list[dict] = []
+    page = 1
+    while True:
+        d = _api_get("issues/search",
+                     {"componentKeys": key, "resolved": "false", "severities": severities,
+                      "ps": 500, "p": page}, token)
+        issues.extend(d.get("issues", []))
+        total = d.get("total", 0)
+        if page * 500 >= total or not d.get("issues"):
+            break
+        page += 1
+    return issues
+
+
+def short_component(comp: str) -> str:
+    """`chrysa_repo:api/foo.py` -> `api/foo.py`."""
+    return comp.split(":", 1)[1] if ":" in comp else comp
+
+
+def build_entry(repo: str, key: str, issues: list[dict], severities: str) -> dict:
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    by_rule: dict[str, dict] = defaultdict(
+        lambda: {"type": "", "severity": "", "count": 0, "example": ""})
+    for it in issues:
+        counts[SEV_BUCKET.get(it.get("severity", "MINOR"), "low")] += 1
+        r = by_rule[it.get("rule", "?")]
+        r["count"] += 1
+        r["type"] = it.get("type", "")
+        # Keep the highest-severity example (BLOCKER ranks above CRITICAL).
+        if r["severity"] != "BLOCKER":
+            r["severity"] = it.get("severity", "")
+        if not r["example"]:
+            loc = short_component(it.get("component", ""))
+            line = it.get("line")
+            r["example"] = f"{loc}:{line}" if line else loc
+
+    deep = (f"https://sonarcloud.io/project/issues?id={urllib.parse.quote(key)}"
+            f"&resolved=false&severities={severities}")
+    total = len(issues)
+
+    lines = [
+        f"SonarCloud reports **{total}** unresolved `{severities}` finding(s) for "
+        f"[`{key}`]({deep}).",
+        "",
+        "_Auto-filed from the SonarCloud API. One consolidated issue per repo; "
+        "resolve findings in SonarCloud and they drop off on the next run._",
+        "",
+        "| Rule | Type | Severity | Count | Example |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    rows = sorted(by_rule.items(), key=lambda kv: -kv[1]["count"])
+    for rule, r in rows[:MAX_DETAIL_ROWS]:
+        lines.append(
+            f"| `{rule}` | {r['type']} | {r['severity']} | {r['count']} | `{r['example']}` |")
+    if len(rows) > MAX_DETAIL_ROWS:
+        lines.append("")
+        lines.append(f"_…and {len(rows) - MAX_DETAIL_ROWS} more rule(s); "
+                     f"see the [full list on SonarCloud]({deep})._")
+    lines += ["", f"**Triage in SonarCloud:** {deep}"]
+
+    return {
+        "title": "SonarCloud: blocker & critical findings",
+        "body": "\n".join(lines),
+        "counts": counts,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--severities", default="BLOCKER,CRITICAL")
+    ap.add_argument("--only", default=None, help="comma-separated repo subset")
+    ap.add_argument("--out", default=None, help="write JSON here (default: stdout)")
+    args = ap.parse_args()
+
+    token = os.environ.get("SONAR_TOKEN")
+    if not token:
+        _stderr("SONAR_TOKEN not set"); return 2
+
+    repos = list_dev_repos(args.only)
+    keymap = project_key_map(token)
+
+    findings: dict[str, dict] = {}
+    skipped_noproj, skipped_clean = [], []
+    for repo in repos:
+        key = keymap.get(f"{ORG}_{repo}".lower())
+        if not key:
+            skipped_noproj.append(repo); continue
+        issues = fetch_issues(key, args.severities, token)
+        if not issues:
+            skipped_clean.append(repo); continue
+        findings[repo] = build_entry(repo, key, issues, args.severities)
+        c = findings[repo]["counts"]
+        _stderr(f"  {repo:35} {len(issues):4} findings "
+                f"(blocker={c['critical']} critical={c['high']})")
+
+    payload = json.dumps(findings, indent=2, ensure_ascii=False)
+    if args.out:
+        os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(payload + "\n")
+        _stderr(f"\nwrote {args.out}")
+    else:
+        print(payload)
+
+    _stderr(f"\nrepos with findings: {len(findings)} · clean: {len(skipped_clean)} · "
+            f"no Sonar project: {len(skipped_noproj)}")
+    if skipped_noproj:
+        _stderr("  no project: " + ", ".join(skipped_noproj))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflows/ci-python.yml
+++ b/workflows/ci-python.yml
@@ -55,6 +55,18 @@ jobs:
             - name: Run tests via Docker
               run: make docker-test
 
+            # Coverage is generated inside the test job; the sonar job runs on a
+            # separate runner, so the report must travel as an artifact. The name
+            # MUST be test-results-<python-version> — that is exactly what
+            # sonar-scan-python downloads into reports/.
+            - name: Upload coverage report
+              if: always()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: test-results-3.14
+                  path: coverage.xml
+                  if-no-files-found: warn
+
     sonar:
         name: SonarCloud
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -79,4 +91,6 @@ jobs:
                   project-name: ${REPO_NAME}
                   sources: ${PACKAGE}
                   tests: ${TESTS}
-                  coverage-report: coverage.xml
+                  # Downloaded from the test-results-3.14 artifact into reports/
+                  # by the action; matches sonar-scan-python's default path.
+                  coverage-report: reports/coverage.xml


### PR DESCRIPTION
## What

Two related deliverables for SonarCloud → GitHub.

### 1. SonarCloud findings → GitHub issues
`scripts/sonar-findings.py` pulls **BLOCKER+CRITICAL** findings per `status:dev` repo and emits the findings-JSON consumed by the existing `file-compliance-issues.sh` — one **consolidated, idempotent** issue per repo (title is count-free, so reruns dedup). Already run: **31 issues filed covering 174 findings** across the dev fleet, all labelled `sonar` (new label added to `labels.yml`).

```
python3 scripts/sonar-findings.py --out docs/audits/sonar-findings-YYYYMMDD.json
bash scripts/file-compliance-issues.sh --findings=…json --labels=sonar
```

### 2. Fix coverage upload in the canonical CI template
`workflows/ci-python.yml`: the `test` and `sonar` jobs run on **separate runners**. `make docker-test` writes `coverage.xml` on the test runner, but the sonar job checked out fresh and never saw it → **60 of 61 dev repos reported no coverage** to SonarCloud. Fix: `test` uploads `coverage.xml` as the `test-results-3.14` artifact (what `sonar-scan-python` downloads into `reports/`); `sonar` reads `reports/coverage.xml`.

**Pilot:** chrysa/guideline-checker#170 (open) — verified end-to-end: coverage.xml now reaches the sonar job and all 21 file paths resolve (after an additional per-repo fix: editable install + `relative_files`, see that PR). Fleet fan-out tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)