### PR TITLE
feat(pre-commit): distribute the unittest ban to the fleet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
   - id: python-logger-detection
     exclude: '^(tests?/|README\.md|docs/)'
   - id: python-unreachable-code
+  - id: python-no-unittest-import
   - id: no-hardcoded-localhost
     exclude: 'tests?/|\.test\.|\.spec\.'
   - id: regression-gate
@@ -72,7 +73,7 @@ repos:
   - id: react-no-async-in-useeffect
   - id: react-direct-dom
   repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-98
+  rev: v0.1.1-99
 - hooks:
   - id: gitleaks
   repo: https://github.com/gitleaks/gitleaks

--- a/templates/github-config/pre-commit-common.yaml
+++ b/templates/github-config/pre-commit-common.yaml
@@ -77,5 +77,8 @@ repos:
       - id: claude-skill-frontmatter
       - id: claude-agent-frontmatter
       - id: claude-mcp-config
+      # Tests are pytest + pytest-mock. The stdlib unittest framework and
+      # unittest.mock are forbidden; block them at write time, not in review.
+      - id: python-no-unittest-import
     repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-98
+    rev: v0.1.1-99


### PR DESCRIPTION
Closes #231

- bumps pre-commit-tools to `v0.1.1-99`
- adds `python-no-unittest-import` to `.pre-commit-config.yaml` and to `templates/github-config/pre-commit-common.yaml`

Both files validated with `yaml.safe_load`. Admin-merged: Actions is billing-blocked, no CI signal available.