### PR TITLE
chore(standards): frontend stack → React 19 + TypeScript 7 + Vite 8

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -17,7 +17,7 @@ local `CLAUDE.md`; this file is the shared baseline imported by it.
 |------------------|----------------------------------------------------------------|
 | Python           | 3.14 target (CI matrix 3.12 + 3.14)                            |
 | FastAPI          | >= 0.115 + Pydantic v2                                          |
-| Frontend         | React 19 + TypeScript + Vite 6                                  |
+| Frontend         | React 19 + TypeScript 7 + Vite 8                                |
 | UI               | shadcn/ui + Tailwind CSS                                        |
 | State            | TanStack Query + Zustand                                        |
 | DB               | PostgreSQL 16 + Redis 7                                         |


### PR DESCRIPTION
Update cross-cutting stack: Frontend Vite 6 → TypeScript 7 + Vite 8. Owner-validated as new fleet baseline after Dependabot bumped chrysa-portfolio-viz. Source of truth for distribute-standards. Note: vite-plugin-dts must be imported dynamically build-only (crashes vite dev under TS 7, see chrysa-portfolio-viz#611).

🤖 Generated with [Claude Code](https://claude.com/claude-code)