### PR TITLE
feat(standards): an agent writes only where the owner owns

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -153,6 +153,18 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   and a documented idempotency/timeout/limits/circuit-breaker/rollback envelope. Untrusted
   execution is sandboxed with network off by default; no agent auto-merges to `main`.
   Detail: annexe `AGENTIC-CAPABILITIES.md`.
+- **An agent writes only where the owner owns.** An AI agent may open issues, pull requests,
+  comments, branches and releases **only on repositories the owner owns** — the `chrysa`
+  account and the organisations under the owner's control. On any third-party repository
+  (an upstream project, a dependency, a fork's source, a client's repo) an agent **does not
+  file an issue, does not comment, does not open a PR**: it drafts the content locally and
+  hands it to the owner, who decides whether and how to send it. This is not a permissions
+  detail — an issue is a **public act under a human's name**, and a wrong or noisy one costs
+  reputation in a community the agent cannot read. The same limit applies to any outward
+  channel an agent could reach (email, chat, social, package registries): drafting is free,
+  publishing outside the owner's own perimeter is the owner's call. Inside the perimeter,
+  the normal rules still hold — one issue per real problem, no duplicate of an open one, and
+  every PR references its issue.
 - **Projects talk through versioned contracts only.** No import from a sibling repo, no path
   dependency, no submodule used as a runtime link, no access to another project's database or
   private models. Each consumer wraps the external contract in a local adapter and degrades


### PR DESCRIPTION
An AI agent may open issues, pull requests, comments, branches and releases **only on repositories the owner owns** — the `chrysa` account and the organisations under the owner's control.

On any third-party repository (upstream project, dependency, fork source, client repo) an agent **does not file an issue, does not comment, does not open a PR**. It drafts the content locally and hands it to the owner, who decides whether and how to send it.

The reason is not permissions: an issue is a **public act under a human's name**, and a wrong or noisy one costs reputation in a community the agent cannot read. The same limit covers every outward channel an agent could reach — email, chat, social, package registries. Drafting is free; publishing outside the owner's perimeter is the owner's call.

Inside the perimeter the normal rules still hold: one issue per real problem, no duplicate of an open one, every PR references its issue.

Refs #278