### PR TITLE
fix: align the gate on canonical targets, free the duplicate ADR id, apply D-0007

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,11 +15,6 @@ jobs:
         name: Check PR dependencies
 
         steps:
-            - name: Check dependencies
-              uses: gregsdennis/dependencies-action@v1.4.2
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
             - name: Add dependent label
               if: >-
                   contains(github.event.pull_request.body, 'depends on') ||

--- a/.quality-gate.json
+++ b/.quality-gate.json
@@ -1,10 +1,10 @@
 {
   "commands": {
     "build": "make build",
-    "coverage": "make test-coverage",
+    "coverage": "make test-cov",
     "lint": "make lint",
     "tests": "make test",
-    "types": "make type-check"
+    "types": "make typecheck"
   },
   "description": "Quality gate configuration for mixed project",
   "thresholds": {

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -98,7 +98,7 @@ hard `❌`/`⚠️`. Shipped in shared-standards PR #110.
 
 ---
 
-## D-0005 — Standards management console (`console/`)
+## D-0008 — Standards management console (`console/`)
 
 **Date**: 2026-06-28
 **Status**: accepted


### PR DESCRIPTION
Closes #264

Three findings from the 2026-07-27 audit, still open **in this repo** — the one that publishes the standard.

## 1. The gate called targets the standard bans

```diff
- "coverage": "make test-coverage",
- "types":    "make type-check",
+ "coverage": "make test-cov",
+ "types":    "make typecheck",
```

`type-check` is **explicitly forbidden** by the Makefile-naming rule, and neither target exists here — so those two gates could only ever fail. The machine-readable gate was contradicting the prose standard it exists to enforce. Verified: `make -n test-cov` and `make -n typecheck` resolve, `make -n test-coverage` does not.

## 2. `D-0005` identified two different ADRs

*pytest plugin exclusions* and *standards management console*. GV-010 makes an id collision a **blocking error**; here it quietly broke ADR traceability. The console ADR becomes **D-0008**.

A third, unrelated `D-0005` lives in `docs/specs/spec-v1.md` ("LICENSE MIT par défaut") — different series, left alone, flagged in the issue rather than renamed by guess.

## 3. D-0007 was accepted but not applied

It states `gregsdennis/dependencies-action` "is removed" in favour of `depends-on/depends-on-action`, which `pr-dependencies.yml` already runs — yet `dependencies.yml` still invoked the superseded action. **Both mechanisms were live**, which is how a supersession quietly becomes a duplication. Removed; the `dependent` label step stays.

actionlint clean.