### PR TITLE
fix(sync): never clobber a repo's hand-tuned ci.yml on fleet sync

### DIFF
--- a/scripts/apply-repo-standard.sh
+++ b/scripts/apply-repo-standard.sh
@@ -139,20 +139,18 @@ deploy_governance() {
     ok "CODEOWNERS (created)"
 }
 
-ci_is_canonical() {
-    local f="$1"
-    [[ -f "$f" ]] || return 1
-    grep -q 'chrysa/github-actions' "$f" \
-        && grep -q 'name: Pre-commit checks' "$f" \
-        && grep -q 'name: SonarCloud' "$f"
-}
-
 deploy_stack_ci() {
     local repo="$1" name; name="${REPO_NAME:-$(basename "$repo")}"
     local tpl dest="$repo/.github/workflows/ci.yml"
     local pkg sources tests project_key
-    if ci_is_canonical "$dest"; then
-        info "ci.yml already canonical · skip (edit manually to re-template)"
+    # Gap-aware, like deploy_governance (CODEOWNERS) and the Tier-1 process
+    # workflows: never clobber an existing ci.yml. Repos hand-tune their CI
+    # (extra jobs, deploy, quality gates, secret-scan); re-templating from the
+    # generic stack template silently reverts that hygiene on every fleet sync.
+    # Bootstrap the template only when a repo has no ci.yml; to intentionally
+    # re-template, delete the file first.
+    if [[ -e "$dest" ]]; then
+        info "ci.yml exists · preserved (never clobber hand-tuned CI)"
         return
     fi
     if [[ -f "$repo/pyproject.toml" ]] || ls "$repo"/requirements*.txt &>/dev/null; then


### PR DESCRIPTION
## Problem
`scripts/apply-repo-standard.sh` → `deploy_stack_ci()` re-templated each repo's `.github/workflows/ci.yml` from the generic stack template (`ci-python.yml` / `ci-node.yml`) on **every fleet sync** (`distribute-standards.yml`), unless the existing file matched 3 "canonical" markers (`chrysa/github-actions`, `Pre-commit checks`, `SonarCloud`).

Any repo with a **richer, non-canonical** `ci.yml` (extra jobs, `deploy`, `quality-gate-check`, `secret-scan`, custom matrix) got its CI **silently reverted** to the generic template on each sync. This is the source of the recurring "workflow hygiene revert" (roadmap P3 / session log #158).

The Tier-1 process workflows (`apply-ci-process.sh`) and `CODEOWNERS` (`deploy_governance`) are already **gap-aware** ("never clobber a repo's existing workflow"). `ci.yml` was the sole non-gap-aware write.

## Fix
Make `deploy_stack_ci` gap-aware, consistent with the rest of the file:
- Preserve any existing `ci.yml` (never clobber).
- Bootstrap the template **only when a repo has no `ci.yml`**.
- To intentionally re-template, delete the file first.
- Removes the now-unused `ci_is_canonical` helper.

## Verification
- `shellcheck scripts/apply-repo-standard.sh` — no new findings (2 pre-existing warnings on lines 133/215 untouched).
- Functional dry-run (git-init'd fake repo):
  - custom `ci.yml` present → `ci.yml exists · preserved (never clobber hand-tuned CI)` ✅
  - no `ci.yml` → `would write ci.yml from ci-python.yml` (bootstrap preserved) ✅
- Canonical repos were already *skipped* before this change, so no fleet-wide CI refresh is lost — only the unwanted revert of custom CI stops.

Refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)