### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.chrysa/STANDARDS.md
+++ b/.chrysa/STANDARDS.md
@@ -65,6 +65,23 @@ local `CLAUDE.md`; this file is the shared baseline imported by it.
 - Lint warnings: **0**. Mypy clean. SonarCloud rating **A**, 0 security hotspot.
 - Max function lines 50 · max file lines 500 · cyclomatic complexity heuristic <= 10.
 
+## Makefile targets
+
+- **Referential**: `Forge-Stack-Workshop/base-makefile` (`Makefile.basic`, `Makefile.python`,
+  `Makefile.with-sub-folder`) is the single source of truth for target names and behaviour.
+- **Canonical naming** — follow base-makefile verbatim, one word where it is one word:
+  `typecheck` (**never** `type-check`), `test-cov`, `format-check`, `quality-gate-verify`,
+  `docker-test`, `ci`. Renaming or aliasing a canonical target is forbidden.
+- **Mandatory socle** — every application repo MUST expose, with these exact names and intent:
+  `help install install-dev lint format format-check typecheck test test-cov pre-commit clean
+  ci quality-gate-baseline quality-gate-verify`. Non-applicative repos (pure infra/Helm/Terraform,
+  config-only, docs) are exempt from the language-specific targets (`typecheck`, `test-cov`) but
+  still expose `help lint pre-commit clean`.
+- **Docs must match** — every `make <target>` cited in `CLAUDE.md` or `README.md` MUST exist in
+  the Makefile (no `make type-check` when the target is `typecheck`).
+- **Recipe style** — prefix every recipe line with `@`; add `## Description` after each target so
+  it appears in `make help`.
+
 ## Shared skills (load on demand from shared-standards/.claude/skills/)
 
 - `testing-pytest` — pytest DDD + pytest-mock + constants (writing tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,63 +1,96 @@
 ---
+# Canonical CI workflow for Python projects (chrysa ecosystem).
+#
+# Usage: copy to .github/workflows/ci.yml. The applier
+# (scripts/apply-repo-standard.sh) substitutes the ${...} placeholders:
+#   scripts      import package / source dir       (e.g. django_pytest)
+#   scripts tests      ruff sources, space-separated     (e.g. "django_pytest tests")
+#   tests        test dir                          (e.g. tests)
+#   shared-standards    repo name                         (e.g. django-pytest)
+#   chrysa_shared-standards  SonarCloud project key            (e.g. chrysa_django-pytest)
+#
+# ⚠️ This file lives in workflows/ (NOT .github/workflows/) — it is a copy-to-use
+#    template, not a reusable `uses:` workflow.
+#
+# NOTE: Lint (ruff/mypy/pre-commit) does NOT run here. It lives in pre-commit
+#       (local) and is replayed in CI only at release time via release.yml's
+#       lint gate (chrysa/github-actions/.github/workflows/lint-python.yml).
+#       This CI keeps only tests + sonar, to gate PRs without per-push lint billing.
+#
+# Job names (test / sonar) are the branch-protection required status checks —
+# keep them stable across repos.
+
 name: CI
 
 on:
+    pull_request:
+        branches: [main]
     push:
         branches:
             - main
-            - develop
             - "feat/**"
             - "fix/**"
-            - "ci/**"
             - "chore/**"
-    pull_request:
-        branches: [main, develop]
+            - "ci/**"
     workflow_dispatch:
 
 permissions:
+    checks: write
     contents: read
+    pull-requests: write
+    statuses: write
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
-    lint:
+    test:
+        name: Docker tests
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - uses: actions/checkout@v6.0.3
+
+            - name: Run tests via Docker
+              run: make docker-test
+
+            # Coverage is generated inside the test job; the sonar job runs on a
+            # separate runner, so the report must travel as an artifact. The name
+            # MUST be test-results-<python-version> — that is exactly what
+            # sonar-scan-python downloads into reports/.
+            - name: Upload coverage report
+              if: always()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: test-results-3.14
+                  path: coverage.xml
+                  if-no-files-found: warn
+
+    sonar:
+        name: SonarCloud
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        needs: test
         runs-on: ubuntu-latest
         timeout-minutes: 15
-        name: Lint & validate
-
+        permissions:
+            contents: read
+            pull-requests: read
         steps:
-            - uses: actions/checkout@v7.0.0
+            - uses: actions/checkout@v6.0.3
+              with:
+                  fetch-depth: 0
 
-            - uses: chrysa/github-actions/python-setup@v1
+            - uses: chrysa/github-actions/sonar-scan-python@v1.1.3
               with:
                   python-version: "3.14"
-
-            - name: Run pre-commit hooks
-              uses: pre-commit/action@v3.0.1
-              env:
-                  SKIP: no-commit-to-branch
-
-    validate-templates:
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        name: Validate template YAML/JSON
-
-        steps:
-            - uses: actions/checkout@v7.0.0
-
-            - name: Validate YAML templates
-              run: |
-                  find templates/ workflows/ -name "*.yml" -o -name "*.yaml" 2>/dev/null | \
-                    while read f; do python3 -c "import yaml,sys; yaml.safe_load(open('$f'))" || exit 1; done
-                  echo "All YAML templates valid"
-
-            - name: Validate JSON templates
-              run: |
-                  find templates/ -name "*.json" 2>/dev/null | \
-                    while read f; do python3 -m json.tool "$f" > /dev/null || exit 1; done
-                  echo "All JSON templates valid"
-
-            - name: Validate repos.yml runtime classification
-              run: bash scripts/validate-repos-runtime.sh
+                  sonar-token: ${{ secrets.SONAR_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  project-key: chrysa_shared-standards
+                  organization: chrysa
+                  project-name: shared-standards
+                  sources: scripts
+                  tests: tests
+                  # Downloaded from the test-results-3.14 artifact into reports/
+                  # by the action; matches sonar-scan-python's default path.
+                  coverage-report: reports/coverage.xml


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@8539265697486ed8a1e14a4bf1b733e01a00e9eb`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards