### PR TITLE
feat(pre-commit): guard the .claude/ mirror across the fleet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,9 @@ repos:
     exclude: '^(tests?/|README\.md|docs/)'
   - id: python-unreachable-code
   - id: python-no-unittest-import
+  # The agent loads .claude/ at session start; an empty mirror loads no skill
+  # and says nothing. This is the only guard against that.
+  - id: claude-assets-present
   - id: no-hardcoded-localhost
     exclude: 'tests?/|\.test\.|\.spec\.'
   - id: regression-gate
@@ -73,7 +76,7 @@ repos:
   - id: react-no-async-in-useeffect
   - id: react-direct-dom
   repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-99
+  rev: v0.1.1-100
 - hooks:
   - id: gitleaks
   repo: https://github.com/gitleaks/gitleaks

--- a/templates/github-config/pre-commit-common.yaml
+++ b/templates/github-config/pre-commit-common.yaml
@@ -80,5 +80,8 @@ repos:
       # Tests are pytest + pytest-mock. The stdlib unittest framework and
       # unittest.mock are forbidden; block them at write time, not in review.
       - id: python-no-unittest-import
+      # The agent loads .claude/ at session start; an empty mirror loads no skill
+      # and says nothing. This is the only guard against that.
+      - id: claude-assets-present
     repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-99
+    rev: v0.1.1-100


### PR DESCRIPTION
Follow-up to the `.claude/` factorisation kill-test.

- bumps pre-commit-tools to `v0.1.1-100`
- adds `claude-assets-present` to `.pre-commit-config.yaml` and to `templates/github-config/pre-commit-common.yaml`

Wired as a **pre-commit hook, not a CI job**: Actions is billing-blocked, so a CI check would be inert exactly when it is needed. Consistent with the standard's own pre-commit doctrine (the gate is host-native).

Both files validated with `yaml.safe_load`.