### PR TITLE
feat(web): vitest v8 coverage for Sonar TS (Phase 2, #183 part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ graphify-out/
 .graphify_version
 graphify
 sys
+
+# web vitest coverage
+console/web/coverage/

--- a/console/web/package.json
+++ b/console/web/package.json
@@ -18,6 +18,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.3",
+    "@vitest/coverage-v8": "^3.2.6",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.13.0",
     "globals": "^15.11.0",
@@ -41,7 +42,8 @@
     "dev": "vite",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:cov": "vitest run --coverage"
   },
   "type": "module",
   "version": "0.1.0"

--- a/console/web/vite.config.ts
+++ b/console/web/vite.config.ts
@@ -12,5 +12,19 @@ export default defineConfig({
     proxy: { "/api": "http://127.0.0.1:8765" },
   },
   build: { outDir: path.resolve(__dirname, "../standards_console/web_dist"), emptyOutDir: true },
-  test: { environment: "jsdom", globals: true, setupFiles: "./src/test/setup.ts" },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./src/test/setup.ts",
+    // Coverage for SonarCloud (Phase 2, #183): `npm run test:cov` emits lcov at
+    // coverage/lcov.info — feed it to Sonar via sonar.javascript.lcov.reportPaths
+    // once sonar-scan-python accepts a JS lcov input.
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "coverage",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.test.{ts,tsx}", "src/test/**", "src/**/*.d.ts"],
+    },
+  },
 });


### PR DESCRIPTION
Refs #183 (TS coverage Phase 2) — Part 1.

## What
- `@vitest/coverage-v8` devDep (matches vitest ^3.2.6)
- `test:cov` script → `vitest run --coverage`
- `vite.config.ts` coverage block: provider v8, reporters `text`+`lcov`, output `console/web/coverage/lcov.info`, scoped to `src/**` (tests/setup/d.ts excluded)
- ignore `console/web/coverage/`

## Scope / follow-up
This is the **web-side prerequisite only** — `npm run test:cov` now emits an lcov Sonar can consume. Feeding it into the single SonarCloud analysis (`sonar.javascript.lcov.reportPaths`) requires the composite action `chrysa/github-actions/sonar-scan-python` to accept a JS lcov input + download a web-coverage artifact; that CI plumbing is a **separate follow-up in chrysa/github-actions** and is intentionally out of scope here. Coverage gate stays non-blocking.

Part 2 of #183 (ci_is_canonical reconcile) tracked separately — see issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)