### PR TITLE
chore(repos): register 3 active Python repos as status:dev

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -267,6 +267,18 @@ repos:
     status: dev
     public: false
     runtime: exempt:native
+  - name: debian-guardian
+    status: dev
+    public: false
+    runtime: exempt:native
+  - name: django-migration-analyzer
+    status: dev
+    public: false
+    runtime: exempt:lib
+  - name: windows-guardian
+    status: dev
+    public: false
+    runtime: exempt:native
   - name: wsmqtt-monitor
     status: dev
     public: false


### PR DESCRIPTION
Register `debian-guardian`, `django-migration-analyzer`, `windows-guardian` (active Python repos created after the 2026-06-06 repos.yml generation) so distribute-standards covers them with stack-aware hooks + shared standards.

Part of fleet-wide 'push useful hooks to all repos'.