### PR TITLE
fix(standards): merge the ruff rules into every pyproject, not the first

### DIFF
--- a/scripts/apply-repo-standard.sh
+++ b/scripts/apply-repo-standard.sh
@@ -223,19 +223,26 @@ merge_precommit() {
 # Ruff's config is per-pyproject and cannot be copied (the standard forbids
 # ruff.toml), so the canonical rule set is merged into whichever pyproject owns
 # the repo's Python package — root, or one level down in a monorepo.
-find_pyproject() {
-    local repo="$1"
-    [[ -f "$repo/pyproject.toml" ]] && { echo "$repo/pyproject.toml"; return 0; }
-    local candidate
+find_pyprojects() {
+    # Every pyproject that can own Python, not just the first: a monorepo may
+    # carry backend/ and agent/ side by side, and returning one silently left
+    # the other outside the rule set (measured on satisfactory-factory-manager).
+    local repo="$1" found=1 candidate
+    if [[ -f "$repo/pyproject.toml" ]]; then
+        echo "$repo/pyproject.toml"
+        return 0
+    fi
     for candidate in "$repo"/*/pyproject.toml; do
-        [[ -f "$candidate" ]] && { echo "$candidate"; return 0; }
+        [[ -f "$candidate" ]] || continue
+        echo "$candidate"
+        found=0
     done
-    return 1
+    return $found
 }
 
 merge_ruff_rules() {
-    local repo="$1" target
-    if ! target="$(find_pyproject "$repo")"; then
+    local repo="$1" targets
+    if ! targets="$(find_pyprojects "$repo")"; then
         # Reported in every mode: a repo with Python but no pyproject cannot
         # receive the rules at all, and silence would read as compliance.
         info "no pyproject.toml · ruff rules not applicable"
@@ -243,17 +250,23 @@ merge_ruff_rules() {
     fi
     local merger="$SCRIPT_DIR/pyproject-ruff-merge.py"
     [[ -f "$merger" ]] || { warn "pyproject-ruff-merge.py missing · ruff rules skipped"; return 0; }
-    if $CHECK; then
-        python3 "$merger" "$target" --check && ok "ruff rules compliant" || warn "ruff rule drift (see above)"
-        return 0
-    fi
-    if $DRY_RUN; then
-        python3 "$merger" "$target" --check >/dev/null 2>&1 \
-            && info "[dry-run] ruff rules already complete" \
-            || info "[dry-run] would add the canonical ruff rules to ${target#"$repo"/}"
-        return 0
-    fi
-    python3 "$merger" "$target" >/dev/null && ok "ruff rules merged into ${target#"$repo"/}"
+    local target rel
+    while IFS= read -r target; do
+        [[ -n "$target" ]] || continue
+        rel="${target#"$repo"/}"
+        if $CHECK; then
+            python3 "$merger" "$target" --check && ok "ruff rules compliant · $rel" \
+                || warn "ruff rule drift in $rel (see above)"
+            continue
+        fi
+        if $DRY_RUN; then
+            python3 "$merger" "$target" --check >/dev/null 2>&1 \
+                && info "[dry-run] ruff rules already complete · $rel" \
+                || info "[dry-run] would add the canonical ruff rules to $rel"
+            continue
+        fi
+        python3 "$merger" "$target" >/dev/null && ok "ruff rules merged into $rel"
+    done <<< "$targets"
 }
 
 apply_one() {

--- a/scripts/pyproject-ruff-merge.py
+++ b/scripts/pyproject-ruff-merge.py
@@ -55,6 +55,14 @@ CANONICAL_RULES: tuple[str, ...] = (
     "RUF100",  # unused-noqa — autofixable, keeps suppressions honest
 )
 
+# Rules the `PLR*`/`RUF` shorthand in the standards block would imply, excluded on
+# purpose. Named here so the decision is visible at the point of distribution rather
+# than only in an issue — see STANDARDS.chrysa.md, *known anti-patterns*.
+DELIBERATELY_EXCLUDED: dict[str, str] = {
+    "PLR2004": "magic-value-comparison — 2519 fleet findings; the `no hardcoded constants` chantier, not a flag",
+    "RUF001": "ambiguous-unicode — 493 findings on 4 repos, all French prose; arm locally with allowed-confusables",
+}
+
 _SELECT_RE = re.compile(r"(?P<head>^select\s*=\s*\[)(?P<body>.*?)(?P<tail>^\s*\])", re.DOTALL | re.MULTILINE)
 
 

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -491,6 +491,17 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   Mechanisation: Ruff (`C901`, `PLR*`, `B`, `SIM`, `PERF`, `RUF`) + Mypy on Python, ESLint
   (`complexity`, `no-await-in-loop`, `react-hooks/exhaustive-deps`) on TS, SonarCloud rating **A**
   with 0 hotspot on both. A finding here is a defect to fix, not a warning to carry.
+  The armed Ruff selection is the canonical set distributed by `scripts/pyproject-ruff-merge.py`
+  and merged into each repo's `[tool.ruff.lint] select` — the script is the source of truth for
+  which codes are on. Two rules that the `PLR*`/`RUF` shorthand above would otherwise imply are
+  **deliberately excluded**, and stay excluded until a decision says otherwise:
+  - `PLR2004` (magic-value-comparison) — 2519 findings across the 65 repos. Hardcoded constants
+    are a chantier with its own remediation (extract to an enum or external config), not a flag
+    to flip; arming it would turn every gate red at once.
+  - `RUF001` (ambiguous-unicode-character-string) — 493 findings concentrated on 4 repos, all of
+    them French user-facing copy using typographic characters (apostrophes, non-breaking spaces).
+    The rule is right about the codepoints and wrong about the intent. A repo that wants it may
+    arm it locally together with `lint.allowed-confusables`.
 
 ## Quality gates
 


### PR DESCRIPTION
Found while measuring the #271 rollout across the 63 `status: dev` repos.

`find_pyproject` returned the **first** match and stopped. In a monorepo with two Python packages side by side, one got the canonical rules and the other silently stayed outside them — while the run reported success.

## Measured
`satisfactory-factory-manager`:
```
✓ ruff rules compliant · agent/pyproject.toml
⚠ ruff rule drift in backend/pyproject.toml
  missing: C901, PERF203, PERF401, PLR0402, PLR0911, PLR0912, PLR0915,
           PLR1714, PLR1730, PLR5501, RUF005…RUF100   (all 20)
```
`agent/` sorts before `backend/`, so `backend/` — 82 of the repo's Python files — was never reached.

## Change
`find_pyprojects` emits every candidate; `merge_ruff_rules` loops and reports per file in all three modes (`--check`, `--dry-run`, apply). Root-pyproject repos are unaffected: the root still short-circuits, verified against `cdn-explorer` (`✓ ruff rules compliant · pyproject.toml`).

## Rollout status this came from
Of the 63 `status: dev` repos, measured against each repo's real config:

| state | repos |
|---|---|
| root `pyproject.toml`, rules present | 42 |
| monorepo, nested pyproject, rules present | 7 (one of them only partly — this bug) |
| **Python but no pyproject anywhere** | **13** |

So the rollout is materially done for every repo that can receive it. The remaining gap is the 13 repos with loose Python and no pyproject — the windows-autonome case (chrysa/windows-autonome#205), 13 more times. Detail posted on #271.