### PR TITLE
feat(standards): require semantic URLs and self-describing code

### DIFF
--- a/.chrysa/STANDARDS.md
+++ b/.chrysa/STANDARDS.md
@@ -49,6 +49,12 @@ local `CLAUDE.md`; this file is the shared baseline imported by it.
   numbers) live in **external YAML files** and are loaded at runtime. Code reads them
   through a typed loader (Pydantic Settings backend · generated typed module frontend),
   never as inline literals. Only language-level enums (e.g. `status.HTTP_*`) are exempt.
+- **Semantic URLs & code** — URLs are resource-oriented and human-readable: lowercase,
+  hyphenated, plural-noun collections, no verbs or actions in the path (`GET /invoices/42`,
+  never `/getInvoice?id=42`); REST shapes follow the `api-design` skill. Code is
+  self-describing: intention-revealing names over comments, semantic HTML elements
+  (`<nav>`, `<button>`, `<main>`, `<header>`…) never a `<div>` wired as a control, and
+  ARIA used only to fill gaps native semantics cannot express.
 
 ## Quality gates
 

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -49,6 +49,12 @@ local `CLAUDE.md`; this file is the shared baseline imported by it.
   numbers) live in **external YAML files** and are loaded at runtime. Code reads them
   through a typed loader (Pydantic Settings backend · generated typed module frontend),
   never as inline literals. Only language-level enums (e.g. `status.HTTP_*`) are exempt.
+- **Semantic URLs & code** — URLs are resource-oriented and human-readable: lowercase,
+  hyphenated, plural-noun collections, no verbs or actions in the path (`GET /invoices/42`,
+  never `/getInvoice?id=42`); REST shapes follow the `api-design` skill. Code is
+  self-describing: intention-revealing names over comments, semantic HTML elements
+  (`<nav>`, `<button>`, `<main>`, `<header>`…) never a `<div>` wired as a control, and
+  ARIA used only to fill gaps native semantics cannot express.
 
 ## Quality gates
 


### PR DESCRIPTION
## What

Adds a **Semantic URLs & code** rule to the transverse standards (`standards/STANDARDS.chrysa.md`), under *Non-negotiable conventions*:

- URLs resource-oriented & human-readable: lowercase, hyphenated, plural-noun collections, no verbs/actions in the path (`GET /invoices/42`, never `/getInvoice?id=42`); REST shapes per the `api-design` skill.
- Code self-describing: intention-revealing names over comments, semantic HTML (`<nav>`, `<button>`, `<main>`, `<header>`…) never a `<div>` wired as a control, ARIA only to fill gaps native semantics can't express.

Regenerates the managed `.chrysa/STANDARDS.md` copy.

> Note: the "No hardcoded constants" rule is already on `main`; this PR only adds the semantic rule.

## Propagation

Once merged, `distribute-standards` propagates the updated baseline to every `status: dev` repo's `.chrysa/STANDARDS.md`.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)