### PR TITLE
feat(standards): codify Playwright E2E scaffold for fullstack tier

### DIFF
--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -99,6 +99,25 @@ infrastructure lands.
 | `web-typecheck` | — | — | ✅ | — | Type-check the frontend |
 | `e2e` | — | — | ✅ | — | Run end-to-end tests (Playwright) |
 
+**`e2e` — canonical form (local dev, opt-in).** Playwright runs inside the
+official docker image (never on the host); the stack must be up first
+(`make docker-up`). It is **not** a CI gate. Scaffold to copy:
+`shared-standards/templates/e2e/` (`playwright.config.ts` + auth-free
+`smoke.spec.ts`; optional seeded-auth `fixtures.ts.example`). Reference
+implementation: `chrysa/discordium`.
+
+```makefile
+e2e: ## Run Playwright E2E tests (stack must be up: make docker-up)
+	docker run --rm --network host \
+		-v $(PWD)/$(FRONTEND_DIR):/app -w /app \
+		-e E2E_BASE_URL=http://localhost:$(E2E_PORT) \
+		mcr.microsoft.com/playwright:v1.60.0-noble \
+		sh -c "npm ci --silent && npx playwright test"
+
+e2e-headed: ## Run Playwright with browser UI (debug)
+	cd $(FRONTEND_DIR) && npx playwright test --headed
+```
+
 **Tier definitions:**
 - **`lib`** — pure package, no `docker-compose.yml`. `lint/format/typecheck/test/test-cov`
   run the tool directly via the venv created by `make install`; the recommended

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ templates/
     tasks.python.json           # VS Code tasks template for Python projects
     tasks.fullstack.json        # VS Code tasks template for full-stack projects (Python + TS)
     README.md                   # Documentation and keyboard shortcuts
+  e2e/                          # Playwright E2E scaffold for fullstack repos (local dev, see EXECUTION_STANDARD §1.3b)
+    playwright.config.ts
+    tests/e2e/smoke.spec.ts     # auth-free smoke + optional fixtures.ts.example
   issue-templates/
     bug.md
     feature.md

--- a/templates/e2e/README.md
+++ b/templates/e2e/README.md
@@ -1,0 +1,42 @@
+# E2E scaffold (Playwright) — chrysa `fullstack` standard
+
+Local-dev end-to-end tests. Playwright runs **inside the official docker image**
+via `make e2e` — never on the host (per chrysa execution rules). Not wired into
+CI; it is a `make`-driven dev-loop check.
+
+## Wire it into a fullstack repo
+
+1. Copy this folder's contents into your frontend dir:
+   ```
+   frontend/playwright.config.ts
+   frontend/tests/e2e/smoke.spec.ts
+   ```
+   (Auth-gated app? Also copy `fixtures.ts.example` → `frontend/tests/e2e/fixtures.ts`.)
+
+2. Add the dev dependency + scripts to `frontend/package.json`:
+   ```jsonc
+   "devDependencies": { "@playwright/test": "^1.60.0" },
+   "scripts": {
+     "test:e2e": "playwright test",
+     "test:e2e:headed": "playwright test --headed"
+   }
+   ```
+
+3. Set `baseURL`'s default port in `playwright.config.ts` to your stack's
+   frontend port (the `docker-compose.yml` published port).
+
+4. Add the canonical `e2e` / `e2e-headed` targets to your `Makefile`
+   (see `EXECUTION_STANDARD.md` §1.3b), setting `E2E_PORT` to the same port.
+
+5. Ignore artefacts: `frontend/playwright-report/`, `frontend/test-results/`.
+
+## Run
+
+```bash
+make docker-up   # bring the stack up (frontend on the configured port)
+make e2e         # Playwright in docker against the running stack
+make docker-down
+```
+
+Failures leave a trace + screenshots under `frontend/playwright-report/`.
+Reference implementation: `chrysa/discordium`.

