### PR TITLE
ci: bump guideline-checker to v1.15.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,6 +115,6 @@ repos:
     - en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
   repo: local
 - repo: https://github.com/chrysa/guideline-checker
-  rev: v1.15.0
+  rev: v1.15.4
   hooks:
   - id: guideline-check


### PR DESCRIPTION
Bumps the guideline-checker hook rev to v1.15.4 so it installs under Python 3.12 (the previous pin required 3.14, breaking pre-commit install).