### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -15,7 +15,7 @@ Create well-formatted commits following the chrysa Conventional Commits standard
 ## What This Command Does
 
 1. Runs `git status` to see which files are staged.
-2. If nothing is staged, stages tracked modifications with `git add -u` (never untracked files, to avoid committing secrets).
+2. If nothing is staged, stages all modified and new files with `git add`.
 3. Runs `git diff` to understand the changes.
 4. Analyzes the diff for multiple logical concerns; if found, proposes splitting into
    several atomic commits and stages them separately.


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@5852bab343950cbef7e8aa9d89a2de1b69ce1b44`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards