### PR TITLE
feat(governance): pillars + refutable ADR format in the distributed baseline

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -121,3 +121,36 @@ Per-project activation checklist:
 3. The auto-issue alert rule exists (run the provisioning script, or add it in
    Alerts → Create Alert → Issues → action "Create a GitHub issue").
 4. The GitHub repo has a `sentry` label (CI label sync provides it).
+
+## Governance — strategic pillars & ADR format
+
+Five non-negotiables hold across every chrysa project, whatever the stack. Breaking one
+requires an ADR with a kill-test, not a shrug.
+
+1. **LLM-provider independence** — no vendor SDK in business code; inference goes through a
+   local port with **≥2 real, tested adapters** (e.g. Claude + a local model). A prompt that
+   only works on one vendor is a bug, not a feature.
+2. **GAFAM independence** — every managed-cloud dependency has a documented self-hosted exit
+   path; the cloud SDK stays confined to an adapter (`BlobStore`, not `S3Client`).
+3. **Portable personalisation data** — all user/personal data is exportable to an open format
+   (JSON/SQLite) by a documented command; `export → import → export` is idempotent (tested).
+   A stored-but-unexportable field needs an ADR.
+4. **k8s config in-project** — manifests live in `deploy/k8s/` of the repo; nothing exists
+   only inside a running cluster.
+5. **Adaptation layer** — no third-party lib/API/service is imported by the domain directly;
+   it goes through an adapter whose port is written in the domain's language, not the vendor's.
+
+**ADR format (refutable).** Any structural decision — new external dependency, LLM/cloud
+provider choice, breaking public-API change, data-model change, or a pillar exception — gets
+one ADR under `docs/adr/` (series named in the local `CLAUDE.md`). Beyond the classic fields,
+every chrysa ADR carries three that make it falsifiable:
+
+- **Fatal hypothesis** — the single, falsifiable belief whose falsity invalidates the decision.
+  One only; about the real world (cost, latency, a third party), not an internal intention.
+- **Kill-test** — the observable, dated signal that proves it wrong: what to measure, which
+  threshold, when checked, what happens on breach. Mechanised as a test where possible.
+- **Validation gate** — the pre-agreed condition that unlocks the next step, written *before*
+  building.
+
+`Killed` is a valid ADR status: the kill-test fired and the hypothesis was false. A corpus with
+no `Killed` entry has kill-tests that are too lax. Scaffold a new record with `/adr-new`.

--- a/templates/claude/commands/adr-new.md
+++ b/templates/claude/commands/adr-new.md
@@ -1,0 +1,47 @@
+---
+description: Scaffold a new ADR in the chrysa refutable format (fatal hypothesis, kill-test, gate)
+argument-hint: <short decision title>
+---
+
+# Command: ADR New
+
+Scaffold a new Architecture Decision Record for **$ARGUMENTS**, following the
+chrysa ADR format. Read `.claude/rules/adr.md` first — it is the standard.
+
+## Usage
+
+```text
+/adr-new <short decision title>
+```
+
+## Steps
+
+1. **Legitimacy check.** An ADR is mandatory only for: a new external dependency,
+   an LLM/cloud provider choice, a breaking public-API change, a data-model
+   change, or an exception to a strategic pillar (`.claude/rules/pillars.md`). No
+   trigger hit → say so and write nothing. An ADR for a refactor or a naming
+   choice is noise that dilutes the real ones.
+
+2. **Number & file.** Next number = highest existing + 1, four digits, never
+   reused. Path: `docs/adr/<SERIES>-<NNNN>-<kebab-slug>.md`, where `<SERIES>` is
+   the repo's ADR series (see its `CLAUDE.md`). File written in English.
+
+3. **The three fields that carry the format.**
+   - *Fatal hypothesis* — the single falsifiable belief whose falsity kills the
+     decision. One only; about the real world, not an internal intention.
+   - *Kill-test* — the observable, dated signal proving it wrong: what to measure,
+     which threshold, when checked, action on breach. Mechanise it as a test, or
+     state why it cannot be.
+   - *Validation gate* — the pre-agreed condition that unlocks the next step,
+     written before implementation.
+
+4. **Options considered.** Each rejected option gets a real reason — no strawman.
+
+5. **Consequences.** Accepted costs · gains · debt created (and when paid) ·
+   blast radius (what changes if this ADR is Killed).
+
+6. **Status = `Proposed`.** Never self-promote an ADR to `Accepted` — that is the
+   author's call. Touch no other file (no code, no external writes).
+
+7. **Report** the file path, plus the fatal hypothesis and kill-test in one
+   sentence each — that is what the decider rules on.


### PR DESCRIPTION
Wire chrysa governance into the fleet the sanctioned way (choice B): put it in the DISTRIBUTED source, not 73 hand-edited CLAUDE.md files.

- standards/STANDARDS.chrysa.md += Governance section (5 strategic pillars + refutable ADR format: fatal hypothesis / kill-test / validation gate). Every repo's CLAUDE.md already imports this via @.chrysa/STANDARDS.md, so distribution auto-wires it everywhere.
- templates/claude/commands/adr-new.md — /adr-new distributed to every repo's .claude/commands/.

Propagation = the existing distribute-standards workflow (one PR per status:dev repo), not a manual mass fan-out. Supersedes the ad-hoc per-repo .claude/rules/ copies from the first wave (harmless duplicates).