### PR TITLE
docs(standards): GitHub Actions reuse-first, custom actions centralised, thin workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -563,6 +563,43 @@ Every repo carries a `runtime:` field in `repos.yml`, machine-checked by `audit-
   `packages:write`), never a plaintext PAT. Distributable libraries publish to public PyPI via
   Trusted Publishing (OIDC), never a token in plaintext.
 
+## GitHub Actions (reuse first · custom actions centralised · thin workflows)
+
+CI is assembled from **existing actions**, not written. A workflow is glue — checkout,
+setup, invoke the repo's own gate (`pre-commit`, `make ci`) — and every line of logic it
+carries is a line that lives in the wrong repo.
+
+- **Reuse before writing — always.** The first choice is a **maintained public action**
+  (`actions/checkout`, `actions/setup-python`, `actions/setup-node`, `astral-sh/setup-uv`,
+  `docker/build-push-action`, `SonarSource/*`, `pypa/gh-action-pypi-publish`, …).
+  Re-implementing in a `run:` block something a maintained action already does — caching,
+  toolchain setup, publishing, artifact upload — is a defect. Preferring a hand-rolled
+  script because "it's shorter" is not a reason.
+- **The only home for chrysa-specific actions is `chrysa/github-actions`.** When no public
+  action fits, the behaviour becomes a composite action / reusable workflow in that repo
+  (`python-setup`, `ruff-check`, `run-tests`, `sonar-scan`, `publish-python-package`, …)
+  and consumers reference it: `uses: chrysa/github-actions/<action>@<rev>`. Reusable
+  workflow templates live in `shared-standards/workflows/` and are distributed, never
+  hand-forked.
+- **Repo-local actions are forbidden by default.** No `.github/actions/**` composite in a
+  product repo, no inline bash beyond glue, no `scripts/ci-*.sh` that exists only to be
+  called by a workflow. The **second occurrence of the same CI logic anywhere in the fleet
+  is an extraction order**, not a copy: it moves to `chrysa/github-actions` and both repos
+  consume it. A repo-local action is tolerated only as a short-lived spike, with an issue
+  tracking its migration.
+- **Keep the code minimal.** A job step is a `uses:` or a one-line `run:`. A `run:` block
+  past ~15 lines, or any conditional/parsing/retry logic, does not belong in YAML — it
+  becomes a tested entrypoint inside the action repo (Python preferred, testable), not a
+  heredoc. Duplicated near-identical jobs collapse into a `strategy.matrix`; shared setup
+  collapses into a composite action. Workflow YAML is not a programming language and is
+  not covered by any test.
+- **Pinning & permissions.** Third-party actions are pinned by **commit SHA** (with the
+  version in a trailing comment); `chrysa/github-actions` and `actions/*` by tag.
+  Workflows declare least-privilege `permissions:` (read by default, `packages:write` /
+  `contents:write` only on the job that needs it), never a plaintext PAT where the
+  workflow `GITHUB_TOKEN` or OIDC works. Dependabot keeps the `github-actions` ecosystem
+  up to date.
+
 ## Pre-commit & git hooks (native, via pre-commit.com — never wrapped in make)
 
 The enforcement engine is **[pre-commit](https://pre-commit.com/)** itself, configured

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -420,6 +420,43 @@ Every repo carries a `runtime:` field in `repos.yml`, machine-checked by `audit-
   `packages:write`), never a plaintext PAT. Distributable libraries publish to public PyPI via
   Trusted Publishing (OIDC), never a token in plaintext.
 
+## GitHub Actions (reuse first · custom actions centralised · thin workflows)
+
+CI is assembled from **existing actions**, not written. A workflow is glue — checkout,
+setup, invoke the repo's own gate (`pre-commit`, `make ci`) — and every line of logic it
+carries is a line that lives in the wrong repo.
+
+- **Reuse before writing — always.** The first choice is a **maintained public action**
+  (`actions/checkout`, `actions/setup-python`, `actions/setup-node`, `astral-sh/setup-uv`,
+  `docker/build-push-action`, `SonarSource/*`, `pypa/gh-action-pypi-publish`, …).
+  Re-implementing in a `run:` block something a maintained action already does — caching,
+  toolchain setup, publishing, artifact upload — is a defect. Preferring a hand-rolled
+  script because "it's shorter" is not a reason.
+- **The only home for chrysa-specific actions is `chrysa/github-actions`.** When no public
+  action fits, the behaviour becomes a composite action / reusable workflow in that repo
+  (`python-setup`, `ruff-check`, `run-tests`, `sonar-scan`, `publish-python-package`, …)
+  and consumers reference it: `uses: chrysa/github-actions/<action>@<rev>`. Reusable
+  workflow templates live in `shared-standards/workflows/` and are distributed, never
+  hand-forked.
+- **Repo-local actions are forbidden by default.** No `.github/actions/**` composite in a
+  product repo, no inline bash beyond glue, no `scripts/ci-*.sh` that exists only to be
+  called by a workflow. The **second occurrence of the same CI logic anywhere in the fleet
+  is an extraction order**, not a copy: it moves to `chrysa/github-actions` and both repos
+  consume it. A repo-local action is tolerated only as a short-lived spike, with an issue
+  tracking its migration.
+- **Keep the code minimal.** A job step is a `uses:` or a one-line `run:`. A `run:` block
+  past ~15 lines, or any conditional/parsing/retry logic, does not belong in YAML — it
+  becomes a tested entrypoint inside the action repo (Python preferred, testable), not a
+  heredoc. Duplicated near-identical jobs collapse into a `strategy.matrix`; shared setup
+  collapses into a composite action. Workflow YAML is not a programming language and is
+  not covered by any test.
+- **Pinning & permissions.** Third-party actions are pinned by **commit SHA** (with the
+  version in a trailing comment); `chrysa/github-actions` and `actions/*` by tag.
+  Workflows declare least-privilege `permissions:` (read by default, `packages:write` /
+  `contents:write` only on the job that needs it), never a plaintext PAT where the
+  workflow `GITHUB_TOKEN` or OIDC works. Dependabot keeps the `github-actions` ecosystem
+  up to date.
+
 ## Pre-commit & git hooks (native, via pre-commit.com — never wrapped in make)
 
 The enforcement engine is **[pre-commit](https://pre-commit.com/)** itself, configured


### PR DESCRIPTION
## Rule added

New socle section **GitHub Actions (reuse first · custom actions centralised · thin workflows)** in `standards/STANDARDS.chrysa.md` + byte-identical inline `CLAUDE.md` mirror.

- **Reuse first** — maintained public actions (`actions/*`, `docker/build-push-action`, `astral-sh/setup-uv`, `SonarSource/*`, …) before any hand-written `run:`. Re-implementing what an action already does is a defect.
- **One home for custom actions** — `chrysa/github-actions` (composite actions / reusable workflows), consumed via `uses: chrysa/github-actions/<action>@<rev>`; workflow templates distributed from `shared-standards/workflows/`.
- **Repo-local actions forbidden by default** — no `.github/actions/**` in product repos, no CI-only `scripts/ci-*.sh`. Second occurrence of the same CI logic in the fleet = extraction order, not a copy.
- **Minimal code** — a step is a `uses:` or a one-liner; a `run:` past ~15 lines or carrying logic becomes a tested entrypoint in the action repo. Matrix over duplicated jobs. YAML is untested code.
- **Pinning & permissions** — third-party by commit SHA, chrysa/actions by tag; least-privilege `permissions:`, `GITHUB_TOKEN`/OIDC over PAT.

Canon text only, no behaviour change.