### PR TITLE
ci: adopt depends-on/depends-on-action as the PR merge-order standard

### DIFF
--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -15,16 +15,22 @@
   workflow_call:
   workflow_dispatch:
 jobs:
-  check_dependencies:
-    name: Check Dependencies
+  extract_dependencies:
+    name: Extract dependent Pull Requests
     runs-on: ubuntu-latest
     steps:
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: gregsdennis/dependencies-action@v1.4.2
-      - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
+      - uses: actions/checkout@v4
+      - uses: depends-on/depends-on-action@0.17.0
         with:
-          use-label: Blocked
+          token: ${{ secrets.GITHUB_TOKEN }}
+  check_dependencies_merged:
+    name: Check dependent Pull Requests are merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: depends-on/depends-on-action@0.17.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check-unmerged-pr: true
 name: Check PR dependencies
 permissions:
   contents: read

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -140,3 +140,31 @@ caught by the default config. High-precision recognizers (`EMAIL_ADDRESS`, `IBAN
 `PHONE_NUMBER`, `CREDIT_CARD`, `IP_ADDRESS`, `FR_NIR`) remain on. Add `PERSON` / `FR_CNI` to
 `entities` in `.pii-scan.toml` to opt in. Both recognizers stay available; only the default
 set is changed.
+
+---
+
+## D-0007 — Adopt depends-on/depends-on-action for PR merge ordering
+
+**Date**: 2026-07-11
+**Status**: accepted
+
+Stacked/dependent PRs across the fleet (e.g. engine → API → SPA changes split across
+repos or branches) need a deterministic, machine-enforced merge order. The previous
+`.github/workflows/pr-dependencies.yml` used `gregsdennis/dependencies-action@v1.4.2`
+plus `Levi-Lesches/blocking-issues` (label-based), which only tracked issue-level
+blocking and did not enforce PR merge order or cross-repo dependency injection.
+
+**Decision**: adopt [`depends-on/depends-on-action`](https://github.com/depends-on/depends-on-action)
+(pinned `@0.17.0`) as the standard mechanism. Contributors declare a dependency on a
+predecessor PR with a `Depends-On: <PR URL>` line in the PR description (see
+`EXECUTION_STANDARD.md` § Merge rules). `pr-dependencies.yml` now runs two jobs:
+1. `extract_dependencies` — injects the dependent change(s) for build/test.
+2. `check_dependencies_merged` — uses `check-unmerged-pr: true` to block the PR until
+   all declared `Depends-On:` targets are merged.
+
+**Consequences**: this supersedes the prior `gregsdennis/dependencies-action` +
+`Levi-Lesches/blocking-issues` setup, which is removed. Repos relying on the old
+`Blocked` label convention must migrate to the `Depends-On:` PR-body syntax. The action
+also supports Gerrit and GitLab dependency URLs and Go/Python/JS/Ansible/container
+dependency injection, which the fleet does not yet use but may adopt later without
+further ADR changes.

--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -268,6 +268,10 @@ description: imperative, lowercase, no period
 - CI must pass (lint + test + typecheck)
 - Branch must be up to date with `main`
 - Squash merge for feature branches; merge commit for releases
+- Dependent/stacked PRs MUST declare their predecessor with a `Depends-On: <PR URL>` line
+  in the PR description; the `pr-dependencies` gate (powered by
+  [depends-on/depends-on-action](https://github.com/depends-on/depends-on-action)) enforces
+  merge order — a PR cannot merge until its declared dependencies are merged
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace `gregsdennis/dependencies-action@v1.4.2` + `Levi-Lesches/blocking-issues` in `.github/workflows/pr-dependencies.yml` with [`depends-on/depends-on-action@0.17.0`](https://github.com/depends-on/depends-on-action) (verified latest release tag).
- Two jobs: `extract_dependencies` (injects declared dependency changes for build/test) and `check_dependencies_merged` (`check-unmerged-pr: true`, blocks merge until all declared dependencies are merged).
- Codify the `Depends-On: <PR URL>` PR-body convention as a MUST under `EXECUTION_STANDARD.md` § Merge rules.
- Add `D-0007` to `DECISIONS.md` recording the switch and that it supersedes the prior `gregsdennis/dependencies-action` usage.

## Why
Stacked/dependent PRs across the fleet (e.g. engine → API → SPA) need a deterministic, machine-enforced merge order. The previous setup only tracked issue-level `Blocked` labels and did not enforce PR merge order. `depends-on/depends-on-action` is purpose-built for this: it parses `Depends-On:` lines from the PR description and can both inject the dependency for CI and gate the merge until dependencies are merged.

## Test plan
- [x] `actionlint .github/workflows/pr-dependencies.yml` passes clean
- [x] Diff scoped to `.github/workflows/pr-dependencies.yml`, `EXECUTION_STANDARD.md`, `DECISIONS.md`
- [ ] Human review/merge (not auto-merged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)