### PR TITLE
chore: bump guideline-checker to v1.30.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,7 +121,7 @@ repos:
     - en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
   repo: local
 - repo: https://github.com/chrysa/guideline-checker
-  rev: v1.15.4
+  rev: v1.30.10
   hooks:
   - id: guideline-check
     # Adoption baseline: fail only on NEW violations. Regenerate with


### PR DESCRIPTION
Bumps the guideline-checker pre-commit pin `v1.15.4` -> `v1.30.10`. Clears the fleet-wide false positive where the canonical 'no executable runtime' bullet was misread as a 'no exec()' rule and flagged every RegExp.exec()/.eval() call (chrysa/guideline-checker#305).