### PR TITLE
fix(hooks): guard claude hook commands against missing hook files

### DIFF
--- a/.claude/HOOKS_README.md
+++ b/.claude/HOOKS_README.md
@@ -222,8 +222,8 @@ node .claude/hooks/model-debt-inventory.cjs --dir /path/to/repo
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "node .claude/hooks/secret-scanner.cjs" },
-          { "type": "command", "command": "node .claude/hooks/circuit-breaker.cjs" }
+          { "type": "command", "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/secret-scanner.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'" },
+          { "type": "command", "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/circuit-breaker.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'" }
         ]
       }
     ],
@@ -231,14 +231,14 @@ node .claude/hooks/model-debt-inventory.cjs --dir /path/to/repo
       {
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
-          { "type": "command", "command": "node .claude/hooks/verifiable-thresholds.cjs" }
+          { "type": "command", "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/verifiable-thresholds.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'" }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "node .claude/hooks/frustration-detection.cjs" }
+          { "type": "command", "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/frustration-detection.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'" }
         ]
       }
     ]
@@ -248,6 +248,15 @@ node .claude/hooks/model-debt-inventory.cjs --dir /path/to/repo
 
 3. Adjust `.claude/thresholds.json` for your project standards
 4. Add `.claude/secret-scanner-allowlist.json` if you have test fixtures with example tokens
+
+> **Always use the guarded command form** shown above
+> (`sh -c 'f="$CLAUDE_PROJECT_DIR/.claude/hooks/<hook>.cjs"; [ ! -f "$f" ] || node "$f"'`),
+> never a bare `node .claude/hooks/<hook>.cjs`. A bare invocation in a repo where the hook
+> file is absent makes Node exit with `MODULE_NOT_FOUND`, which Claude Code reports on every
+> single tool call as:
+> `PreToolUse:Bash hook error - Failed with non-blocking status code: node:internal/modules/cjs/loader:<line>`.
+> The guard turns a missing hook into a silent no-op, and `$CLAUDE_PROJECT_DIR` makes the
+> path independent of the tool's working directory.
 
 ## Disabling a hook
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
       {
         "hooks": [
           {
-            "command": "node .claude/hooks/verifiable-thresholds.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/verifiable-thresholds.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "verifiable-thresholds",
             "timeout": 10000,
             "type": "command"
@@ -43,13 +43,13 @@
       {
         "hooks": [
           {
-            "command": "node .claude/hooks/secret-scanner.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/secret-scanner.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "secret-scanner",
             "timeout": 10000,
             "type": "command"
           },
           {
-            "command": "node .claude/hooks/circuit-breaker.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/circuit-breaker.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "circuit-breaker",
             "timeout": 5000,
             "type": "command"
@@ -62,7 +62,7 @@
       {
         "hooks": [
           {
-            "command": "node .claude/hooks/frustration-detection.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/frustration-detection.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "frustration-detection",
             "timeout": 5000,
             "type": "command"

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -11,7 +11,7 @@
     ],
     "PostToolUse": [
       {
-        "command": "node .claude/hooks/verifiable-thresholds.cjs",
+        "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/verifiable-thresholds.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
         "matcher": "Write|Edit|MultiEdit",
         "name": "verifiable-thresholds",
         "timeout": 10000
@@ -26,13 +26,13 @@
     ],
     "PreToolUse": [
       {
-        "command": "node .claude/hooks/secret-scanner.cjs",
+        "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/secret-scanner.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
         "matcher": "Bash",
         "name": "secret-scanner",
         "timeout": 10000
       },
       {
-        "command": "node .claude/hooks/circuit-breaker.cjs",
+        "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/circuit-breaker.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
         "matcher": "Bash",
         "name": "circuit-breaker",
         "timeout": 5000
@@ -40,7 +40,7 @@
     ],
     "UserPromptSubmit": [
       {
-        "command": "node .claude/hooks/frustration-detection.cjs",
+        "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/frustration-detection.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
         "matcher": "*",
         "name": "frustration-detection",
         "timeout": 5000


### PR DESCRIPTION
A bare `node .claude/hooks/<hook>.cjs` hook command makes Node exit with `MODULE_NOT_FOUND` in any repo where the hook file is absent. Claude Code then reports, on **every single tool call**:

```
PreToolUse:Bash hook error
Failed with non-blocking status code: node:internal/modules/cjs/loader:1520
```

This rewrites every hook command to the guarded form already used elsewhere:

```sh
sh -c 'f="$CLAUDE_PROJECT_DIR/.claude/hooks/<hook>.cjs"; [ ! -f "$f" ] || node "$f"'
```

Two effects: a missing hook file becomes a silent no-op instead of a hard error, and `$CLAUDE_PROJECT_DIR` makes the path independent of the tool's working directory.

Files: `templates/settings.json (4)`, `.claude/settings.json (4)`, `.claude/HOOKS_README.md (4)`

Closes #290