### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,8 @@ jobs:
                   project-key: chrysa_shared-standards
                   organization: chrysa
                   project-name: shared-standards
-                  # Analyse the real code so the console coverage.xml maps (was
-                  # `scripts` only, which never covered console/ → 0% coverage).
-                  sources: console/standards_console,scripts,console/web/src
-                  tests: console/tests
+                  sources: scripts
+                  tests: tests
                   # Downloaded from the test-results-3.14 artifact into reports/
                   # by the action; matches sonar-scan-python's default path.
                   coverage-report: reports/coverage.xml


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@a01d698ccd65a2f4f975ce584cd9e6f9868952e4`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards