### PR TITLE
feat(pre-commit): distribute the three code-quality hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,13 @@ repos:
     exclude: '^(tests?/|README\.md|docs/)'
   - id: python-unreachable-code
   - id: python-no-unittest-import
+  # Mechanise the code-quality rules of the standards block: typed raises,
+  # lookup table over dispatch ladder, and the mutable-default anti-pattern.
+  # Fixtures deliberately raise builtins as detector input, hence the exclude.
+  - id: python-untyped-raise
+    exclude: '^tests?/'
+  - id: python-mutable-default
+  - id: python-dispatch-ladder
   # The agent loads .claude/ at session start; an empty mirror loads no skill
   # and says nothing. This is the only guard against that.
   - id: claude-assets-present
@@ -78,7 +85,7 @@ repos:
   - id: react-no-async-in-useeffect
   - id: react-direct-dom
   repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-100
+  rev: v0.2.0-247
 - hooks:
   - id: gitleaks
   repo: https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
## Why
#250 put four code-quality rules in the standards block and fanned them out to 63 repos. Three of them now have detectors (pre-commit-tools#316, released `v0.2.0-247`) — but the baseline still pinned `v0.1.1-100` and listed none, so **no repo actually enforced anything**.

## What
In the python section of the baseline: `python-untyped-raise` (exclude `^tests?/`), `python-mutable-default`, `python-dispatch-ladder`; `rev` → `v0.2.0-247`.

`pre-commit-merge.py` only adds missing ids and preserves existing per-repo entries, so the fan-out is additive — no repo loses its own excludes or revs.

## Blast radius (measured, not assumed)
Ran the three hooks over every tracked `.py` of 7 checkouts:

| repo | untyped-raise | mutable-default | dispatch-ladder |
|---|---|---|---|
| chrysa-lib | 3 | 0 | 0 |
| doc-gen | 4 | 0 | 0 |
| chrysa-portfolio-viz | 16 | 0 | 0 |
| guideline-checker | 2 | 0 | 0 |
| dev-nexus | 5 | 0 | 0 |
| server | 0 | 0 | 0 |
| automations | 2 | 0 | 0 |

32 findings total, all on one hook. These are commit-stage hooks over changed files, so a pre-existing finding surfaces when its file is next touched.

## Verification
The three hooks run clean on this repo at the new rev (`pre-commit run <id> --all-files`: Passed ×3).

Closes #260