### PR TITLE
docs(standards): require constants in external YAML, ban hardcoded values

### DIFF
--- a/compliance/gitversion-conformance.json
+++ b/compliance/gitversion-conformance.json
@@ -2,66 +2,371 @@
   "canonical": "GitVersion.yml",
   "canonical_sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
   "rows": [
-    {"repo":"agent-config","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"ai-aggregator","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"audit-platform","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"automations","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"catalog","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"cdn-explorer","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"chrysa-lib","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"chrysa-portfolio-viz","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"chrysa-skills","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"claude-config","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"coach","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"container-webview","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"D-D","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"dev-nexus","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"devtool","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"discord-bot-back","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"discordium","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"diy-stream-deck","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"django-app-forge","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"django-autoload","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"django-pytest","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"django-query-optimizer","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"django-query-optimizer-vscode","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"django-traceid","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"doc-gen","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"epub-sorter","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"fastapi-autoload","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"fastapi-pytest","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"fastapi-query-optimizer","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"fastapi-traceid","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"feedback-gateway","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"floating-agent","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"game-solver-platform","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"gaming-os","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"genealogy-validator","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"gestureOS","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"github-actions","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"guideline-checker","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"lifeos","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"linkendin-resume","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"link-reader-bot","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"mediavault","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"mirrador","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"my-resume","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"orchestrator","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"paperclip","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"PO-GO-DEX","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"pre-commit-hooks-changelog","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"pre-commit-tools","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"project-init","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"quality-gatekeeper","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"satisfactory-automated_calculator","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"satisfactory-factory-manager","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"server","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"shared-standards","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"sport-intelligence-hub","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"studioverse","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"usefull-containers","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"windows-autonome","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"windows-docker-state-notification","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"},
-    {"repo":"wsmqtt-monitor","status":"ok","sha":"d810ff11d38af0dc9ceddc03cc8e587eab553cd2","note":"-"}
+    {
+      "note": "-",
+      "repo": "agent-config",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "ai-aggregator",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "audit-platform",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "automations",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "catalog",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "cdn-explorer",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "chrysa-lib",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "chrysa-portfolio-viz",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "chrysa-skills",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "claude-config",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "coach",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "container-webview",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "D-D",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "dev-nexus",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "devtool",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "discord-bot-back",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "discordium",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "diy-stream-deck",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "django-app-forge",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "django-autoload",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "django-pytest",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "django-query-optimizer",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "django-query-optimizer-vscode",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "django-traceid",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "doc-gen",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "epub-sorter",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-autoload",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-pytest",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-query-optimizer",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "fastapi-traceid",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "feedback-gateway",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "floating-agent",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "game-solver-platform",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "gaming-os",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "genealogy-validator",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "gestureOS",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "github-actions",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "guideline-checker",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "lifeos",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "linkendin-resume",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "link-reader-bot",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "mediavault",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "mirrador",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "my-resume",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "orchestrator",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "paperclip",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "PO-GO-DEX",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "pre-commit-hooks-changelog",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "pre-commit-tools",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "project-init",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "quality-gatekeeper",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "satisfactory-automated_calculator",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "satisfactory-factory-manager",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "server",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "shared-standards",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "sport-intelligence-hub",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "studioverse",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "usefull-containers",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "windows-autonome",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "windows-docker-state-notification",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    },
+    {
+      "note": "-",
+      "repo": "wsmqtt-monitor",
+      "sha": "d810ff11d38af0dc9ceddc03cc8e587eab553cd2",
+      "status": "ok"
+    }
   ]
 }

--- a/copilot-instructions/fastapi.md
+++ b/copilot-instructions/fastapi.md
@@ -22,7 +22,8 @@ app/
   schemas/      # Pydantic request/response schemas
   services/     # business logic (no HTTP or ORM imports)
   dependencies/ # FastAPI Depends() factories
-  constants.py  # app-wide constants (Final)
+  constants.py  # typed loader exposing constants read from external YAML (Final)
+  config/       # external YAML files holding all constants & config values
 tests/
   unit/
   integration/
@@ -36,6 +37,9 @@ tests/
 - ORM models and Pydantic schemas are separate classes; never share them.
 - Use `Depends()` for DB sessions, auth, pagination — never pass them as plain args.
 - Settings come from `pydantic_settings.BaseSettings`; never use `os.environ` directly.
+- No hardcoded constants in code: thresholds, business rules, labels, URLs and magic
+  numbers live in external YAML under `config/`, loaded once via `constants.py`. Only
+  `status.HTTP_*` and language enums are exempt.
 
 ## API design
 

--- a/copilot-instructions/python-library.md
+++ b/copilot-instructions/python-library.md
@@ -12,7 +12,8 @@ src/
     __init__.py       # public API surface — explicit re-exports only
     _internal/        # private implementation (not part of public API)
     py.typed          # marker file for PEP 561
-    constants.py      # library-wide constants (Final)
+    constants.py      # typed loader exposing constants read from a bundled YAML (Final)
+    config/           # YAML data files holding constants & config values (no inline literals)
 tests/
   unit/
   integration/        # optional — only if the lib has external dependencies

--- a/copilot-instructions/react19.md
+++ b/copilot-instructions/react19.md
@@ -19,7 +19,7 @@ src/
   hooks/        # global custom hooks
   pages/        # route-level components — thin wrappers over features
   store/        # Redux Toolkit store + root reducer
-  constants.ts  # app-wide constants (as const)
+  constants.ts  # typed module exposing constants generated from external YAML (as const)
   types/        # shared TypeScript types
   utils/        # pure utility functions
 ```
@@ -117,6 +117,8 @@ src/
 
 - All user-facing strings **must** go through `react-i18next` (`useTranslation` hook).
 - No hardcoded UI text in components. Translation keys in `src/i18n/locales/`.
+- No hardcoded constants in components: thresholds, business rules, labels, URLs and
+  magic numbers come from `constants.ts` (generated from external YAML), never inline.
 - Supported locales from V1: `fr`, `en`.
 
 ## Styling

--- a/docs/audits/sonar-findings-20260622.json
+++ b/docs/audits/sonar-findings-20260622.json
@@ -1,312 +1,312 @@
 {
-  "agent-config": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **18** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_agent-config`](https://sonarcloud.io/project/issues?id=chrysa_agent-config&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 11 | `scripts/notion_roadmap_sync.py:269` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 6 | `skills/read/scripts/fetch_feishu.py:99` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 1 | `scripts/generate_agents_md.py:135` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_agent-config&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 1,
-      "high": 17,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "ai-aggregator": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_ai-aggregator`](https://sonarcloud.io/project/issues?id=chrysa_ai-aggregator&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S8409` | CODE_SMELL | BLOCKER | 2 | `api/routers/health.py:14` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_ai-aggregator&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 2,
-      "high": 0,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "cdn-explorer": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_cdn-explorer`](https://sonarcloud.io/project/issues?id=chrysa_cdn-explorer&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/crawler.py:104` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_cdn-explorer&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 0,
-      "high": 1,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "chrysa-lib": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_chrysa-lib`](https://sonarcloud.io/project/issues?id=chrysa_chrysa-lib&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S6418` | VULNERABILITY | BLOCKER | 1 | `packages/python/auth/tests/test_jwt.py:9` |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `packages/typescript/api/src/client.ts:24` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_chrysa-lib&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 1,
-      "high": 1,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "claude-config": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **12** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_claude-config`](https://sonarcloud.io/project/issues?id=chrysa_claude-config&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 4 | `multi-machine/snapshot/configure.sh:247` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 4 | `claude/hooks/prompt-validator.py:513` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 3 | `claude/hooks/prompt-validator.py:65` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 1 | `claude/hooks/error-tracker.py:71` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_claude-config&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 1,
-      "high": 11,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "coach": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_coach`](https://sonarcloud.io/project/issues?id=chrysa_coach&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:216` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:222` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_coach&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 0,
-      "high": 2,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "container-webview": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_container-webview`](https://sonarcloud.io/project/issues?id=chrysa_container-webview&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `code/src/domain/health/deriveHealth.ts:30` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/app/routers/metrics.py:51` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_container-webview&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 0,
-      "high": 2,
-      "medium": 0,
-      "low": 0
-    }
-  },
   "D-D": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_D-D`](https://sonarcloud.io/project/issues?id=chrysa_D-D&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `css:S4657` | BUG | CRITICAL | 1 | `code/src/app.css:33` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_D-D&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 0,
       "high": 1,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "dev-nexus": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **26** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_dev-nexus`](https://sonarcloud.io/project/issues?id=chrysa_dev-nexus&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S8410` | CODE_SMELL | BLOCKER | 14 | `backend/src/app/api/v1/auth.py:21` |\n| `python:S8409` | CODE_SMELL | BLOCKER | 8 | `backend/src/app/api/v1/auth.py:28` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 2 | `docker-compose.yml:9` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `backend/src/app/api/v1/projects.py:50` |\n| `python:S2208` | CODE_SMELL | CRITICAL | 1 | `backend/alembic/env.py:13` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_dev-nexus&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 24,
-      "high": 2,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "discord-bot-back": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_discord-bot-back`](https://sonarcloud.io/project/issues?id=chrysa_discord-bot-back&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `githubactions:S7630` | VULNERABILITY | BLOCKER | 1 | `.github/workflows/enforce-feature-branch.yml:16` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_discord-bot-back&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 1,
-      "high": 0,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "discordium": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **10** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_discordium`](https://sonarcloud.io/project/issues?id=chrysa_discordium&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 4 | `backend/app/db/base.py:19` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci.yml:83` |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 2 | `frontend/src/domain/queries.ts:52` |\n| `typescript:S2004` | CODE_SMELL | CRITICAL | 1 | `frontend/src/game/scenes/CombatScene.ts:93` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_discordium&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 3,
-      "high": 7,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "django-autoload": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_django-autoload`](https://sonarcloud.io/project/issues?id=chrysa_django-autoload&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `secrets:S6687` | VULNERABILITY | BLOCKER | 1 | `examples/demo/demo_project/settings.py:16` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_django-autoload&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 1,
-      "high": 0,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "epub-sorter": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_epub-sorter`](https://sonarcloud.io/project/issues?id=chrysa_epub-sorter&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S2638` | CODE_SMELL | CRITICAL | 2 | `cli.py:23` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `gui.py:152` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_epub-sorter&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 0,
-      "high": 3,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "floating-agent": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_floating-agent`](https://sonarcloud.io/project/issues?id=chrysa_floating-agent&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `floating_agent/plugins/notion.py:76` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_floating-agent&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 0,
-      "high": 1,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "gaming-os": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **4** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_gaming-os`](https://sonarcloud.io/project/issues?id=chrysa_gaming-os&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci.yml:94` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `backend/app/routers/sessions.py:61` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_gaming-os&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 3,
-      "high": 1,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "genealogy-validator": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **13** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_genealogy-validator`](https://sonarcloud.io/project/issues?id=chrysa_genealogy-validator&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 11 | `scripts/quality_gate.py:217` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:213` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 1 | `.vscode/PythonImportHelper-v2-Completion.json:1001` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_genealogy-validator&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 1,
-      "high": 12,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "github-actions": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_github-actions`](https://sonarcloud.io/project/issues?id=chrysa_github-actions&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `githubactions:S7630` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci-fullstack.yml:107` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_github-actions&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 3,
-      "high": 0,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "guideline-checker": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **13** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_guideline-checker`](https://sonarcloud.io/project/issues?id=chrysa_guideline-checker&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 10 | `guideline_checker/guidelines.py:191` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 2 | `guideline_checker/web/central.py:158` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `guideline_checker/reporters/html.py:371` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_guideline-checker&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 2,
-      "high": 11,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "linkendin-resume": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_linkendin-resume`](https://sonarcloud.io/project/issues?id=chrysa_linkendin-resume&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `app/src/components/contact/ContactModal.tsx:35` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_linkendin-resume&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 0,
-      "high": 1,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "link-reader-bot": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_link-reader-bot`](https://sonarcloud.io/project/issues?id=chrysa_link-reader-bot&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 1 | `ui/src/pages/RecapPage.tsx:23` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/routers/webhooks.py:33` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_link-reader-bot&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 0,
-      "high": 2,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "mediavault": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_mediavault`](https://sonarcloud.io/project/issues?id=chrysa_mediavault&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:202` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:206` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 1 | `.github/workflows/ci.yml:144` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_mediavault&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 1,
-      "high": 2,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "mirrador": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **8** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_mirrador`](https://sonarcloud.io/project/issues?id=chrysa_mirrador&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 3 | `frontend/src/App.tsx:77` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/e2e.yml:27` |\n| `python:S6418` | VULNERABILITY | BLOCKER | 2 | `api/config.py:12` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_mirrador&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 5,
-      "high": 3,
-      "medium": 0,
-      "low": 0
-    }
-  },
-  "my-resume": {
-    "title": "SonarCloud: blocker & critical findings",
-    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_my-resume`](https://sonarcloud.io/project/issues?id=chrysa_my-resume&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `css:S4657` | BUG | CRITICAL | 1 | `code/src/app.css:23` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_my-resume&resolved=false&severities=BLOCKER,CRITICAL",
-    "counts": {
-      "critical": 0,
-      "high": 1,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   },
   "PO-GO-DEX": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_PO-GO-DEX`](https://sonarcloud.io/project/issues?id=chrysa_PO-GO-DEX&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:202` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:206` |\n| `css:S4657` | BUG | CRITICAL | 1 | `code/src/app.css:33` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_PO-GO-DEX&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 0,
       "high": 3,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "agent-config": {
+    "body": "SonarCloud reports **18** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_agent-config`](https://sonarcloud.io/project/issues?id=chrysa_agent-config&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 11 | `scripts/notion_roadmap_sync.py:269` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 6 | `skills/read/scripts/fetch_feishu.py:99` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 1 | `scripts/generate_agents_md.py:135` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_agent-config&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 17,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "ai-aggregator": {
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_ai-aggregator`](https://sonarcloud.io/project/issues?id=chrysa_ai-aggregator&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S8409` | CODE_SMELL | BLOCKER | 2 | `api/routers/health.py:14` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_ai-aggregator&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 2,
+      "high": 0,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "cdn-explorer": {
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_cdn-explorer`](https://sonarcloud.io/project/issues?id=chrysa_cdn-explorer&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/crawler.py:104` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_cdn-explorer&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "chrysa-lib": {
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_chrysa-lib`](https://sonarcloud.io/project/issues?id=chrysa_chrysa-lib&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S6418` | VULNERABILITY | BLOCKER | 1 | `packages/python/auth/tests/test_jwt.py:9` |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `packages/typescript/api/src/client.ts:24` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_chrysa-lib&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 1,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "claude-config": {
+    "body": "SonarCloud reports **12** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_claude-config`](https://sonarcloud.io/project/issues?id=chrysa_claude-config&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 4 | `multi-machine/snapshot/configure.sh:247` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 4 | `claude/hooks/prompt-validator.py:513` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 3 | `claude/hooks/prompt-validator.py:65` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 1 | `claude/hooks/error-tracker.py:71` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_claude-config&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 11,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "coach": {
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_coach`](https://sonarcloud.io/project/issues?id=chrysa_coach&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:216` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:222` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_coach&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 2,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "container-webview": {
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_container-webview`](https://sonarcloud.io/project/issues?id=chrysa_container-webview&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `code/src/domain/health/deriveHealth.ts:30` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/app/routers/metrics.py:51` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_container-webview&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 2,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "dev-nexus": {
+    "body": "SonarCloud reports **26** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_dev-nexus`](https://sonarcloud.io/project/issues?id=chrysa_dev-nexus&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S8410` | CODE_SMELL | BLOCKER | 14 | `backend/src/app/api/v1/auth.py:21` |\n| `python:S8409` | CODE_SMELL | BLOCKER | 8 | `backend/src/app/api/v1/auth.py:28` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 2 | `docker-compose.yml:9` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `backend/src/app/api/v1/projects.py:50` |\n| `python:S2208` | CODE_SMELL | CRITICAL | 1 | `backend/alembic/env.py:13` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_dev-nexus&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 24,
+      "high": 2,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "discord-bot-back": {
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_discord-bot-back`](https://sonarcloud.io/project/issues?id=chrysa_discord-bot-back&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `githubactions:S7630` | VULNERABILITY | BLOCKER | 1 | `.github/workflows/enforce-feature-branch.yml:16` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_discord-bot-back&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 0,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "discordium": {
+    "body": "SonarCloud reports **10** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_discordium`](https://sonarcloud.io/project/issues?id=chrysa_discordium&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 4 | `backend/app/db/base.py:19` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci.yml:83` |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 2 | `frontend/src/domain/queries.ts:52` |\n| `typescript:S2004` | CODE_SMELL | CRITICAL | 1 | `frontend/src/game/scenes/CombatScene.ts:93` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_discordium&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 3,
+      "high": 7,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "django-autoload": {
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_django-autoload`](https://sonarcloud.io/project/issues?id=chrysa_django-autoload&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `secrets:S6687` | VULNERABILITY | BLOCKER | 1 | `examples/demo/demo_project/settings.py:16` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_django-autoload&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 0,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "epub-sorter": {
+    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_epub-sorter`](https://sonarcloud.io/project/issues?id=chrysa_epub-sorter&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S2638` | CODE_SMELL | CRITICAL | 2 | `cli.py:23` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `gui.py:152` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_epub-sorter&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 3,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "floating-agent": {
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_floating-agent`](https://sonarcloud.io/project/issues?id=chrysa_floating-agent&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `floating_agent/plugins/notion.py:76` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_floating-agent&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "gaming-os": {
+    "body": "SonarCloud reports **4** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_gaming-os`](https://sonarcloud.io/project/issues?id=chrysa_gaming-os&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci.yml:94` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `backend/app/routers/sessions.py:61` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_gaming-os&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 3,
+      "high": 1,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "genealogy-validator": {
+    "body": "SonarCloud reports **13** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_genealogy-validator`](https://sonarcloud.io/project/issues?id=chrysa_genealogy-validator&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 11 | `scripts/quality_gate.py:217` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:213` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 1 | `.vscode/PythonImportHelper-v2-Completion.json:1001` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_genealogy-validator&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 12,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "github-actions": {
+    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_github-actions`](https://sonarcloud.io/project/issues?id=chrysa_github-actions&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `githubactions:S7630` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/ci-fullstack.yml:107` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_github-actions&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 3,
+      "high": 0,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "guideline-checker": {
+    "body": "SonarCloud reports **13** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_guideline-checker`](https://sonarcloud.io/project/issues?id=chrysa_guideline-checker&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 10 | `guideline_checker/guidelines.py:191` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 2 | `guideline_checker/web/central.py:158` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `guideline_checker/reporters/html.py:371` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_guideline-checker&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 2,
+      "high": 11,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "link-reader-bot": {
+    "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_link-reader-bot`](https://sonarcloud.io/project/issues?id=chrysa_link-reader-bot&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 1 | `ui/src/pages/RecapPage.tsx:23` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `api/routers/webhooks.py:33` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_link-reader-bot&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 2,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "linkendin-resume": {
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_linkendin-resume`](https://sonarcloud.io/project/issues?id=chrysa_linkendin-resume&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3776` | CODE_SMELL | CRITICAL | 1 | `app/src/components/contact/ContactModal.tsx:35` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_linkendin-resume&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "mediavault": {
+    "body": "SonarCloud reports **3** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_mediavault`](https://sonarcloud.io/project/issues?id=chrysa_mediavault&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:202` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:206` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 1 | `.github/workflows/ci.yml:144` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_mediavault&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 1,
+      "high": 2,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "mirrador": {
+    "body": "SonarCloud reports **8** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_mirrador`](https://sonarcloud.io/project/issues?id=chrysa_mirrador&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `typescript:S3735` | CODE_SMELL | CRITICAL | 3 | `frontend/src/App.tsx:77` |\n| `secrets:S6698` | VULNERABILITY | BLOCKER | 3 | `.github/workflows/e2e.yml:27` |\n| `python:S6418` | VULNERABILITY | BLOCKER | 2 | `api/config.py:12` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_mirrador&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 5,
+      "high": 3,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
+  },
+  "my-resume": {
+    "body": "SonarCloud reports **1** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_my-resume`](https://sonarcloud.io/project/issues?id=chrysa_my-resume&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `css:S4657` | BUG | CRITICAL | 1 | `code/src/app.css:23` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_my-resume&resolved=false&severities=BLOCKER,CRITICAL",
+    "counts": {
+      "critical": 0,
+      "high": 1,
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   },
   "pre-commit-hooks-changelog": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_pre-commit-hooks-changelog`](https://sonarcloud.io/project/issues?id=chrysa_pre-commit-hooks-changelog&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3516` | CODE_SMELL | BLOCKER | 1 | `pre_commit_hook/generate_changelog.py:81` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `formater.py:95` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_pre-commit-hooks-changelog&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 1,
       "high": 1,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   },
   "pre-commit-tools": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **7** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_pre-commit-tools`](https://sonarcloud.io/project/issues?id=chrysa_pre-commit-tools&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S3776` | CODE_SMELL | CRITICAL | 5 | `pre_commit_hooks/makefile_check.py:178` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `pre_commit_hooks/makefile_check.py:152` |\n| `pythonsecurity:S2083` | VULNERABILITY | BLOCKER | 1 | `pre_commit_hooks/requirements_sort.py:163` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_pre-commit-tools&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 1,
       "high": 6,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   },
   "satisfactory-automated_calculator": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **5** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_satisfactory-automated_calculator`](https://sonarcloud.io/project/issues?id=chrysa_satisfactory-automated_calculator&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `javascript:S3776` | CODE_SMELL | CRITICAL | 5 | `scripts/bottleneck-analyzer.js:105` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_satisfactory-automated_calculator&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 0,
       "high": 5,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   },
   "shared-standards": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **13** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_shared-standards`](https://sonarcloud.io/project/issues?id=chrysa_shared-standards&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 9 | `scripts/audit-docker-compliance.sh:107` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 3 | `scripts/pre-commit-merge.py:214` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:216` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_shared-standards&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 0,
       "high": 13,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   },
   "usefull-containers": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **4** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_usefull-containers`](https://sonarcloud.io/project/issues?id=chrysa_usefull-containers&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 2 | `pytest/docker-cmd.sh:27` |\n| `python:S1192` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:202` |\n| `python:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/quality_gate.py:206` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_usefull-containers&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 0,
       "high": 4,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   },
   "windows-autonome": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **8** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_windows-autonome`](https://sonarcloud.io/project/issues?id=chrysa_windows-autonome&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `shelldre:S131` | CODE_SMELL | CRITICAL | 3 | `scripts/scan/scan-debian.sh:60` |\n| `powershelldre:S8659` | CODE_SMELL | CRITICAL | 2 | `scripts/lib/software.ps1:12` |\n| `powershelldre:S3776` | CODE_SMELL | CRITICAL | 1 | `scripts/scan/scan-os.ps1:73` |\n| `json:S6418` | VULNERABILITY | BLOCKER | 1 | `annexes/vscode-settings.json:168` |\n| `secrets:S6690` | VULNERABILITY | BLOCKER | 1 | `annexes/vscode-settings.json:168` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_windows-autonome&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 2,
       "high": 6,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   },
   "windows-docker-state-notification": {
-    "title": "SonarCloud: blocker & critical findings",
     "body": "SonarCloud reports **2** unresolved `BLOCKER,CRITICAL` finding(s) for [`chrysa_windows-docker-state-notification`](https://sonarcloud.io/project/issues?id=chrysa_windows-docker-state-notification&resolved=false&severities=BLOCKER,CRITICAL).\n\n_Auto-filed from the SonarCloud API. One consolidated issue per repo; resolve findings in SonarCloud and they drop off on the next run._\n\n| Rule | Type | Severity | Count | Example |\n| --- | --- | --- | --- | --- |\n| `python:S2190` | BUG | BLOCKER | 1 | `src/docker_notification.py:24` |\n| `python:S6903` | CODE_SMELL | CRITICAL | 1 | `src/docker_notification.py:25` |\n\n**Triage in SonarCloud:** https://sonarcloud.io/project/issues?id=chrysa_windows-docker-state-notification&resolved=false&severities=BLOCKER,CRITICAL",
     "counts": {
       "critical": 1,
       "high": 1,
-      "medium": 0,
-      "low": 0
-    }
+      "low": 0,
+      "medium": 0
+    },
+    "title": "SonarCloud: blocker & critical findings"
   }
 }

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -44,6 +44,11 @@ local `CLAUDE.md`; this file is the shared baseline imported by it.
 - **One PR per issue**, scoped tight. Every PR references an issue (`Closes/Fixes/Refs #N`).
   Exception: label `hotfix`. The `enforce-issue-link` workflow is a blocking status check.
 - **Dark mode** mandatory from V1. **Accessibility** WCAG 2.1 AA.
+- **No hardcoded constants** in code — neither backend (Python) nor frontend (TS).
+  All constants and config values (thresholds, business rules, labels, URLs, magic
+  numbers) live in **external YAML files** and are loaded at runtime. Code reads them
+  through a typed loader (Pydantic Settings backend · generated typed module frontend),
+  never as inline literals. Only language-level enums (e.g. `status.HTTP_*`) are exempt.
 
 ## Quality gates
 


### PR DESCRIPTION
## Summary
Add a non-negotiable convention: all constants & config values (thresholds, business rules, labels, URLs, magic numbers) live in **external YAML files** loaded at runtime — never inline literals, neither backend (Python) nor frontend (TS). Language-level enums (e.g. `status.HTTP_*`) are exempt.

## Changes
- `standards/STANDARDS.chrysa.md` — new rule under Non-negotiable conventions (source of truth).
- `copilot-instructions/fastapi.md` — `config/` YAML dir + `constants.py` as typed loader + architecture rule.
- `copilot-instructions/python-library.md` — constants read from bundled YAML.
- `copilot-instructions/react19.md` — `constants.ts` generated from YAML + no-hardcoded-constants rule.

## Propagation
After merge, the `distribute-standards` workflow fans this out to all status:dev repos as sync PRs.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)