### PR TITLE
feat(pre-commit): universal-safe excludes for python detection hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,14 @@ repos:
   # TODO: add detect-duplicated-copilot-instructions after chrysa/pre-commit-tools#163 is merged and released
   # --- python (all Python repos) ---
   - id: debugger-detection
+    exclude: '^(tests?/|README\.md|docs/)'
   - id: python-print-detection
+    exclude: '^(tests?/|README\.md|docs/)'
   - id: python-pprint-detection
-    exclude: 'tests?/'
+    exclude: '^(tests?/|README\.md|docs/)'
   - id: no-bare-except
   - id: python-logger-detection
+    exclude: '^(tests?/|README\.md|docs/)'
   - id: python-unreachable-code
   - id: no-hardcoded-localhost
     exclude: 'tests?/|\.test\.|\.spec\.'


### PR DESCRIPTION
## Why
The shared baseline gave the python code-pattern detectors (`print`/`pprint`/`debugger`/`logger`) near-zero excludes, so they fire on test fixtures and documentation examples in every repo — same dogfooding false-positives fixed locally in pre-commit-tools#270.

## What
Add `exclude: '^(tests?/|README\.md|docs/)'` to `debugger-detection`, `python-print-detection`, `python-pprint-detection` (was `tests?/`) and `python-logger-detection`. Universal-safe: every repo has test fixtures + docs with these patterns. Repo-specific broader excludes (pre-commit-tools `pre_commit_hooks/`+`scripts/`, #270) are preserved by pre-commit-merge.py (local excludes win).

Refs chrysa/pre-commit-tools#270