### PR TITLE
ci(release): release on markdown changes — the standards ARE the product

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,14 @@ name: Release
 on:
     push:
         branches: [main]
+        # NOTE: '**.md' is deliberately NOT ignored here. In this repo the product *is*
+        # markdown — standards/STANDARDS.chrysa.md and its annexes — and the release is what
+        # triggers distribute-standards. Ignoring markdown meant a standards-only promotion
+        # to main cut no release and never reached the fleet.
         paths-ignore:
-            - '**.md'
             - '.github/**'
+            - 'README.md'
+            - 'CHANGELOG.md'
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
`release.yml` ignored `**.md` on push to `main`. In this repo the product *is* markdown (`standards/STANDARDS.chrysa.md` + annexes), and the release is what triggers `distribute-standards` — so a standards-only promotion cut no release and **never reached the fleet**.

Observed live: the floating-assistant (#281) + agent-legible-architecture (#282) batch merged to `main` via #284 without cutting a release; it shipped only after a manual `workflow_dispatch` (v1.1.0-237).

`README.md` and `CHANGELOG.md` stay ignored (they are release *outputs*), as does `.github/**`.

Refs #278