### PR TITLE
release: semantic web standard (markup, data, URLs)

### DIFF
--- a/.claude/HOOKS_README.md
+++ b/.claude/HOOKS_README.md
@@ -222,8 +222,8 @@ node .claude/hooks/model-debt-inventory.cjs --dir /path/to/repo
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "node .claude/hooks/secret-scanner.cjs" },
-          { "type": "command", "command": "node .claude/hooks/circuit-breaker.cjs" }
+          { "type": "command", "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/secret-scanner.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'" },
+          { "type": "command", "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/circuit-breaker.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'" }
         ]
       }
     ],
@@ -231,14 +231,14 @@ node .claude/hooks/model-debt-inventory.cjs --dir /path/to/repo
       {
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
-          { "type": "command", "command": "node .claude/hooks/verifiable-thresholds.cjs" }
+          { "type": "command", "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/verifiable-thresholds.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'" }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          { "type": "command", "command": "node .claude/hooks/frustration-detection.cjs" }
+          { "type": "command", "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/frustration-detection.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'" }
         ]
       }
     ]
@@ -248,6 +248,15 @@ node .claude/hooks/model-debt-inventory.cjs --dir /path/to/repo
 
 3. Adjust `.claude/thresholds.json` for your project standards
 4. Add `.claude/secret-scanner-allowlist.json` if you have test fixtures with example tokens
