### PR TITLE
fix(governance): align onboarding formalization with inline standards model (#202)

### DIFF
--- a/EXECUTION_STANDARD.md
+++ b/EXECUTION_STANDARD.md
@@ -820,9 +820,9 @@ Docker-based tests (`make docker-test`).
 ## 15. Governance — Strategic Pillars & ADR Format (Mandatory)
 
 Every project complies with the five chrysa strategic pillars and records structural
-decisions as **refutable ADRs**. Full text: the distributed baseline
-`.chrysa/STANDARDS.md` (section "Governance — strategic pillars & ADR format"),
-imported by every `CLAUDE.md` via `@.chrysa/STANDARDS.md`.
+decisions as **refutable ADRs**. Full text: the transverse standards inlined into every `CLAUDE.md` by
+`distribute-standards` (managed `<!-- chrysa:standards -->` block); source of truth
+`standards/STANDARDS.chrysa.md`, section "Governance — strategic pillars & ADR format".
 
 ### 15.1 The five pillars (non-negotiable)
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -15,7 +15,7 @@
 ## Conventions
 
 - Language: English — all code, comments, documentation, instructions, and configuration files must be in English.
-- Governance: the five strategic pillars and the refutable ADR format are mandatory — see the imported `@.chrysa/STANDARDS.md` (Governance section) and `EXECUTION_STANDARD.md` §15.
+- Governance: the five strategic pillars and the refutable ADR format are mandatory — see the managed `chrysa:standards` block below (inlined by distribute-standards) and `EXECUTION_STANDARD.md` §15.
 - Commits: Conventional Commits (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`)
 - Branch naming: `feature/`, `bugfix/`, `chore/`, `hotfix/`, `release/`
 - Default branch: `develop`
@@ -91,7 +91,3 @@ graph. Only read source files when (a) modifying/debugging specific code, (b) th
 the needed detail, or (c) the graph is missing or stale.
 
 Type `/graphify` in Copilot Chat to build or update the graph.
-
-<!-- chrysa:standards-import:start -->
-@.chrysa/STANDARDS.md
-<!-- chrysa:standards-import:end -->


### PR DESCRIPTION
Corrects #205, which was authored against the pre-#202 vendored @.chrysa/STANDARDS.md model. #202 retired that indirection and now inlines standards into each CLAUDE.md (managed chrysa:standards block, legacy purged).

- templates/CLAUDE.md: remove the retired chrysa:standards-import block + @.chrysa/STANDARDS.md (purge_legacy deletes it anyway, and it dangles if a project is scaffolded before first sync). Governance bullet now points to the inline block + EXECUTION_STANDARD §15.
- EXECUTION_STANDARD.md §15: reference the inline model (source standards/STANDARDS.chrysa.md), not the vendored @import.

Governance itself is intact fleet-wide: verified inline in CLAUDE.md across dev-nexus/paperclip/lifeos/server/catalog (governance=1, legacy .chrysa purged).