### PR TITLE
fix(quality-gate): stop reading pytest progress as the coverage figure

### DIFF
--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -85,14 +85,45 @@ class QualityGate:
                 return int(match.group(1))
         return 0
 
+    # Coverage summary lines, in order of trust. Anchored on purpose: a loose
+    # "any line mentioning coverage" scan matches pytest's own verbose progress
+    # (`… ::test_service_named_dev_is_covered PASSED [ 13%]`) and reports the
+    # progress percentage as the coverage figure.
+    COVERAGE_PATTERNS = (
+        r"^TOTAL\s+.*?(\d+(?:\.\d+)?)%",  # pytest-cov / coverage term report
+        r"Total coverage:\s*(\d+(?:\.\d+)?)%",  # --cov-fail-under summary line
+        r"All files\s*\|\s*(\d+(?:\.\d+)?)",  # jest / istanbul text summary
+        r"^Statements\s*:\s*(\d+(?:\.\d+)?)%",  # nyc text-summary
+    )
+
     def _parse_coverage(self, output: str) -> float:
-        for line in output.splitlines():
-            if any(token in line.lower() for token in ["total", "coverage", "covered"]):
-                for value in re.findall(r"(\d+(?:\.\d+)?)%", line):
-                    try:
-                        return float(value)
-                    except ValueError:
-                        continue
+        for pattern in self.COVERAGE_PATTERNS:
+            match = re.search(pattern, output, flags=re.IGNORECASE | re.MULTILINE)
+            if match:
+                try:
+                    return float(match.group(1))
+                except ValueError:
+                    continue
+        return self._parse_coverage_report()
+
+    def _parse_coverage_report(self) -> float:
+        """Read the coverage percentage from a written XML report.
+
+        `make test-cov` may emit only `--cov-report=xml`, in which case stdout
+        carries no summary at all and the textual patterns above find nothing.
+        """
+        for candidate in (Path("reports/coverage.xml"), Path("coverage.xml")):
+            if not candidate.is_file():
+                continue
+            match = re.search(
+                r'<coverage[^>]*\bline-rate="([0-9.]+)"',
+                candidate.read_text(encoding="utf-8", errors="replace"),
+            )
+            if match:
+                try:
+                    return round(float(match.group(1)) * 100, 2)
+                except ValueError:
+                    continue
         return -1.0
 
     def _parse_warning_count(self, output: str) -> int:


### PR DESCRIPTION
## Why
The canonical gate distributed to the fleet reports a bogus coverage number. `_parse_coverage` took the first percentage on any line containing `total`/`coverage`/`covered`; pytest's own verbose progress lines match:

```
tests/…::test_service_named_dev_is_covered PASSED [ 13%]
```

On `chrysa/pre-commit-tools` (real coverage 94%) the gate reported `current=13.0` against a 58.0 baseline and failed as a *metric regression*.

## What
- Matching anchored on genuine summary lines: `^TOTAL … %`, `Total coverage: X%`, istanbul `All files |`, nyc `Statements :`.
- New fallback reading `line-rate` from `reports/coverage.xml` / `coverage.xml`, for repos whose `make test-cov` emits only `--cov-report=xml` (no textual summary at all — the previous code returned `-1.0` there).

## Verification
Replayed against real captured output from `chrysa/pre-commit-tools`:

| input | before | after |
|---|---|---|
| full `pytest -v --cov` output | 13.0 | 91.73 |
| `TOTAL  3467  211  94%` | 94.0 | 94.0 |
| `Required test coverage of 85% reached. Total coverage: 93.91%` | 85.0 | 93.91 |
| no summary at all | -1.0 | -1.0 |

Note the third row: the old code also mis-read the `--cov-fail-under` line, returning the *threshold* (85) instead of the measured value.

Closes #258