### PR TITLE
ci(distribute): trigger on release + manual only, drop push:main

### DIFF
--- a/.github/workflows/distribute-standards.yml
+++ b/.github/workflows/distribute-standards.yml
@@ -21,14 +21,6 @@ on:
                 type: boolean
                 required: false
                 default: false
-    push:
-        branches: [main]
-        paths:
-            - 'standards/**'
-            - '.claude/skills/**'
-            - 'templates/claude/**'
-            - 'scripts/distribute-standards.sh'
-            - 'scripts/apply-repo-standard.sh'
 
 permissions:
     contents: read


### PR DESCRIPTION
The `push: main` trigger fired `distribute-standards` on every commit touching `standards/**` etc., opening ~61 sync PRs per commit — contradicting the file's documented intent ('Triggered on release, or manually') and spamming the fleet. Keep `release` + `workflow_dispatch`.

This file is not in the trigger paths, so merging it does not fan out.