--- a/templates/e2e/playwright.config.ts
+++ b/templates/e2e/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright E2E configuration (chrysa fullstack standard — local dev).
+ *
+ * Tests target the production-like docker stack started by `make docker-up`.
+ * Set the default port below to your stack's frontend port (the nginx/Vite
+ * service exposed by docker-compose, e.g. discordium 9101, portfolio-viz 8080).
+ *
+ * E2E_BASE_URL is overridable so the same suite can later run against staging
+ * or read-only prod smoke checks without editing this file.
+ *
+ * Run with `make e2e` (Playwright runs inside the official docker image — never
+ * on the host). The stack must be up first.
+ */
+
+const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:8080"; // adjust port to your stack
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/templates/e2e/tests/e2e/fixtures.ts.example
+++ b/templates/e2e/tests/e2e/fixtures.ts.example
@@ -1,0 +1,34 @@
+/**
+ * OPTIONAL — auth helpers for repos with seeded dev accounts.
+ *
+ * Drop the `.example` suffix and adjust selectors/creds if your app is
+ * auth-gated. Pattern proven in chrysa/discordium: the stack seeds default
+ * accounts on startup (e.g. SEED_DEFAULTS=1 in docker-compose), and specs log
+ * in through the real login form. Repos without auth (e.g. portfolio-viz) do
+ * not need this file.
+ */
+
+import { expect, type Page } from "@playwright/test";
+
+export const ADMIN_CREDS = {
+  username: process.env.E2E_ADMIN_USER ?? "admin",
+  password: process.env.E2E_ADMIN_PASS ?? "change-me",
+} as const;
+
+/** Log in via the username/password form and wait for the post-login nav. */
+export async function login(
+  page: Page,
+  creds: { username: string; password: string },
+): Promise<void> {
+  await page.goto("/login");
+  await page.getByPlaceholder(/identifiant|username|email/i).fill(creds.username);
+  await page.locator('input[type="password"]').fill(creds.password);
+  await page.getByRole("button", { name: /login|sign in|connexion|entrer/i }).click();
+  await expect(page).not.toHaveURL(/\/login$/, { timeout: 10_000 });
+}
+
+/** Reset auth state between tests. */
+export async function clearAuth(page: Page): Promise<void> {
+  await page.context().clearCookies();
+  await page.addInitScript(() => window.localStorage.clear());
+}

--- a/templates/e2e/tests/e2e/smoke.spec.ts
+++ b/templates/e2e/tests/e2e/smoke.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Auth-free smoke: the app boots and renders without a fatal console error.
+ *
+ * This is the minimal starting point every fullstack repo gets. Replace the
+ * landing assertion with something specific to your app (a wordmark, a heading,
+ * the main canvas/svg). For auth-gated apps, add seeded-account fixtures —
+ * see fixtures.ts.example.
+ */
+
+test.describe("smoke", () => {
+  test("landing page renders without fatal console errors", async ({ page }) => {
+    const fatal: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") fatal.push(msg.text());
+    });
+    page.on("pageerror", (err) => fatal.push(err.message));
+
+    const response = await page.goto("/");
+    expect(response?.ok(), `GET / returned ${response?.status()}`).toBeTruthy();
+
+    // App root mounted (adjust selector to your app shell).
+    await expect(page.locator("body")).toBeVisible();
+
+    // No uncaught runtime / console errors during initial render.
+    expect(fatal, `console/page errors:\n${fatal.join("\n")}`).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Codifies the `e2e` Makefile target (named-only in EXECUTION_STANDARD §1.3b) into a real, reusable standard:

- **`templates/e2e/`** — copy-into-repo scaffold derived from the discordium reference:
  - `playwright.config.ts` (env-overridable `E2E_BASE_URL`, single worker, traces/screenshots/video on failure)
  - `tests/e2e/smoke.spec.ts` — auth-free smoke (boots `/`, no fatal console errors)
  - `tests/e2e/fixtures.ts.example` — optional seeded-auth helpers for auth-gated apps
  - `README.md` — wiring steps
- **EXECUTION_STANDARD.md §1.3b** — `e2e` row fleshed out with the canonical docker-runner `e2e`/`e2e-headed` snippet + pointer to the scaffold.
- **README.md** — templates index updated.

## Why

Only 3/10 fullstack repos had Playwright, each hand-wired. This makes the proven discordium pattern copy-pasteable.

## Scope

- **Local dev / opt-in only** — Playwright runs inside the official docker image via `make e2e`, never on the host. **Not** a CI gate (Actions minutes + flakiness).
- Pilot validation lands separately on `chrysa-portfolio-viz`.
- Fleet-wide fan-out is out of scope (later, repo by repo, rule 1+2).

Refs #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)