+
+> **Always use the guarded command form** shown above
+> (`sh -c 'f="$CLAUDE_PROJECT_DIR/.claude/hooks/<hook>.cjs"; [ ! -f "$f" ] || node "$f"'`),
+> never a bare `node .claude/hooks/<hook>.cjs`. A bare invocation in a repo where the hook
+> file is absent makes Node exit with `MODULE_NOT_FOUND`, which Claude Code reports on every
+> single tool call as:
+> `PreToolUse:Bash hook error - Failed with non-blocking status code: node:internal/modules/cjs/loader:<line>`.
+> The guard turns a missing hook into a silent no-op, and `$CLAUDE_PROJECT_DIR` makes the
+> path independent of the tool's working directory.
 
 ## Disabling a hook
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
       {
         "hooks": [
           {
-            "command": "node .claude/hooks/verifiable-thresholds.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/verifiable-thresholds.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "verifiable-thresholds",
             "timeout": 10000,
             "type": "command"
@@ -43,13 +43,13 @@
       {
         "hooks": [
           {
-            "command": "node .claude/hooks/secret-scanner.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/secret-scanner.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "secret-scanner",
             "timeout": 10000,
             "type": "command"
           },
           {
-            "command": "node .claude/hooks/circuit-breaker.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/circuit-breaker.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "circuit-breaker",
             "timeout": 5000,
             "type": "command"
@@ -62,7 +62,7 @@
       {
         "hooks": [
           {
-            "command": "node .claude/hooks/frustration-detection.cjs",
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/frustration-detection.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
             "name": "frustration-detection",
             "timeout": 5000,
             "type": "command"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,14 @@ name: Release
 on:
     push:
         branches: [main]
+        # NOTE: '**.md' is deliberately NOT ignored here. In this repo the product *is*
+        # markdown — standards/STANDARDS.chrysa.md and its annexes — and the release is what
+        # triggers distribute-standards. Ignoring markdown meant a standards-only promotion
+        # to main cut no release and never reached the fleet.
         paths-ignore:
-            - '**.md'
             - '.github/**'
+            - 'README.md'
+            - 'CHANGELOG.md'
     workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,25 @@ deprecated and archived — nothing is added to it, nothing reads from it.
 - **Language**: English — all code, comments, docs, instructions, and config files.
 - **Commits**: Conventional Commits (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`).
 - **Branches**: `feature/`, `bugfix/`, `chore/`, `hotfix/`, `release/` · default branch `develop`.
+- **Branch model — `main` is production, `develop` is the workspace.** Every repo runs the
+  same two long-lived branches, and the mapping is literal, not decorative:
+  1. **`main` = the code deployed in production.** It is a **protected branch**: no direct
+     push, no force push, no branch deletion; every change arrives through a pull request.
+     Reading `main` answers "what is running in prod right now" — nothing else is on it.
+  2. **`develop` is the repository's default branch** (the GitHub default, what a clone
+     checks out) and the integration target for all work. A repo whose default branch is
+     `main` is a defect, not a variant.
+  3. **Every feature/bugfix/chore PR targets `develop`.** `feature/x` → PR → `develop`.
+     A feature PR opened against `main` is closed and retargeted.
+  4. **The only way code reaches `main` is a pull request from `develop`** (or, for a
+     production emergency, a `hotfix/` branch — which is merged back into `develop` in the
+     same breath so the two never diverge). No other source branch may target `main`.
+  5. **Production is triggered by a new release**, not by a merge: merging `develop` → `main`
+     lands the code, and the deployment is driven by the tagged release (GitVersion tag +
+     git-cliff changelog + the release workflow). No manual deploy from a laptop, no push
+     that silently ships.
+  Protection is configured, not assumed: `main` requires a PR, blocks force-push and
+  deletion, and is machine-checked across the fleet by `scripts/audit-branch-policy.sh`.
 - **Merge**: squash merge only · force push forbidden · auto-merge requires CI + owner.
 - **One PR per issue**, scoped tight. Every PR references an issue (`Closes/Fixes/Refs #N`).
   Exception: label `hotfix`. The `enforce-issue-link` workflow is a blocking status check.
@@ -290,6 +309,31 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   numbers) live in **external YAML files** and are loaded at runtime. Code reads them
   through a typed loader (Pydantic Settings backend · generated typed module frontend),
   never as inline literals. Only language-level enums (e.g. `status.HTTP_*`) are exempt.
+- **No literal HTTP status codes — use the constants the framework already ships.** A bare
+  `200`, `404`, `422`, `500` in code or in a test is forbidden; the value comes from the
+  library that defines it: Python `fastapi.status.HTTP_404_NOT_FOUND` (or
+  `http.HTTPStatus.NOT_FOUND` outside FastAPI), Django `HTTPStatus`, TypeScript a typed
+  status enum/const from the HTTP client layer, C# `System.Net.HttpStatusCode`. This applies
+  everywhere the code names a status — route decorators (`status_code=status.HTTP_201_CREATED`),
+  raised errors, client-side branching, and **assertions in tests**
+  (`assert response.status_code == status.HTTP_403_FORBIDDEN`). The same rule generalises: when
+  a standard library or a framework already publishes the constant/enum for a protocol value
+  (HTTP methods, MIME types, headers, signal numbers, exit codes), import it — never retype the
+  literal. A magic number the reader has to look up is a defect, not a shortcut.
+- **No code duplication — the second occurrence is an extraction order.** Copy-pasting a
+  function, a fixture, a type, a config block, or a workflow step across files or repos is
+  forbidden. The rule is mechanical: the **first** occurrence is code, the **second** is a
+  factoring order — the logic moves to the transverse home for its kind and both call sites
+  consume it from there. The homes are fixed: shared Python code → **`chrysa-lib`** (or the
+  relevant `chrysa/*` library), CI logic → **`chrysa/github-actions`**, commit gates →
+  **`chrysa/pre-commit-tools`**, standards/templates → **`shared-standards`**, UI components →
+  the design system. Inside one repo, duplication is extracted to a shared module in the same
+  layer — never re-typed in a sibling. Rewriting the same logic in different words does not
+  make it a different implementation; a near-duplicate diverges silently and costs sixty PRs
+  to fix once. Mechanisation: SonarCloud duplication ratio and `jscpd`-class detectors; a
+  reported duplicate block is a defect to factor, not a warning to carry. Legitimate exception:
+  a deliberate copy that decouples two projects on purpose (see *projects talk through
+  versioned contracts only*) — documented as such, not left implicit.
 - **Semantic URLs & code** — URLs are resource-oriented and human-readable: lowercase,
   hyphenated, plural-noun collections, no verbs or actions in the path (`GET /invoices/42`,
   never `/getInvoice?id=42`); REST shapes follow the `api-design` skill. Code is
@@ -318,6 +362,60 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   `pytest.ini` are forbidden. Distributed libraries use a `src/` layout and follow the Public API
   Contract (`docs/PUBLIC-API-CONTRACT.md`): sorted `__all__`, relative imports in `__init__`,
   `__version__` via `importlib.metadata`, uniform `install()` entrypoint, shared types in `chrysa-lib`.
+- **Python is written object-oriented, one class per file.** Behaviour is carried by classes,
+  not by a bag of module-level functions sharing state through globals or long parameter
+  lists: a cohesive responsibility (a service, a repository, an adapter, a use case, a value
+  object) is a **class**, dependencies are injected through `__init__`, and state lives on
+  the instance. **One class per module, and the module is named after it** —
+  `vehicle_dispatcher.py` holds `VehicleDispatcher`, and nothing else of substance (private
+  helpers of that class and its own exception types may live beside it). Method order inside
+  a class is fixed: dunder → property → abstract → classmethod → staticmethod → public →
+  private, alphabetical within each group. Pure functions remain legitimate where there is
+  genuinely no state and no variation point — a stateless transformation, a validator, the
+  functional core called by the class — and Pydantic models, dataclasses, enums and
+  protocols are classes already. What is forbidden is a `utils.py` grab-bag, a module of
+  loosely related procedures threading the same objects through every signature, and two
+  unrelated public classes sharing one file.
+- **Import the item, not the module — `from x import y; y()`.** Python imports name the
+  symbol actually used (`from fastapi import status`, `from datetime import datetime`,
+  `from app.services.billing import BillingService`), so call sites read `datetime.now()`
+  and `BillingService(...)`, not `datetime.datetime.now()` or a chain of package prefixes.
+  Bare `import x` is reserved for the cases where it is genuinely better: a module used as a
+  namespace whose name carries meaning at the call site (`import numpy as np`,
+  `import json`), or breaking an import cycle. **Forbidden**: wildcard `from x import *`,
+  relative imports beyond a package's own `__init__` re-exports, and importing a module only
+  to reach one attribute through it. Imports sit at module top level (never inside a function
+  except to break a cycle, and that is commented), and are ordered/deduplicated by Ruff
+  (`I` rules) — the linter owns the ordering, no hand-sorting.
+- **Everything is machine-agnostic and portable — no rule, repo, or script is bound to one
+  machine.** A standard, a Makefile target, a script, a hook, a compose file, or a CI job must
+  behave identically on any developer machine, any runner, and the server, with nothing but a
+  clone and the sanctioned host tools. Concretely, **forbidden**: absolute paths tied to a user
+  or host (`/home/<user>/…`, `/Users/<name>/…`, `C:\Users\…`, a hardcoded workspace root), a
+  hostname/IP/mount point of a specific box baked into code or config, an assumption that a tool
+  was installed a particular way, and "works because my machine has it" reasoning. Instead:
+  paths are relative to the repo root (or resolved from `$(git rev-parse --show-toplevel)` /
+  the script's own directory), machine-specific values arrive through **environment variables
+  with documented defaults** (`.env.example` committed, `.env` never), and anything the code
+  needs is provided by the container image. The same portability applies to the standards
+  corpus itself: a rule names a *mechanism* (a hook id, a Makefile target, a workflow), never a
+  particular machine, user account, or local directory layout. The test is mechanical: a fresh
+  clone on an unknown machine, with git + Docker + pre-commit, must reach a green
+  `make ci` — if it needs a manual step that only the owner knows, that is a defect.
+- **External dependencies are installed in containers, never on the host.** A project's
+  runtime dependencies — language packages (pip/npm/cargo/nuget), databases, brokers, caches,
+  system libraries, compilers, CLIs a service shells out to — are declared in the image
+  (`Dockerfile`) or in a compose service, and installed **inside the container**. `sudo apt
+  install`, `pip install` into the system interpreter, a global `npm -g`, or a locally
+  installed Postgres/Redis "to make it work" are **defects**: they make the machine the
+  environment, so the build is unreproducible, the version drifts per-machine, and CI and prod
+  no longer run what the developer ran. A missing dependency is fixed by editing the image,
+  never by installing it on a developer machine. Three sanctioned host tools only, all repo-independent
+  and installed **outside** any project tree: **git**, **Docker** itself, and the commit gate
+  (`pipx`/`uv install pre-commit`, which provisions its own hook envs — see *the gate is
+  host-native*). Everything else runs through `docker compose run` / the `make docker-*`
+  targets. Host-bound repos (`exempt:native`: desktop, hardware, editor extensions) are the
+  documented exception, and only for the part genuinely bound to the host OS.
 - **No virtualenv in a repo — ever.** `venv/`, `.venv/`, `env/` are **forbidden** inside a
   project tree. Python runs in the Docker image (deps baked into the image layer, or a named
   volume for editable installs). A committed or on-disk virtualenv is a bug, not a setup step.
@@ -415,6 +513,35 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   to `/setup`** rather than crashing or showing a generic error. An admin **configuration panel**
   (auth-gated CRUD API) manages runtime config with a versioned audit trail, hot-reload where
   possible (else a `RESTART_REQUIRED` flag), and JSON export/import for backup and cross-env cloning.
+- **A floating assistant where it earns its place — never as decoration.** Any human-facing
+  product whose users face a **non-obvious surface** (a dense cockpit, a multi-step form or
+  wizard, a query/graph/config console, an admin panel with domain jargon) ships an **in-app
+  floating assistant**: a persistent, dismissible affordance that answers "what am I looking
+  at / what do I do next" **in context**, without leaving the page. The value test comes
+  first — a product with two screens and no jargon does not get one, and shipping an empty
+  chat bubble is worse than shipping nothing. Where it is warranted, it obeys the same rules
+  as the rest of the app:
+  1. **Context-aware, not a generic chat box** — it receives the current route, selection and
+     visible state, and its opening move is a useful suggestion about *this* screen.
+  2. **Opt-in and reversible** — off by default behind a documented flag/config key
+     (`ASSISTANT_ENABLED`-style), dismissible, and its position/open state persists per user
+     (see *UI state survives reload & focus*). It never steals focus, never blocks the
+     underlying surface, and never auto-opens on every visit.
+  3. **Governed like any agent** — read-only Q&A is R0/R1; the moment it *acts* (writes, calls,
+     runs, changes state) the full agentic envelope applies: versioned manifest, typed I/O,
+     least privilege, risk level with proportionate confirmation and dry-run, audit trail.
+     Detail: annexe `AGENTIC-CAPABILITIES.md`.
+  4. **Provider-independent** — inference goes through the local port with ≥2 tested adapters
+     (strategic pillar 1); no vendor SDK in the product's business code, and the assistant
+     degrades to a documented help panel when no model is reachable.
+  5. **Accessible and quiet** — reachable and closable by keyboard (visible focus, `Esc`
+     closes), announced to assistive tech, honours `prefers-reduced-motion`, and respects the
+     WCAG 2.1 AA + design-token rules like every other surface. It is lazily loaded behind a
+     shape-accurate placeholder so it never delays first paint.
+  6. **Scoped and honest** — it answers from the product's own data and docs, says "I don't
+     know" rather than inventing, and states what it did after acting.
+  A desktop/overlay assistant (the `floating-agent` pattern) follows the same rules outside the
+  browser: overlay-only, dismissible, no capture of surfaces the user did not consent to.
 - **Raised errors are typed** — in any language whose type system allows it. Code raises a
   **domain-specific exception class** (Python: a module `…Error(Exception)` hierarchy rooted in one
   base per bounded context; TypeScript: `class XError extends Error` with a discriminant field, or a
@@ -530,6 +657,19 @@ components. This complements *dark mode + WCAG 2.1 AA* and the `ui-ux` skill.
   the Makefile (no `make type-check` when the target is `typecheck`).
 - **Recipe style** — prefix every recipe line with `@`; add `## Description` after each target so
   it appears in `make help`.
+- **Modular Makefiles — 500 lines max, split by domain.** No hand-maintained Makefile exceeds
+  **500 lines** (the same file gate as code). Approaching the limit, it is split into thematic
+  files under `make/` (`make/common.mk` for shared variables/functions, then `docker.mk`,
+  `test.mk`, `quality.mk`, `k8s.mk`, `docs.mk`… as the repo needs), loaded explicitly from the
+  root Makefile with `include` / `-include`. The **root Makefile stays an entry point and an
+  orchestrator**: it exposes the main commands, loads the thematic files, and serves the global
+  `make help`. A target exists **in exactly one file** — duplicates, near-identical variants and
+  copy-paste between thematic files are forbidden (*no code duplication* applies to Make too).
+  Inclusion is acyclic: a thematic file never includes back into its parent. Target names stay
+  predictable and grouped by domain (`test-unit`, `docker-build`, `k8s-deploy`), every public
+  target is documented in `make help` from its `## Description`, and any long or business-logic
+  recipe moves to a **versioned, testable script** — the Makefile is a command surface, not an
+  application language.
 
 ## Container-runtime policy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,6 +542,34 @@ deprecated and archived — nothing is added to it, nothing reads from it.
      know" rather than inventing, and states what it did after acting.
   A desktop/overlay assistant (the `floating-agent` pattern) follows the same rules outside the
   browser: overlay-only, dismissible, no capture of surfaces the user did not consent to.
+- **The repository architecture is legible to an agent — optimised for Claude, not only for
+  humans.** An AI agent reads a repo through a narrow window: it cannot skim thirty files to
+  infer a convention. So the layout itself carries the answers, and a repo where an agent has
+  to guess is a defect.
+  1. **One entry point that says what to do now** — `CLAUDE.md` (repo-specific rules, layered
+     over the inlined standards block) plus `primer.md` (current state, next action), read
+     before anything else. `AGENTS.md`/`copilot-instructions.md` stay generated from the same
+     source, never hand-diverged.
+  2. **Every non-trivial folder carries a `README.md`** stating role, structure, what belongs
+     in it and — critically — **what must not**, so a file lands in the right layer at write
+     time instead of in review.
+  3. **Predictable, name-addressable structure** — layers named after the architecture
+     (`domain/`, `application/`, `infrastructure/`, `interfaces/`), one class per file with
+     the module named after it, test file mirroring the source path. Finding *where* something
+     lives is a naming derivation, never a search.
+  4. **Small units by contract** — the file/function/complexity gates (500 / 50 / 10) exist so
+     a unit fits in one read; the same reason bans god-objects and `utils.py` grab-bags.
+  5. **Machine-readable seams** — typed signatures, Pydantic/OpenAPI contracts, YAML config
+     with a typed loader, `docs/adr/` for the *why*. An agent should be able to answer "what
+     breaks if I change this" from types and contracts, not from tribal memory.
+  6. **Task-shaped tooling over prose** — the repeatable operations are `make` targets and
+     shared skills (`.claude/skills/`), so an agent invokes a named contract instead of
+     reconstructing a command line. Every documented command exists in the Makefile.
+  7. **Session continuity** — decisions, known issues and progress live in `.claude/memory/`
+     (see *Session lifecycle*), so the next session starts from state, not from scratch.
+  The test is mechanical: drop a fresh agent in the repo with no conversation history — it
+  must find the entry point, the layer to touch, the command to run and the gate to pass,
+  from committed files alone.
 - **Raised errors are typed** — in any language whose type system allows it. Code raises a
   **domain-specific exception class** (Python: a module `…Error(Exception)` hierarchy rooted in one
   base per bounded context; TypeScript: `class XError extends Error` with a discriminant field, or a

--- a/compliance/branch-policy.json
+++ b/compliance/branch-policy.json
@@ -1,626 +1,635 @@
 {
-  "audited": 69,
+  "audited": 70,
   "repos": [
     {
+      "repo": "agent-config",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "agent-config"
+      "pr_only": true
     },
     {
+      "repo": "ai-aggregator",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "ai-aggregator"
+      "pr_only": true
     },
     {
+      "repo": "audit-platform",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "audit-platform"
+      "pr_only": true
     },
     {
+      "repo": "automations",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "automations"
+      "pr_only": true
     },
     {
+      "repo": "catalog",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "catalog"
+      "pr_only": true
     },
     {
+      "repo": "cdn-explorer",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "cdn-explorer"
+      "pr_only": true
     },
     {
+      "repo": "chrysa-claude-template",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "chrysa-claude-template"
+      "pr_only": true
     },
     {
+      "repo": "chrysa-knowledge",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "chrysa-knowledge"
+      "pr_only": true
     },
     {
+      "repo": "chrysa-lib",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "chrysa-lib"
+      "pr_only": true
     },
     {
+      "repo": "chrysa-portfolio-viz",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "chrysa-portfolio-viz"
+      "pr_only": true
     },
     {
+      "repo": "chrysa-skills",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "chrysa-skills"
+      "pr_only": true
     },
     {
+      "repo": "claude-config",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "claude-config"
+      "pr_only": true
     },
     {
+      "repo": "coach",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "coach"
+      "pr_only": true
     },
     {
+      "repo": "container-webview",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "container-webview"
+      "pr_only": true
     },
     {
+      "repo": "D-D",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "D-D"
+      "pr_only": true
     },
     {
+      "repo": "debian-guardian",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "debian-guardian"
+      "pr_only": true
     },
     {
+      "repo": "dev-nexus",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "dev-nexus"
+      "pr_only": true
     },
     {
+      "repo": "devtool",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "devtool"
+      "pr_only": true
     },
     {
+      "repo": "discord-bot-back",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "discord-bot-back"
+      "pr_only": true
     },
     {
+      "repo": "discordium",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "discordium"
+      "pr_only": true
     },
     {
+      "repo": "diy-stream-deck",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "diy-stream-deck"
+      "pr_only": true
     },
     {
+      "repo": "django-app-forge",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "django-app-forge"
+      "pr_only": true
     },
     {
+      "repo": "django-autoload",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "django-autoload"
+      "pr_only": true
     },
     {
+      "repo": "django-migration-analyzer",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "django-migration-analyzer"
+      "pr_only": true
     },
     {
+      "repo": "django-pytest",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "django-pytest"
+      "pr_only": true
     },
     {
+      "repo": "django-query-optimizer",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "django-query-optimizer"
+      "pr_only": true
     },
     {
+      "repo": "django-query-optimizer-vscode",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "django-query-optimizer-vscode"
+      "pr_only": true
     },
     {
+      "repo": "django-traceid",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "django-traceid"
+      "pr_only": true
     },
     {
+      "repo": "doc-gen",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "doc-gen"
+      "pr_only": true
     },
     {
+      "repo": "dotfiles",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "dotfiles"
+      "pr_only": true
     },
     {
+      "repo": "epub-sorter",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "epub-sorter"
+      "pr_only": true
     },
     {
+      "repo": "fastapi-autoload",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "fastapi-autoload"
+      "pr_only": true
     },
     {
+      "repo": "fastapi-pytest",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "fastapi-pytest"
+      "pr_only": true
     },
     {
+      "repo": "fastapi-query-optimizer",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "fastapi-query-optimizer"
+      "pr_only": true
     },
     {
+      "repo": "fastapi-traceid",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "fastapi-traceid"
+      "pr_only": true
     },
     {
+      "repo": "feedback-gateway",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "feedback-gateway"
+      "pr_only": true
     },
     {
+      "repo": "floating-agent",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "floating-agent"
+      "pr_only": true
     },
     {
+      "repo": "floating-knowledge-architect-offline",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "floating-knowledge-architect-offline"
+      "pr_only": true
     },
     {
+      "repo": "game-solver-platform",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "game-solver-platform"
+      "pr_only": true
     },
     {
+      "repo": "gaming-os",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "gaming-os"
+      "pr_only": true
     },
     {
+      "repo": "genealogy-validator",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "genealogy-validator"
+      "pr_only": true
     },
     {
+      "repo": "gestureOS",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "gestureOS"
+      "pr_only": true
     },
     {
+      "repo": "github-actions",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "github-actions"
+      "pr_only": true
     },
     {
+      "repo": "guideline-checker",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "guideline-checker"
+      "pr_only": true
     },
     {
+      "repo": "herdr-rtk-savings",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "homeassistant-config"
+      "pr_only": true
     },
     {
+      "repo": "homeassistant-config",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "lifeos"
+      "pr_only": true
     },
     {
+      "repo": "lifeos",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "link-reader-bot"
+      "pr_only": true
     },
     {
+      "repo": "link-reader-bot",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "linkendin-resume"
+      "pr_only": true
     },
     {
+      "repo": "linkendin-resume",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "mediavault"
+      "pr_only": true
     },
     {
+      "repo": "mediavault",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "mirrador"
+      "pr_only": true
     },
     {
+      "repo": "mirrador",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "my-resume"
+      "pr_only": true
     },
     {
+      "repo": "my-resume",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "orchestrator"
+      "pr_only": true
     },
     {
+      "repo": "orchestrator",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "paperclip"
+      "pr_only": true
     },
     {
+      "repo": "paperclip",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "PO-GO-DEX"
+      "pr_only": true
     },
     {
+      "repo": "PO-GO-DEX",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "pre-commit-hooks-changelog"
+      "pr_only": true
     },
     {
+      "repo": "pre-commit-hooks-changelog",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "pre-commit-tools"
+      "pr_only": true
     },
     {
+      "repo": "pre-commit-tools",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "project-init"
+      "pr_only": true
     },
     {
+      "repo": "project-init",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "projects-claude-config"
+      "pr_only": true
     },
     {
+      "repo": "projects-claude-config",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "quality-gatekeeper"
+      "pr_only": true
     },
     {
+      "repo": "quality-gatekeeper",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "satisfactory-factory-manager"
+      "pr_only": true
     },
     {
+      "repo": "satisfactory-factory-manager",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "server"
+      "pr_only": true
     },
     {
+      "repo": "server",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "shared-standards"
+      "pr_only": true
     },
     {
+      "repo": "shared-standards",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "sport-intelligence-hub"
+      "pr_only": true
     },
     {
+      "repo": "sport-intelligence-hub",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "studioverse"
+      "pr_only": true
     },
     {
+      "repo": "studioverse",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "usefull-containers"
+      "pr_only": true
     },
     {
+      "repo": "usefull-containers",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "windows-autonome"
+      "pr_only": true
     },
     {
+      "repo": "windows-docker-state-notification",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "windows-docker-state-notification"
+      "pr_only": true
     },
     {
+      "repo": "windows-guardian",
       "default": "develop",
-      "default_is_develop": true,
-      "develop": true,
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "windows-guardian"
+      "pr_only": true
     },
     {
+      "repo": "workstation-os",
       "default": "develop",
-      "default_is_develop": true,
+      "main": true,
       "develop": true,
+      "default_is_develop": true,
+      "main_protected": true,
+      "pr_only": true
+    },
+    {
+      "repo": "wsmqtt-monitor",
+      "default": "develop",
       "main": true,
+      "develop": true,
+      "default_is_develop": true,
       "main_protected": true,
-      "pr_only": true,
-      "repo": "wsmqtt-monitor"
+      "pr_only": true
     }
   ]
 }

--- a/scripts/apply-repo-standard.sh
+++ b/scripts/apply-repo-standard.sh
@@ -223,19 +223,26 @@ merge_precommit() {
 # Ruff's config is per-pyproject and cannot be copied (the standard forbids
 # ruff.toml), so the canonical rule set is merged into whichever pyproject owns
 # the repo's Python package — root, or one level down in a monorepo.
-find_pyproject() {
-    local repo="$1"
-    [[ -f "$repo/pyproject.toml" ]] && { echo "$repo/pyproject.toml"; return 0; }
-    local candidate
+find_pyprojects() {
+    # Every pyproject that can own Python, not just the first: a monorepo may
+    # carry backend/ and agent/ side by side, and returning one silently left
+    # the other outside the rule set (measured on satisfactory-factory-manager).
+    local repo="$1" found=1 candidate
+    if [[ -f "$repo/pyproject.toml" ]]; then
+        echo "$repo/pyproject.toml"
+        return 0
+    fi
     for candidate in "$repo"/*/pyproject.toml; do
-        [[ -f "$candidate" ]] && { echo "$candidate"; return 0; }
+        [[ -f "$candidate" ]] || continue
+        echo "$candidate"
+        found=0
     done
-    return 1
+    return $found
 }
 
 merge_ruff_rules() {
-    local repo="$1" target
-    if ! target="$(find_pyproject "$repo")"; then
+    local repo="$1" targets
+    if ! targets="$(find_pyprojects "$repo")"; then
         # Reported in every mode: a repo with Python but no pyproject cannot
         # receive the rules at all, and silence would read as compliance.
         info "no pyproject.toml · ruff rules not applicable"
@@ -243,17 +250,23 @@ merge_ruff_rules() {
     fi
     local merger="$SCRIPT_DIR/pyproject-ruff-merge.py"
     [[ -f "$merger" ]] || { warn "pyproject-ruff-merge.py missing · ruff rules skipped"; return 0; }
-    if $CHECK; then
-        python3 "$merger" "$target" --check && ok "ruff rules compliant" || warn "ruff rule drift (see above)"
-        return 0
-    fi
-    if $DRY_RUN; then
-        python3 "$merger" "$target" --check >/dev/null 2>&1 \
-            && info "[dry-run] ruff rules already complete" \
-            || info "[dry-run] would add the canonical ruff rules to ${target#"$repo"/}"
-        return 0
-    fi
-    python3 "$merger" "$target" >/dev/null && ok "ruff rules merged into ${target#"$repo"/}"
+    local target rel
+    while IFS= read -r target; do
+        [[ -n "$target" ]] || continue
+        rel="${target#"$repo"/}"
+        if $CHECK; then
+            python3 "$merger" "$target" --check && ok "ruff rules compliant · $rel" \
+                || warn "ruff rule drift in $rel (see above)"
+            continue
+        fi
+        if $DRY_RUN; then
+            python3 "$merger" "$target" --check >/dev/null 2>&1 \
+                && info "[dry-run] ruff rules already complete · $rel" \
+                || info "[dry-run] would add the canonical ruff rules to $rel"
+            continue
+        fi
+        python3 "$merger" "$target" >/dev/null && ok "ruff rules merged into $rel"
+    done <<< "$targets"
 }
 
 apply_one() {

--- a/scripts/pii_scan.py
+++ b/scripts/pii_scan.py
@@ -89,9 +89,11 @@ def _scan_paths(cfg: ScanConfig, paths: list[Path], allowed: set[str]) -> list[F
         text = _read_text(path)
         if text is None:
             continue
-        for finding in scan_text(analyzer, cfg, str(path), text):
-            if finding.fingerprint not in allowed:
-                findings.append(finding)
+        findings.extend(
+            finding
+            for finding in scan_text(analyzer, cfg, str(path), text)
+            if finding.fingerprint not in allowed
+        )
     return findings
 
 

--- a/scripts/pyproject-ruff-merge.py
+++ b/scripts/pyproject-ruff-merge.py
@@ -169,20 +169,32 @@ def merge(text: str, rules: list[str]) -> str:
     return text + block
 
 
-def main(argv: list[str]) -> int:
+def _resolve_target(argv: list[str]) -> Path | None:
+    """The single positional argument, or None when the usage is wrong."""
     args = [a for a in argv if not a.startswith("--")]
     if len(args) != 1:
         sys.stderr.write(__doc__ or "")
-        return 2
+        return None
     target = Path(args[0])
     if not target.is_file():
         sys.stderr.write(f"{target}: not found\n")
-        return 2
+        return None
+    return target
 
-    rules = CANONICAL_RULES
+
+def _resolve_rules(argv: list[str]) -> tuple[str, ...]:
+    """The canonical set, unless --rules= overrides it."""
     for arg in argv:
         if arg.startswith("--rules="):
-            rules = tuple(code.strip() for code in arg.split("=", 1)[1].split(",") if code.strip())
+            return tuple(code.strip() for code in arg.split("=", 1)[1].split(",") if code.strip())
+    return CANONICAL_RULES
+
+
+def main(argv: list[str]) -> int:
+    target = _resolve_target(argv)
+    if target is None:
+        return 2
+    rules = _resolve_rules(argv)
 
     text = target.read_text(encoding="utf-8")
     try:
@@ -197,9 +209,13 @@ def main(argv: list[str]) -> int:
             sys.stderr.write(f"{target}: missing Ruff rules: {', '.join(missing)}\n")
             return 1
         return 0
-
     if not missing:
         return 0
+    return _write_merged(target, text, missing)
+
+
+def _write_merged(target: Path, text: str, missing: list[str]) -> int:
+    """Merge the missing codes in, refusing to write a pyproject that would not parse."""
     merged = merge(text, missing)
     try:
         tomllib.loads(merged)

--- a/scripts/pyproject-ruff-merge.py
+++ b/scripts/pyproject-ruff-merge.py
@@ -55,6 +55,14 @@ CANONICAL_RULES: tuple[str, ...] = (
     "RUF100",  # unused-noqa — autofixable, keeps suppressions honest
 )
 
+# Rules the `PLR*`/`RUF` shorthand in the standards block would imply, excluded on
+# purpose. Named here so the decision is visible at the point of distribution rather
+# than only in an issue — see STANDARDS.chrysa.md, *known anti-patterns*.
+DELIBERATELY_EXCLUDED: dict[str, str] = {
+    "PLR2004": "magic-value-comparison — 2519 fleet findings; the `no hardcoded constants` chantier, not a flag",
+    "RUF001": "ambiguous-unicode — 493 findings on 4 repos, all French prose; arm locally with allowed-confusables",
+}
+
 _SELECT_RE = re.compile(r"(?P<head>^select\s*=\s*\[)(?P<body>.*?)(?P<tail>^\s*\])", re.DOTALL | re.MULTILINE)
 
 

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -161,21 +161,20 @@ class QualityGate:
         return 0
 
     def _parse_metric(self, gate_name: str, exit_code: int, output: str) -> Any:
-        if gate_name == "Tests":
-            return self._parse_passed_tests(output)
-        if gate_name == "Coverage":
-            return self._parse_coverage(output)
-        if gate_name == "Lint":
-            return self._parse_warning_count(output)
-        if gate_name == "Types":
-            return self._parse_error_count(output)
+        # Build is the only gate whose metric comes from the exit code rather
+        # than the output, so it stays out of the table.
         if gate_name == "Build":
             return 0 if exit_code == 0 else 1
-        if gate_name == "Secrets":
-            return self._parse_secret_count(output)
-        if gate_name == "VulnDeps":
-            return self._parse_vuln_count(output)
-        return None
+        parsers = {
+            "Tests": self._parse_passed_tests,
+            "Coverage": self._parse_coverage,
+            "Lint": self._parse_warning_count,
+            "Types": self._parse_error_count,
+            "Secrets": self._parse_secret_count,
+            "VulnDeps": self._parse_vuln_count,
+        }
+        parser = parsers.get(gate_name)
+        return parser(output) if parser else None
 
     def _compare(self, current: Any, target: Any, operator: str) -> bool:
         if operator == "=":

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -191,12 +191,40 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   reported duplicate block is a defect to factor, not a warning to carry. Legitimate exception:
   a deliberate copy that decouples two projects on purpose (see *projects talk through
   versioned contracts only*) — documented as such, not left implicit.
-- **Semantic URLs & code** — URLs are resource-oriented and human-readable: lowercase,
-  hyphenated, plural-noun collections, no verbs or actions in the path (`GET /invoices/42`,
-  never `/getInvoice?id=42`); REST shapes follow the `api-design` skill. Code is
-  self-describing: intention-revealing names over comments, semantic HTML elements
-  (`<nav>`, `<button>`, `<main>`, `<header>`…) never a `<div>` wired as a control, and
-  ARIA used only to fill gaps native semantics cannot express.
+- **Everything is semantic — the markup, the data, and the URLs.** A surface must be
+  understandable by a machine that never sees the pixels: a screen reader, a crawler, an
+  AI agent, another service. Meaning lives in the markup and the address, never only in the
+  CSS or the JavaScript.
+  1. **Semantic URLs.** Resource-oriented and human-readable: lowercase, hyphenated,
+     plural-noun collections, a **noun path with no verb or action**
+     (`GET /invoices/42`, never `/getInvoice?id=42`, never `/page?id=7`). The path expresses
+     the hierarchy (`/projects/42/settings`), the query expresses filtering/pagination/
+     selection — not identity. Opaque ids stay out of the path when a stable readable slug
+     exists (`/articles/semantic-urls`, optionally `/articles/42-semantic-urls`). A URL is a
+     **permanent contract**: it is not renamed on a redesign, and when it must change the old
+     one answers `301`, never `404`. REST shapes follow the `api-design` skill; a navigable
+     view is always a real URL (see *URL-addressable frontend navigation*).
+  2. **Semantic HTML.** The right element for the meaning — `<nav>`, `<main>`, `<header>`,
+     `<article>`, `<section>`, `<button>`, `<a href>`, `<table>`, `<form>`, `<time
+     datetime>`, `<label for>` — never a `<div>` wired as a control, never a heading level
+     picked for its size. One `<h1>` per page and a heading outline with no skipped level;
+     images carry meaningful `alt` (or `alt=""` when purely decorative); every input has a
+     programmatic label; language is declared (`<html lang>`). **ARIA only fills gaps native
+     semantics cannot express** — a native element always beats `role="button"`.
+  3. **Structured, machine-readable data.** Any public or shareable page publishes
+     **schema.org JSON-LD** appropriate to its type (`Article`, `Product`, `Organization`,
+     `BreadcrumbList`, `SoftwareApplication`…), plus the metadata that makes a link
+     self-describing: `<title>`, `meta description`, canonical link, Open Graph/Twitter
+     cards, `hreflang` on localised pages, `sitemap.xml` and `robots.txt`. The structured
+     data **describes what is actually on the page** — mismatched markup is a defect, not
+     an SEO trick.
+  4. **Semantic code and data shapes.** Intention-revealing names over comments, typed
+     contracts over free-form dicts, ISO-8601 dates and explicit units/currency in payloads,
+     stable machine-readable codes on errors (see *typed errors*). A field named `data`,
+     `value`, or `flag` is a naming defect.
+  Mechanisation: the a11y gates already required (Lighthouse ≥ 90, keyboard, contrast) plus
+  an HTML-validity/structured-data check on public pages. A page that reads correctly only
+  because of CSS is not accessible, not crawlable, and not agent-readable.
 - **URL-addressable frontend navigation — mandatory.** Every navigable view/route/tab/
   detail is a **real, semantic URL** (`/projects/42/settings`, not `/#` or a modal with no
   address). Navigating **must change the URL** via the router (History API `pushState`), so:

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -491,6 +491,17 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   Mechanisation: Ruff (`C901`, `PLR*`, `B`, `SIM`, `PERF`, `RUF`) + Mypy on Python, ESLint
   (`complexity`, `no-await-in-loop`, `react-hooks/exhaustive-deps`) on TS, SonarCloud rating **A**
   with 0 hotspot on both. A finding here is a defect to fix, not a warning to carry.
+  The armed Ruff selection is the canonical set distributed by `scripts/pyproject-ruff-merge.py`
+  and merged into each repo's `[tool.ruff.lint] select` — the script is the source of truth for
+  which codes are on. Two rules that the `PLR*`/`RUF` shorthand above would otherwise imply are
+  **deliberately excluded**, and stay excluded until a decision says otherwise:
+  - `PLR2004` (magic-value-comparison) — 2519 findings across the 65 repos. Hardcoded constants
+    are a chantier with its own remediation (extract to an enum or external config), not a flag
+    to flip; arming it would turn every gate red at once.
+  - `RUF001` (ambiguous-unicode-character-string) — 493 findings concentrated on 4 repos, all of
+    them French user-facing copy using typographic characters (apostrophes, non-breaking spaces).
+    The rule is right about the codepoints and wrong about the intent. A repo that wants it may
+    arm it locally together with `lint.allowed-confusables`.
 
 ## Quality gates
 

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -399,6 +399,34 @@ deprecated and archived — nothing is added to it, nothing reads from it.
      know" rather than inventing, and states what it did after acting.
   A desktop/overlay assistant (the `floating-agent` pattern) follows the same rules outside the
   browser: overlay-only, dismissible, no capture of surfaces the user did not consent to.
+- **The repository architecture is legible to an agent — optimised for Claude, not only for
+  humans.** An AI agent reads a repo through a narrow window: it cannot skim thirty files to
+  infer a convention. So the layout itself carries the answers, and a repo where an agent has
+  to guess is a defect.
+  1. **One entry point that says what to do now** — `CLAUDE.md` (repo-specific rules, layered
+     over the inlined standards block) plus `primer.md` (current state, next action), read
+     before anything else. `AGENTS.md`/`copilot-instructions.md` stay generated from the same
+     source, never hand-diverged.
+  2. **Every non-trivial folder carries a `README.md`** stating role, structure, what belongs
+     in it and — critically — **what must not**, so a file lands in the right layer at write
+     time instead of in review.
+  3. **Predictable, name-addressable structure** — layers named after the architecture
+     (`domain/`, `application/`, `infrastructure/`, `interfaces/`), one class per file with
+     the module named after it, test file mirroring the source path. Finding *where* something
+     lives is a naming derivation, never a search.
+  4. **Small units by contract** — the file/function/complexity gates (500 / 50 / 10) exist so
+     a unit fits in one read; the same reason bans god-objects and `utils.py` grab-bags.
+  5. **Machine-readable seams** — typed signatures, Pydantic/OpenAPI contracts, YAML config
+     with a typed loader, `docs/adr/` for the *why*. An agent should be able to answer "what
+     breaks if I change this" from types and contracts, not from tribal memory.
+  6. **Task-shaped tooling over prose** — the repeatable operations are `make` targets and
+     shared skills (`.claude/skills/`), so an agent invokes a named contract instead of
+     reconstructing a command line. Every documented command exists in the Makefile.
+  7. **Session continuity** — decisions, known issues and progress live in `.claude/memory/`
+     (see *Session lifecycle*), so the next session starts from state, not from scratch.
+  The test is mechanical: drop a fresh agent in the repo with no conversation history — it
+  must find the entry point, the layer to touch, the command to run and the gate to pass,
+  from committed files alone.
 - **Raised errors are typed** — in any language whose type system allows it. Code raises a
   **domain-specific exception class** (Python: a module `…Error(Exception)` hierarchy rooted in one
   base per bounded context; TypeScript: `class XError extends Error` with a discriminant field, or a

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -11,7 +11,7 @@
     ],
     "PostToolUse": [
       {
-        "command": "node .claude/hooks/verifiable-thresholds.cjs",
+        "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/verifiable-thresholds.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
         "matcher": "Write|Edit|MultiEdit",
         "name": "verifiable-thresholds",
         "timeout": 10000
@@ -26,13 +26,13 @@
     ],
     "PreToolUse": [
       {
-        "command": "node .claude/hooks/secret-scanner.cjs",
+        "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/secret-scanner.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
         "matcher": "Bash",
         "name": "secret-scanner",
         "timeout": 10000
       },
       {
-        "command": "node .claude/hooks/circuit-breaker.cjs",
+        "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/circuit-breaker.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
         "matcher": "Bash",
         "name": "circuit-breaker",
         "timeout": 5000
@@ -40,7 +40,7 @@
     ],
     "UserPromptSubmit": [
       {
-        "command": "node .claude/hooks/frustration-detection.cjs",
+        "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/frustration-detection.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
         "matcher": "*",
         "name": "frustration-detection",
         "timeout": 5000


### PR DESCRIPTION
Production promotion `develop` → `main`; the push cuts the release that distributes the socle to the fleet.

Ships #294 — *Everything is semantic — the markup, the data and the URLs*: semantic URLs as a permanent contract, semantic HTML with ARIA as a gap-filler only, schema.org JSON-LD + canonical/OG/hreflang/sitemap on public pages, semantic code and data shapes.

Also carries the refreshed branch-policy ledger (#292, 70/70 conform).

Refs #278