### PR TITLE
fix(console): guard Standard editor on load failure (P0)

### DIFF
--- a/console/web/src/locales/en.ts
+++ b/console/web/src/locales/en.ts
@@ -36,6 +36,7 @@ export const en = {
       summary: "Commit summary (e.g. tighten coverage gate)",
       openPr: "Open PR",
       prOpened: "PR #{{number}} opened on branch {{branch}}.",
+      loadError: "Could not load the standard — the editor is disabled so a PR cannot be opened from a state that was never loaded.",
     },
   },
 };

--- a/console/web/src/locales/fr.ts
+++ b/console/web/src/locales/fr.ts
@@ -42,6 +42,7 @@ export const fr = {
       summary: "Résumé du commit (ex. durcir le seuil de couverture)",
       openPr: "Ouvrir une PR",
       prOpened: "PR #{{number}} ouverte sur la branche {{branch}}.",
+      loadError: "Impossible de charger le standard — l'éditeur est désactivé pour éviter d'ouvrir une PR depuis un état jamais chargé.",
     },
   },
 };

--- a/console/web/src/pages/Standard.test.tsx
+++ b/console/web/src/pages/Standard.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import "@/i18n";
+import { Standard } from "./Standard";
+
+afterEach(() => vi.restoreAllMocks());
+
+function renderStandard(response: Partial<Response> & { json?: () => Promise<unknown> }) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <Standard meta={undefined} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("Standard", () => {
+  it("shows the editor once the standard loads", async () => {
+    renderStandard({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ text: "50 lines/function", path: "STANDARDS.md" }),
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: /standard/i })).toHaveValue("50 lines/function"),
+    );
+  });
+
+  it("hides the editor and keeps the PR button unrenderable on load failure", async () => {
+    // 502: GET /api/standard failed -> data undefined, isError true.
+    renderStandard({ ok: false, status: 502, json: () => Promise.resolve({}) });
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    // The editor must not exist, so no empty PR can ever be opened from this state.
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /open pr|ouvrir une pr/i })).not.toBeInTheDocument();
+  });
+});

--- a/console/web/src/pages/Standard.tsx
+++ b/console/web/src/pages/Standard.tsx
@@ -10,7 +10,7 @@ import { Textarea } from "@/components/ui/textarea";
 
 export function Standard({ meta }: { meta?: Meta }) {
   const { t } = useTranslation();
-  const { data, isLoading } = useQuery({ queryKey: ["standard"], queryFn: api.standard });
+  const { data, isLoading, isError } = useQuery({ queryKey: ["standard"], queryFn: api.standard });
   const [content, setContent] = useState("");
   const [summary, setSummary] = useState("");
 
@@ -38,7 +38,9 @@ export function Standard({ meta }: { meta?: Meta }) {
           </a>
         </Banner>
       )}
-      {isLoading ? (
+      {isError ? (
+        <Banner kind="error">{t("standard.loadError")}</Banner>
+      ) : isLoading ? (
         <p className="text-muted-foreground">{t("common.loading")}</p>
       ) : (
         <>
@@ -55,7 +57,10 @@ export function Standard({ meta }: { meta?: Meta }) {
               value={summary}
               onChange={(e) => setSummary(e.target.value)}
             />
-            <Button disabled={edit.isPending} onClick={() => edit.mutate()}>
+            <Button
+              disabled={edit.isPending || !data || content === data.text || content.trim() === ""}
+              onClick={() => edit.mutate()}
+            >
               {t("standard.openPr")}
             </Button>
           </div>


### PR DESCRIPTION
## P0 — un load raté ouvrait une PR qui vide le standard
`Standard.tsx` ne lisait que `{ data, isLoading }`. Sur un GET /api/standard en échec (502, `app.py` mappe GitHubError), `isLoading=false` + `data=undefined` → l'éditeur s'affichait avec `content=''` et le bouton **Open PR restait activé** (seule garde : `edit.isPending`). Un clic POSTait `content:''` → **PR réelle remplaçant STANDARDS.chrysa.md par un fichier vide**.

## Fix
- `isError` extrait ; en erreur → `<Banner kind=error>`, **aucun éditeur rendu**.
- garde mutation : `disabled` tant que data non chargé / content inchangé / content vide.
- clé `standard.loadError` en/fr.
- `Standard.test.tsx` : sur 502, l'alerte s'affiche et ni textbox ni bouton Open PR n'existent. `tsc` clean, 6 tests.

Refs: audit d7e488fc (P0).