### PR TITLE
fix(security): scope git add permission to tracked files (#85 follow-up)

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -15,7 +15,7 @@ Create well-formatted commits following the chrysa Conventional Commits standard
 ## What This Command Does
 
 1. Runs `git status` to see which files are staged.
-2. If nothing is staged, stages all modified and new files with `git add`.
+2. If nothing is staged, stages tracked modifications with `git add -u` (never untracked files, to avoid committing secrets).
 3. Runs `git diff` to understand the changes.
 4. Analyzes the diff for multiple logical concerns; if found, proposes splitting into
    several atomic commits and stages them separately.

--- a/docs/adr/0004-scope-git-add-permission.md
+++ b/docs/adr/0004-scope-git-add-permission.md
@@ -1,0 +1,27 @@
+# 4. Scope `git add` permission to tracked files
+
+Date: 2026-07-17
+Status: Accepted
+
+## Context
+
+PR #85 was merged to `main` via `--admin` (CI is billing-blocked fleet-wide), shipping two
+findings that propagate to every repo consuming the template:
+
+- `templates/settings.json` granted `Bash(git add:*)`, letting an agent stage arbitrary paths.
+- The `/commit` command staged "all modified and new files" with a bare `git add`, which can
+  stage untracked files (for example secrets not yet in `.gitignore`).
+
+## Decision
+
+- Scope the template permission to `Bash(git add -u)` — stage tracked modifications only, never
+  arbitrary paths.
+- The `/commit` command uses `git add -u` and never stages untracked files automatically.
+
+## Consequences
+
+- Agents can no longer stage new or untracked files without an explicit, separately-authorized
+  action, reducing the risk of committing secrets.
+- Adding a genuinely new file to a commit now requires an explicit `git add <path>` a human
+  authorizes, by design.
+- Propagates to all consuming repos on the next standards distribution.

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -52,7 +52,7 @@
       "Bash(git status)",
       "Bash(git diff:*)",
       "Bash(git log:*)",
-      "Bash(git add:*)",
+      "Bash(git add -u)",
       "Bash(gh issue view:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr diff:*)",


### PR DESCRIPTION
Follow-up to the security findings surfaced by #85 (merged to main via `--admin` while CI is billing-blocked).

## Changes
- **`templates/settings.json`** — `Bash(git add:*)` → `Bash(git add -u)`. Blocks staging arbitrary paths; tracked modifications only. **This is the finding that propagates to every repo using the template.**
- **`.claude/commands/commit.md`** — the `/commit` flow stages tracked modifications with `git add -u`, never untracked files (avoids committing secrets).
- **`docs/adr/0004-scope-git-add-permission.md`** — records the decision (the missing ADR from #85; numbered 0004 per this repo's 4-digit scheme, not the `D-000x` scheme).

## Not addressed (false positive)
The #85 note flagged a "missing general-purpose agent file". `general-purpose` is a **built-in** Claude Code agent — it needs no repo file. No change made.

## CI
CI is billing-blocked fleet-wide, so checks will not run. Review manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)