### PR TITLE
ci: adopt guideline-checker blocking gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,3 +114,7 @@ repos:
     - fr_core_news_sm @ https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.8.0/fr_core_news_sm-3.8.0-py3-none-any.whl
     - en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
   repo: local
+- repo: https://github.com/chrysa/guideline-checker
+  rev: v1.15.0
+  hooks:
+  - id: guideline-check


### PR DESCRIPTION
Adds the chrysa/guideline-checker pre-commit hook (blocking, --fail-on error). Repo passes clean today (0 errors). Part of the fleet-wide rollout after the validation gate was met.