### PR TITLE
refactor(ci): forward the distribute-standards script extraction to develop

### DIFF
--- a/.github/workflows/distribute-standards.yml
+++ b/.github/workflows/distribute-standards.yml
@@ -41,13 +41,9 @@ jobs:
 
             - name: Build repo matrix from repos.yml
               id: list
-              run: |
-                  chmod +x scripts/list-dev-repos.sh
-                  repos="$(scripts/list-dev-repos.sh --json --only '${{ github.event.inputs.only }}')"
-                  count="$(echo "$repos" | tr ',' '\n' | grep -c '"' || true)"
-                  echo "matrix={\"repo\":$repos}" >> "$GITHUB_OUTPUT"
-                  echo "count=$count" >> "$GITHUB_OUTPUT"
-                  echo "Targeting $count repo(s): $repos"
+              env:
+                  ONLY_FILTER: ${{ github.event.inputs.only }}
+              run: bash scripts/ci/build-repo-matrix.sh
 
     distribute:
         needs: discover
@@ -76,24 +72,8 @@ jobs:
               id: base
               env:
                   GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-              run: |
-                  meta="$(gh api "repos/chrysa/${{ matrix.repo }}" --jq '[.default_branch, .archived] | @tsv')"
-                  branch="$(echo "$meta" | cut -f1)"
-                  archived="$(echo "$meta" | cut -f2)"
-                  # An archived repo is read-only: pushing a sync branch returns 403 and
-                  # would fail the whole distribution run over a repo nobody can update.
-                  # Skip it here rather than let the push fail 20 steps later.
-                  if [ "$archived" = "true" ]; then
-                      echo "::warning::${{ matrix.repo }} is archived on GitHub — skipping. Set status:archived in repos.yml."
-                      echo "skip=true" >> "$GITHUB_OUTPUT"
-                      exit 0
-                  fi
-                  if [ -z "$branch" ]; then
-                      echo "::error::could not resolve default branch for ${{ matrix.repo }}"
-                      exit 1
-                  fi
-                  echo "Target ${{ matrix.repo }} default branch: $branch"
-                  echo "branch=$branch" >> "$GITHUB_OUTPUT"
+                  TARGET_REPO: chrysa/${{ matrix.repo }}
+              run: bash shared-standards/scripts/ci/resolve-target-branch.sh
 
             - name: Apply standards
               if: ${{ steps.base.outputs.skip != 'true' }}

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -1,0 +1,28 @@
+# scripts/ci
+
+**Role.** Shell entrypoints called by this repo's workflows. A workflow step is a `uses:`
+or a one-line `run:`; anything longer lives here (see the GitHub Actions standard).
+
+## Structure
+
+| Path                        | Purpose                                                     |
+| --------------------------- | ----------------------------------------------------------- |
+| `build-repo-matrix.sh`      | Emit the distribute-standards job matrix to `$GITHUB_OUTPUT` |
+| `resolve-target-branch.sh`  | Resolve a target repo's default branch, skip archived repos  |
+
+## Should contain
+
+- Bash entrypoints called by exactly one workflow step, taking their inputs from
+  environment variables the step declares.
+
+## Should NOT contain
+
+- Fleet-wide automation — that belongs in `scripts/` at the repo root, which is
+  distributed and runnable locally.
+- Logic another repo would want: extract it to `chrysa/github-actions` instead.
+
+## Rules
+
+- `set -euo pipefail`, `shellcheck --severity=error` clean, `shfmt -i 4`.
+- Inputs are env vars with defaults (`${VAR:-}`), never positional args, so the step's
+  `env:` block documents the contract.

--- a/scripts/ci/build-repo-matrix.sh
+++ b/scripts/ci/build-repo-matrix.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Emit the distribute-standards job matrix (repo list + count) to $GITHUB_OUTPUT.
+# Input: ONLY_FILTER — comma-separated repo subset, empty for every status:dev repo.
+set -euo pipefail
+
+repos="$(scripts/list-dev-repos.sh --json --only "${ONLY_FILTER:-}")"
+count="$(echo "$repos" | tr ',' '\n' | grep -c '"' || true)"
+
+{
+    echo "matrix={\"repo\":$repos}"
+    echo "count=$count"
+} >>"$GITHUB_OUTPUT"
+
+echo "Targeting $count repo(s): $repos"

--- a/scripts/ci/resolve-target-branch.sh
+++ b/scripts/ci/resolve-target-branch.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Resolve a target repo's default branch for the distribution job.
+# An archived repo is read-only: pushing a sync branch returns 403 and would fail the
+# whole run over a repo nobody can update — skip it here instead.
+# Inputs: TARGET_REPO (owner/name), GH_TOKEN. Outputs: skip | branch.
+set -euo pipefail
+
+meta="$(gh api "repos/${TARGET_REPO}" --jq '[.default_branch, .archived] | @tsv')"
+branch="$(echo "$meta" | cut -f1)"
+archived="$(echo "$meta" | cut -f2)"
+
+if [[ "$archived" == "true" ]]; then
+    echo "::warning::${TARGET_REPO} is archived on GitHub — skipping. Set status:archived in repos.yml."
+    echo "skip=true" >>"$GITHUB_OUTPUT"
+    exit 0
+fi
+
+if [[ -z "$branch" ]]; then
+    echo "::error::could not resolve default branch for ${TARGET_REPO}"
+    exit 1
+fi
+
+echo "Target ${TARGET_REPO} default branch: $branch"
+echo "branch=$branch" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
The two >15-line `run:` blocks of `distribute-standards.yml` were moved into `scripts/ci/*.sh` (#293) — on `main`. Every chrysa repo's trunk is `develop`, so the change never reached it. This forward-ports the same file states.

No behaviour change: the matrix build and the target-default-branch resolution keep their exact logic, including the archived-repo skip.