### PR TITLE
docs(standards): record the deliberate Ruff exclusions

### DIFF
--- a/scripts/pyproject-ruff-merge.py
+++ b/scripts/pyproject-ruff-merge.py
@@ -55,6 +55,14 @@ CANONICAL_RULES: tuple[str, ...] = (
     "RUF100",  # unused-noqa — autofixable, keeps suppressions honest
 )
 
+# Rules the `PLR*`/`RUF` shorthand in the standards block would imply, excluded on
+# purpose. Named here so the decision is visible at the point of distribution rather
+# than only in an issue — see STANDARDS.chrysa.md, *known anti-patterns*.
+DELIBERATELY_EXCLUDED: dict[str, str] = {
+    "PLR2004": "magic-value-comparison — 2519 fleet findings; the `no hardcoded constants` chantier, not a flag",
+    "RUF001": "ambiguous-unicode — 493 findings on 4 repos, all French prose; arm locally with allowed-confusables",
+}
+
 _SELECT_RE = re.compile(r"(?P<head>^select\s*=\s*\[)(?P<body>.*?)(?P<tail>^\s*\])", re.DOTALL | re.MULTILINE)
 
 

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -491,6 +491,17 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   Mechanisation: Ruff (`C901`, `PLR*`, `B`, `SIM`, `PERF`, `RUF`) + Mypy on Python, ESLint
   (`complexity`, `no-await-in-loop`, `react-hooks/exhaustive-deps`) on TS, SonarCloud rating **A**
   with 0 hotspot on both. A finding here is a defect to fix, not a warning to carry.
+  The armed Ruff selection is the canonical set distributed by `scripts/pyproject-ruff-merge.py`
+  and merged into each repo's `[tool.ruff.lint] select` — the script is the source of truth for
+  which codes are on. Two rules that the `PLR*`/`RUF` shorthand above would otherwise imply are
+  **deliberately excluded**, and stay excluded until a decision says otherwise:
+  - `PLR2004` (magic-value-comparison) — 2519 findings across the 65 repos. Hardcoded constants
+    are a chantier with its own remediation (extract to an enum or external config), not a flag
+    to flip; arming it would turn every gate red at once.
+  - `RUF001` (ambiguous-unicode-character-string) — 493 findings concentrated on 4 repos, all of
+    them French user-facing copy using typographic characters (apostrophes, non-breaking spaces).
+    The rule is right about the codepoints and wrong about the intent. A repo that wants it may
+    arm it locally together with `lint.allowed-confusables`.
 
 ## Quality gates
 


### PR DESCRIPTION
Closes #273 — takes the **exclude explicitly** option.

## Decision
`RUF001` (ambiguous-unicode-character-string) stays **out** of the canonical set. 493 findings on 4 of 65 repos, all of them French user-facing copy using typographic characters — apostrophes, non-breaking spaces. The rule is right about the codepoints and wrong about the intent. A repo that wants it can arm it locally alongside `lint.allowed-confusables`.

`PLR2004` stays out for the already-measured reason: 2519 findings, a remediation chantier (extract to enum/config), not a flag to flip.

## Why this is a change and not a comment
The standards block mechanises quality through "Ruff (`C901`, `PLR*`, `B`, `SIM`, `PERF`, `RUF`)". That shorthand *implies* both rules. Nothing said they were out, so the only available reading was that someone forgot them — exactly the state #273 called out.

- `standards/STANDARDS.chrysa.md`: the armed selection is declared to be whatever `pyproject-ruff-merge.py` distributes, followed by the two exclusions with their reasons and volumes.
- `scripts/pyproject-ruff-merge.py`: `DELIBERATELY_EXCLUDED` — code → reason — so the decision lives at the point of distribution, next to `CANONICAL_RULES`, instead of only in an issue.

## Verification
- `pyproject-ruff-merge.py pyproject.toml --check` → exit 0, unchanged behaviour
- asserted `CANONICAL_RULES ∩ DELIBERATELY_EXCLUDED == ∅` (20 canonical, 2 excluded)
- `ruff check` clean on `console/`

Unrelated pre-existing finding, left alone: `pyproject-ruff-merge.py` itself trips `PLR0911` (8 returns > 6) in `main` — present before this diff, worth its own PR.