### PR TITLE
ci: pin chrysa/github-actions at v1.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
                   name: web-coverage-lcov
                   path: console/web/coverage
 
-            - uses: chrysa/github-actions/sonar-scan-python@v1.4.9
+            - uses: chrysa/github-actions/sonar-scan-python@v1.6.0
               with:
                   python-version: "3.14"
                   sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@v1.4.9
+        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@v1.6.0


### PR DESCRIPTION
Moves every `chrysa/github-actions` pin to **v1.6.0**.

An older tag keeps running an older gate. `v1.4.x` of `quality-gate-check.yml` invokes `make quality-gate-verify` with no guard and fails with `No rule to make target` on any repo that is not onboarded — a red check that says nothing about the code. `v1.6.0` also skips `pip install -e .` for a tooling-only `pyproject.toml` and only enables the npm cache when a lockfile exists.

Swept from `chrysa/shared-standards` (`scripts/github_actions_pin.py`).