### PR TITLE
fix(lint): clear the canonical repo's own Ruff findings

### DIFF
--- a/scripts/apply-repo-standard.sh
+++ b/scripts/apply-repo-standard.sh
@@ -223,19 +223,26 @@ merge_precommit() {
 # Ruff's config is per-pyproject and cannot be copied (the standard forbids
 # ruff.toml), so the canonical rule set is merged into whichever pyproject owns
 # the repo's Python package — root, or one level down in a monorepo.
-find_pyproject() {
-    local repo="$1"
-    [[ -f "$repo/pyproject.toml" ]] && { echo "$repo/pyproject.toml"; return 0; }
-    local candidate
+find_pyprojects() {
+    # Every pyproject that can own Python, not just the first: a monorepo may
+    # carry backend/ and agent/ side by side, and returning one silently left
+    # the other outside the rule set (measured on satisfactory-factory-manager).
+    local repo="$1" found=1 candidate
+    if [[ -f "$repo/pyproject.toml" ]]; then
+        echo "$repo/pyproject.toml"
+        return 0
+    fi
     for candidate in "$repo"/*/pyproject.toml; do
-        [[ -f "$candidate" ]] && { echo "$candidate"; return 0; }
+        [[ -f "$candidate" ]] || continue
+        echo "$candidate"
+        found=0
     done
-    return 1
+    return $found
 }
 
 merge_ruff_rules() {
-    local repo="$1" target
-    if ! target="$(find_pyproject "$repo")"; then
+    local repo="$1" targets
+    if ! targets="$(find_pyprojects "$repo")"; then
         # Reported in every mode: a repo with Python but no pyproject cannot
         # receive the rules at all, and silence would read as compliance.
         info "no pyproject.toml · ruff rules not applicable"
@@ -243,17 +250,23 @@ merge_ruff_rules() {
     fi
     local merger="$SCRIPT_DIR/pyproject-ruff-merge.py"
     [[ -f "$merger" ]] || { warn "pyproject-ruff-merge.py missing · ruff rules skipped"; return 0; }
-    if $CHECK; then
-        python3 "$merger" "$target" --check && ok "ruff rules compliant" || warn "ruff rule drift (see above)"
-        return 0
-    fi
-    if $DRY_RUN; then
-        python3 "$merger" "$target" --check >/dev/null 2>&1 \
-            && info "[dry-run] ruff rules already complete" \
-            || info "[dry-run] would add the canonical ruff rules to ${target#"$repo"/}"
-        return 0
-    fi
-    python3 "$merger" "$target" >/dev/null && ok "ruff rules merged into ${target#"$repo"/}"
+    local target rel
+    while IFS= read -r target; do
+        [[ -n "$target" ]] || continue
+        rel="${target#"$repo"/}"
+        if $CHECK; then
+            python3 "$merger" "$target" --check && ok "ruff rules compliant · $rel" \
+                || warn "ruff rule drift in $rel (see above)"
+            continue
+        fi
+        if $DRY_RUN; then
+            python3 "$merger" "$target" --check >/dev/null 2>&1 \
+                && info "[dry-run] ruff rules already complete · $rel" \
+                || info "[dry-run] would add the canonical ruff rules to $rel"
+            continue
+        fi
+        python3 "$merger" "$target" >/dev/null && ok "ruff rules merged into $rel"
+    done <<< "$targets"
 }
 
 apply_one() {

--- a/scripts/pii_scan.py
+++ b/scripts/pii_scan.py
@@ -89,9 +89,11 @@ def _scan_paths(cfg: ScanConfig, paths: list[Path], allowed: set[str]) -> list[F
         text = _read_text(path)
         if text is None:
             continue
-        for finding in scan_text(analyzer, cfg, str(path), text):
-            if finding.fingerprint not in allowed:
-                findings.append(finding)
+        findings.extend(
+            finding
+            for finding in scan_text(analyzer, cfg, str(path), text)
+            if finding.fingerprint not in allowed
+        )
     return findings
 
 

--- a/scripts/pyproject-ruff-merge.py
+++ b/scripts/pyproject-ruff-merge.py
@@ -169,20 +169,32 @@ def merge(text: str, rules: list[str]) -> str:
     return text + block
 
 
-def main(argv: list[str]) -> int:
+def _resolve_target(argv: list[str]) -> Path | None:
+    """The single positional argument, or None when the usage is wrong."""
     args = [a for a in argv if not a.startswith("--")]
     if len(args) != 1:
         sys.stderr.write(__doc__ or "")
-        return 2
+        return None
     target = Path(args[0])
     if not target.is_file():
         sys.stderr.write(f"{target}: not found\n")
-        return 2
+        return None
+    return target
 
-    rules = CANONICAL_RULES
+
+def _resolve_rules(argv: list[str]) -> tuple[str, ...]:
+    """The canonical set, unless --rules= overrides it."""
     for arg in argv:
         if arg.startswith("--rules="):
-            rules = tuple(code.strip() for code in arg.split("=", 1)[1].split(",") if code.strip())
+            return tuple(code.strip() for code in arg.split("=", 1)[1].split(",") if code.strip())
+    return CANONICAL_RULES
+
+
+def main(argv: list[str]) -> int:
+    target = _resolve_target(argv)
+    if target is None:
+        return 2
+    rules = _resolve_rules(argv)
 
     text = target.read_text(encoding="utf-8")
     try:
@@ -197,9 +209,13 @@ def main(argv: list[str]) -> int:
             sys.stderr.write(f"{target}: missing Ruff rules: {', '.join(missing)}\n")
             return 1
         return 0
-
     if not missing:
         return 0
+    return _write_merged(target, text, missing)
+
+
+def _write_merged(target: Path, text: str, missing: list[str]) -> int:
+    """Merge the missing codes in, refusing to write a pyproject that would not parse."""
     merged = merge(text, missing)
     try:
         tomllib.loads(merged)

--- a/scripts/pyproject-ruff-merge.py
+++ b/scripts/pyproject-ruff-merge.py
@@ -55,6 +55,14 @@ CANONICAL_RULES: tuple[str, ...] = (
     "RUF100",  # unused-noqa — autofixable, keeps suppressions honest
 )
 
+# Rules the `PLR*`/`RUF` shorthand in the standards block would imply, excluded on
+# purpose. Named here so the decision is visible at the point of distribution rather
+# than only in an issue — see STANDARDS.chrysa.md, *known anti-patterns*.
+DELIBERATELY_EXCLUDED: dict[str, str] = {
+    "PLR2004": "magic-value-comparison — 2519 fleet findings; the `no hardcoded constants` chantier, not a flag",
+    "RUF001": "ambiguous-unicode — 493 findings on 4 repos, all French prose; arm locally with allowed-confusables",
+}
+
 _SELECT_RE = re.compile(r"(?P<head>^select\s*=\s*\[)(?P<body>.*?)(?P<tail>^\s*\])", re.DOTALL | re.MULTILINE)
 
 

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -161,21 +161,20 @@ class QualityGate:
         return 0
 
     def _parse_metric(self, gate_name: str, exit_code: int, output: str) -> Any:
-        if gate_name == "Tests":
-            return self._parse_passed_tests(output)
-        if gate_name == "Coverage":
-            return self._parse_coverage(output)
-        if gate_name == "Lint":
-            return self._parse_warning_count(output)
-        if gate_name == "Types":
-            return self._parse_error_count(output)
+        # Build is the only gate whose metric comes from the exit code rather
+        # than the output, so it stays out of the table.
         if gate_name == "Build":
             return 0 if exit_code == 0 else 1
-        if gate_name == "Secrets":
-            return self._parse_secret_count(output)
-        if gate_name == "VulnDeps":
-            return self._parse_vuln_count(output)
-        return None
+        parsers = {
+            "Tests": self._parse_passed_tests,
+            "Coverage": self._parse_coverage,
+            "Lint": self._parse_warning_count,
+            "Types": self._parse_error_count,
+            "Secrets": self._parse_secret_count,
+            "VulnDeps": self._parse_vuln_count,
+        }
+        parser = parsers.get(gate_name)
+        return parser(output) if parser else None
 
     def _compare(self, current: Any, target: Any, operator: str) -> bool:
         if operator == "=":

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -491,6 +491,17 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   Mechanisation: Ruff (`C901`, `PLR*`, `B`, `SIM`, `PERF`, `RUF`) + Mypy on Python, ESLint
   (`complexity`, `no-await-in-loop`, `react-hooks/exhaustive-deps`) on TS, SonarCloud rating **A**
   with 0 hotspot on both. A finding here is a defect to fix, not a warning to carry.
+  The armed Ruff selection is the canonical set distributed by `scripts/pyproject-ruff-merge.py`
+  and merged into each repo's `[tool.ruff.lint] select` — the script is the source of truth for
+  which codes are on. Two rules that the `PLR*`/`RUF` shorthand above would otherwise imply are
+  **deliberately excluded**, and stay excluded until a decision says otherwise:
+  - `PLR2004` (magic-value-comparison) — 2519 findings across the 65 repos. Hardcoded constants
+    are a chantier with its own remediation (extract to an enum or external config), not a flag
+    to flip; arming it would turn every gate red at once.
+  - `RUF001` (ambiguous-unicode-character-string) — 493 findings concentrated on 4 repos, all of
+    them French user-facing copy using typographic characters (apostrophes, non-breaking spaces).
+    The rule is right about the codepoints and wrong about the intent. A repo that wants it may
+    arm it locally together with `lint.allowed-confusables`.
 
 ## Quality gates
 


### PR DESCRIPTION
Found while rolling the LOT 1 rules out to the last repos (#271): **the repo that distributes the rule set does not pass it.** `ruff check .` on `main` → 3 findings.

| file | finding | fix |
|---|---|---|
| `scripts/quality_gate.py` | PLR0911 — `_parse_metric`, 8 returns | dispatch table; `Build` stays out of it, being the one gate whose metric comes from the exit code |
| `scripts/pyproject-ruff-merge.py` | PLR0911 — `main()`, 8 returns | split into `_resolve_target` / `_resolve_rules` / `_write_merged` |
| `scripts/pii_scan.py` | PERF401 — append loop | `findings.extend(generator)` |

## Why the first one matters beyond this repo
`scripts/quality_gate.py` is the file **22 repos vendor** (#274). Measuring the five smallest repos still outside the rollout, every one of them reported the *same* two findings in its own copy of it:

```
agent-config        scripts/quality_gate.py: PERF203, PLR0911
automations         scripts/quality_gate.py: PERF203, PLR0911
mediavault          scripts/quality_gate.py: PERF203, PLR0911
PO-GO-DEX           scripts/quality_gate.py: PERF203, PLR0911
usefull-containers  scripts/quality_gate.py: PERF203, PLR0911
```

The duplication now duplicates lint debt too — the same defect arriving 22 times, which is the argument #274 makes, measured.

## Verification
```
ruff check .  → All checks passed!
```
Plus an end-to-end run of the merger on a scratch pyproject: adds the 20 codes, `--check` then passes, second merge is a no-op — the refactor of `main()` did not change behaviour.