### PR TITLE
docs(standards): require Notion logging for all progress and modifications

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -44,6 +44,9 @@ local `CLAUDE.md`; this file is the shared baseline imported by it.
 - **One PR per issue**, scoped tight. Every PR references an issue (`Closes/Fixes/Refs #N`).
   Exception: label `hotfix`. The `enforce-issue-link` workflow is a blocking status check.
 - **Dark mode** mandatory from V1. **Accessibility** WCAG 2.1 AA.
+- **Notion logging**: every advancement and modification (progress, decisions, state
+  changes) is logged in Notion — the single source of truth. Run `@notion-sync` after any
+  state change; in case of conflict between local docs and Notion, Notion wins.
 - **No hardcoded constants** in code — neither backend (Python) nor frontend (TS).
   All constants and config values (thresholds, business rules, labels, URLs, magic
   numbers) live in **external YAML files** and are loaded at runtime. Code reads them


### PR DESCRIPTION
## What

Adds a non-negotiable convention to the **canonical** transverse standard `standards/STANDARDS.chrysa.md` (the source distributed to every chrysa repo's `.chrysa/STANDARDS.md` via `distribute-standards.sh`):

> **Notion logging**: every advancement and modification (progress, decisions, state changes) is logged in Notion — the single source of truth. Run `@notion-sync` after any state change; in case of conflict between local docs and Notion, Notion wins.

## Why

Previously the rule was added only to a *distributed copy* (`agent-config/.chrysa/STANDARDS.md`), which is overwritten on every distribution run and absent from the other repos. Putting it in the canonical source makes it durable and propagable to all repos.

## Rollout

After merge, run the `distribute-standards` Action (or `distribute-standards.sh <repo>` locally) to propagate to all repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)