### PR TITLE
ci(actions): pin every third-party action by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7.0.1
 
-            - uses: astral-sh/setup-uv@v7
+            - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
               with:
                   enable-cache: true
 
@@ -89,7 +89,7 @@ jobs:
         steps:
             - uses: actions/checkout@v7.0.1
 
-            - uses: pnpm/action-setup@v6
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
               with:
                   version: 9
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - id: metadata
       name: Fetch Dependabot metadata
-      uses: dependabot/fetch-metadata@v3
+      uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - env:

--- a/.github/workflows/distribute-standards.yml
+++ b/.github/workflows/distribute-standards.yml
@@ -107,7 +107,7 @@ jobs:
 
             - name: Open sync PR
               if: ${{ github.event.inputs.dry_run != 'true' && steps.base.outputs.skip != 'true' }}
-              uses: peter-evans/create-pull-request@v8
+              uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
               with:
                   path: target
                   token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
-      - uses: depends-on/depends-on-action@0.17.0
+      - uses: depends-on/depends-on-action@c7ac9a6932a7069e83aef80c202d9f60f91e43fd # 0.17.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   check_dependencies_merged:
     name: Check dependent Pull Requests are merged
     runs-on: ubuntu-latest
     steps:
-      - uses: depends-on/depends-on-action@0.17.0
+      - uses: depends-on/depends-on-action@c7ac9a6932a7069e83aef80c202d9f60f91e43fd # 0.17.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           check-unmerged-pr: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,16 +24,16 @@ jobs:
                   token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
             - name: Setup GitVersion
-              uses: gittools/actions/gitversion/setup@v4
+              uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4
               with:
                   versionSpec: 6.x
 
             - name: Determine version
               id: gitversion
-              uses: gittools/actions/gitversion/execute@v4
+              uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4
 
             - name: Install git-cliff
-              uses: taiki-e/install-action@git-cliff
+              uses: taiki-e/install-action@fec60f319ad7cbc8b09dc216572fc3b29817d658 # git-cliff
 
             - name: Generate changelog
               id: changelog
@@ -51,7 +51,7 @@ jobs:
                   git push origin "${{ steps.changelog.outputs.version }}" || echo "Tag push skipped"
 
             - name: Create GitHub Release
-              uses: softprops/action-gh-release@v3
+              uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
               with:
                   tag_name: ${{ steps.changelog.outputs.version }}
                   name: Release ${{ steps.changelog.outputs.version }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
     - name: Sync labels
-      uses: EndBug/label-sync@v2
+      uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2
       with:
         config-file: .github/labels.yml
         delete-other-labels: false

--- a/templates/workflows-process/pr-dependencies.yml
+++ b/templates/workflows-process/pr-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: gregsdennis/dependencies-action@v1.4.2
+        uses: gregsdennis/dependencies-action@a8cccab69814b9b985496cf97cbfe154c96c03c7 # v1.4.2
       - uses: Levi-Lesches/blocking-issues@2eeffdc6b055341f635eb0f3e4aea671516a61dc
         with:
           use-label: Blocked

--- a/workflows/mutation-testing.yml
+++ b/workflows/mutation-testing.yml
@@ -105,7 +105,7 @@ jobs:
 
             - name: Notify Discord on failure
               if: failure() && secrets.DISCORD_WEBHOOK != ''
-              uses: Ilshidur/action-discord@0.3.2
+              uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # 0.3.2
               env:
                   DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
               with:

--- a/workflows/pages.yml
+++ b/workflows/pages.yml
@@ -96,7 +96,7 @@ jobs:
               run: ${{ inputs.build-command }}
 
             - name: Deploy to GitHub Pages
-              uses: peaceiris/actions-gh-pages@v4
+              uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: ${{ inputs.publish-dir || 'site' }}

--- a/workflows/pr-size.yml
+++ b/workflows/pr-size.yml
@@ -59,7 +59,7 @@ jobs:
         name: Label PR by size
         steps:
             - name: Label pull request by size
-              uses: codelytv/pr-size-labeler@v1
+              uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   xs_max_size: ${{ inputs.xs-max-size || 20 }}

--- a/workflows/regression-gate.yml
+++ b/workflows/regression-gate.yml
@@ -90,7 +90,7 @@ jobs:
             - name: Download quality baseline from main
               if: github.event_name == 'pull_request'
               id: download-baseline
-              uses: dawidd6/action-download-artifact@v9
+              uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
               with:
                   workflow: ${{ github.workflow }}
                   branch: ${{ github.event.pull_request.base.ref }}

--- a/workflows/release.yml
+++ b/workflows/release.yml
@@ -72,16 +72,16 @@ jobs:
                   token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
             - name: Install GitVersion
-              uses: gittools/actions/gitversion/setup@v3
+              uses: gittools/actions/gitversion/setup@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3
               with:
                   versionSpec: '6.x'
 
             - name: Determine version
               id: gitversion
-              uses: gittools/actions/gitversion/execute@v3
+              uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3
 
             - name: Install git-cliff
-              uses: taiki-e/install-action@git-cliff
+              uses: taiki-e/install-action@fec60f319ad7cbc8b09dc216572fc3b29817d658 # git-cliff
 
             - name: Generate changelog
               id: changelog
@@ -100,7 +100,7 @@ jobs:
 
             - name: Create GitHub Release
               if: ${{ inputs.create-github-release }}
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
               with:
                   tag_name: ${{ steps.changelog.outputs.version }}
                   name: Release ${{ steps.changelog.outputs.version }}

--- a/workflows/secret-scan.yml
+++ b/workflows/secret-scan.yml
@@ -55,6 +55,6 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: gitleaks/gitleaks-action@v2
+            - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/sonar.yml
+++ b/workflows/sonar.yml
@@ -60,7 +60,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: SonarSource/sonarcloud-github-action@master
+            - uses: SonarSource/sonarcloud-github-action@ba3875ecf642b2129de2b589510c81a8b53dbf4e # master
               env:
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
                   SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL || 'https://sonarcloud.io' }}


### PR DESCRIPTION
Applies the pinning rule from the new GitHub Actions standard to the canonical workflow sources.

22 references moved from a mutable tag/branch to a full commit SHA, version kept in a trailing comment. Worst offenders fixed:

- `SonarSource/sonarcloud-github-action@master` — a moving branch
- `taiki-e/install-action@git-cliff` — a moving tag alias
- `gregsdennis/dependencies-action@v1.4.2` — the single most duplicated unpinned action in the fleet (46 occurrences, distributed from `templates/workflows-process/pr-dependencies.yml`)
- `gittools/actions/*`, `softprops/action-gh-release`, `peaceiris/actions-gh-pages`, `gitleaks/gitleaks-action`, `dependabot/fetch-metadata`, `depends-on/depends-on-action`, `astral-sh/setup-uv`, `pnpm/action-setup`, `EndBug/label-sync`, `codelytv/pr-size-labeler`, `dawidd6/action-download-artifact`, `Ilshidur/action-discord`, `peter-evans/create-pull-request`

Scope: `templates/workflows-process/` + `workflows/` (distributed) and this repo's own `.github/workflows/`. `actions/*` and `chrysa/*` intentionally stay on tags per the standard. All files still parse.

Found by a fleet audit: 87 unpinned third-party references across 63 repos; this kills the source of the distributed ones. The rest are per-repo hand-written workflows (mostly `pre-commit/action@v3.0.1`), handled separately.