### PR TITLE
fix(ci): point SonarCloud at console/standards_console, not scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
                   project-key: chrysa_shared-standards
                   organization: chrysa
                   project-name: shared-standards
-                  sources: scripts
-                  tests: tests
+                  sources: console/standards_console
+                  tests: console/tests
                   # Downloaded from the test-results-3.14 artifact into reports/
                   # by the action; matches sonar-scan-python's default path.
                   coverage-report: reports/coverage.xml


### PR DESCRIPTION
## Problem
`.github/workflows/ci.yml` runs `sonar-scan-python` with `sources: scripts` / `tests: tests`. SonarCloud therefore indexes only `scripts/`, never `console/standards_console/` where all executable code lives.

Consequences (observed on #171):
- The (correctly generated + path-rewritten) `coverage.xml` referenced files under `console/standards_console/` that Sonar never indexed → **new_coverage stuck at 0%** (< 80% gate).
- The only file Sonar analysed was `scripts/rewrite-coverage-paths.py`, so the lone new-code security finding surfaced there.
- #171 shipped with the SonarCloud gate red.

## Fix
Point Sonar at the real code:
```yaml
sources: console/standards_console
tests: console/tests
```
Backend suite is 95% covered locally (52 tests), so the coverage gate will pass once Sonar indexes the right tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)