### PR TITLE
release: CI/CD annexe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,18 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   and a documented idempotency/timeout/limits/circuit-breaker/rollback envelope. Untrusted
   execution is sandboxed with network off by default; no agent auto-merges to `main`.
   Detail: annexe `AGENTIC-CAPABILITIES.md`.
+- **An agent writes only where the owner owns.** An AI agent may open issues, pull requests,
+  comments, branches and releases **only on repositories the owner owns** — the `chrysa`
+  account and the organisations under the owner's control. On any third-party repository
+  (an upstream project, a dependency, a fork's source, a client's repo) an agent **does not
+  file an issue, does not comment, does not open a PR**: it drafts the content locally and
+  hands it to the owner, who decides whether and how to send it. This is not a permissions
+  detail — an issue is a **public act under a human's name**, and a wrong or noisy one costs
+  reputation in a community the agent cannot read. The same limit applies to any outward
+  channel an agent could reach (email, chat, social, package registries): drafting is free,
+  publishing outside the owner's own perimeter is the owner's call. Inside the perimeter,
+  the normal rules still hold — one issue per real problem, no duplicate of an open one, and
+  every PR references its issue.
 - **Projects talk through versioned contracts only.** No import from a sibling repo, no path
   dependency, no submodule used as a runtime link, no access to another project's database or
   private models. Each consumer wraps the external contract in a local adapter and degrades

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -27,6 +27,7 @@ Where an annexe and this file disagree, **this file wins**.
 | `PROJECT-DECOUPLING.md`   | inter-project contracts, forbidden linkages, degradation        |
 | `CONTAINERS-K3S.md`       | reference stage shape · container responsibility · k3s workload baseline |
 | `TESTING.md`              | common test levels and rules across languages                   |
+| `CI-CD.md`                | pipeline architecture · action pinning · least privilege · cost · what the gate proves |
 | `GOVERNANCE.md`           | rule identity, maturity ladder, enforcement rollout, sources of truth |
 
 **Source of truth:** the canon lives in this repo. Notion is a governance and decision view
@@ -648,7 +649,25 @@ Every repo carries a `runtime:` field in `repos.yml`, machine-checked by `audit-
 
 CI is assembled from **existing actions**, not written. A workflow is glue — checkout,
 setup, invoke the repo's own gate (`pre-commit`, `make ci`) — and every line of logic it
-carries is a line that lives in the wrong repo.
+carries is a line that lives in the wrong repo. A pipeline has one job: **tell the truth
+about the code, fast, without becoming a codebase of its own**. Full rules, with ids and a
+review checklist: annexe [`CI-CD.md`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md)
+(`CI-000`…`CI-052`) — pipeline architecture, supply-chain pinning, least privilege,
+cost/latency, what the gate must prove, feedback.
+
+Four of its rules are load-bearing enough to state here:
+
+- **A red check means the code is wrong** (`CI-040`). A gate that fails because a repo is not
+  onboarded, a tool is missing or billing lapsed trains everyone to ignore red — and the next
+  real failure is ignored too. Fix it or remove it the day it appears.
+- **A skipped job reports as skipped, never as passed** (`CI-032`). Path filters may skip work;
+  they must never turn a required check green without running it. A tick that means "not
+  executed" destroys trust in the whole pipeline.
+- **Build once, promote the artefact** (`CI-046`). The image digest that was tested is the one
+  deployed; rebuilding per environment means production runs something no test ever saw.
+- **Every job declares `timeout-minutes:` and every PR workflow a concurrency group**
+  (`CI-030`, `CI-031`) — cancelling superseded PR runs, and explicitly **not** cancelling
+  deployments.
 
 - **Reuse before writing — always.** The first choice is a **maintained public action**
   (`actions/checkout`, `actions/setup-python`, `actions/setup-node`, `astral-sh/setup-uv`,

--- a/standards/annexes/CI-CD.md
+++ b/standards/annexes/CI-CD.md
@@ -1,0 +1,288 @@
+# Annexe CI — Continuous integration & delivery
+
+> **Normative annexe.** Authority: `standards/STANDARDS.chrysa.md` (section *GitHub Actions*).
+> Rule ids (`CI-nnn`) are stable. Where this annexe and the socle disagree, the socle wins.
+> Related: [`CONTAINERS-K3S.md`](CONTAINERS-K3S.md) for what the pipeline builds,
+> [`TESTING.md`](TESTING.md) for what it runs, [`GOVERNANCE.md`](GOVERNANCE.md) for how a rule
+> is enforced.
+
+A pipeline has one job: **tell the truth about the code, fast, without becoming a codebase of
+its own**. Every rule below serves one of three properties — *trustworthy* (a red check means
+the code is wrong), *cheap* (in wall-clock and in attention), *maintainable* (a fleet-wide
+change costs one pull request, not sixty).
+
+______________________________________________________________________
+
+## 1. Architecture — thin workflows, reusable cores
+
+### CI-000 — A workflow is a graph of jobs, not a script
+
+An entry-point workflow declares *what runs, in what order, in parallel where possible*, and
+delegates the doing. A job does one thing; two unrelated concerns are two jobs, so a failure
+names the discipline that failed (`tests`, `quality-python`, `quality-docker`, `sonar`,
+`secrets-scan`) instead of "CI".
+
+### CI-001 — Shared stages are reusable workflows, prefixed `_`
+
+A stage used by more than one entry point is a `workflow_call` workflow named `_<stage>.yml`
+(`_tests.yml`, `_quality-python.yml`, `_sonar.yml`, `_version.yml`, `_image-setup.yml`). Its
+contract is typed: every input declares `type`, `required` and a `default`; every secret is
+declared by name. An untyped reusable workflow is a global variable with extra steps.
+
+### CI-002 — Logic lives in an action or a tested script, never in YAML
+
+A step is a `uses:` or a one-line `run:`. Past ~15 lines, or at the first conditional, parse
+or retry, the behaviour moves into a **composite action** with declared inputs/outputs, or a
+script in the repo that a test can call. Workflow YAML is not a programming language and no
+test covers it.
+
+### CI-003 — One home for custom actions, one for workflow templates
+
+Custom actions live in a **single** shared actions repository; reusable workflow templates in
+the standards repository. Two action repositories with overlapping content is drift by
+construction: the same action exists twice, diverges silently, and consumers cannot tell which
+is canonical. Merge them, alias the retired one, delete the copy.
+
+### CI-004 — The second occurrence is an extraction order
+
+The same CI logic appearing in a second repository moves to the shared home and both consume
+it from there. This is the socle's *no code duplication* applied to pipelines — and pipelines
+are where duplication hurts most, because a fleet-wide fix otherwise costs one pull request
+per repository.
+
+### CI-005 — `.github/workflows/` carries a README
+
+It lists the reusable workflows (purpose, inputs, outputs, runner) and draws the job graph of
+each entry point. A pipeline nobody can read is a pipeline nobody dares change, and it ossifies.
+
+______________________________________________________________________
+
+## 2. Supply chain
+
+### CI-010 — Third-party actions are pinned by commit SHA
+
+Full 40-character SHA, with the human version in a trailing comment:
+
+```yaml
+uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+```
+
+A tag is mutable; a branch (`@main`, `@master`) is arbitrary code execution, updated by a third
+party, whenever they choose, with the workflow token in scope. Pinning a *third-party* action
+to a branch is a security defect, not a convenience.
+
+### CI-011 — Internal shared actions are pinned by tag, never by branch
+
+The shared actions repository is released like any other product; consumers move deliberately
+by bumping a tag. `@main` is not "always up to date" — it is unversioned, untestable, and
+unrollbackable: a push changes every consumer's CI retroactively, with no review at the call
+site. Floating on `main` is also how a broken action takes down the whole fleet at once.
+
+### CI-012 — Pinning implies Dependabot
+
+Pinning without an update mechanism freezes the fleet years behind. The `github-actions`
+ecosystem is declared in `dependabot.yml`, and its pull requests are reviewed like any other.
+
+### CI-013 — No long-lived credential where a short-lived one works
+
+Cloud access uses OIDC (`permissions: id-token: write`) against a role, not a stored key.
+Cross-repository writes use a scoped app token minted in the job, not a personal access token.
+A long-lived provider key in a repository secret is a finding with an owner and an expiry, not
+a configuration choice.
+
+### CI-014 — Reuse before writing
+
+The first choice is a maintained public action (checkout, language setup, build-push, publish,
+artifact upload). Re-implementing caching, toolchain setup or publishing in a `run:` block is a
+defect; "it's shorter this way" is not a reason.
+
+______________________________________________________________________
+
+## 3. Least privilege
+
+### CI-020 — Every workflow declares `permissions:`
+
+Read-only at the top; elevated on the single job that needs it (`contents: write`,
+`packages: write`, `id-token: write`). The default token is far broader than most jobs need,
+and an undeclared permission set is an undeclared blast radius.
+
+### CI-021 — `secrets: inherit` is banned
+
+A reusable workflow receives only the secrets it uses, named one by one:
+
+```yaml
+secrets:
+    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+```
+
+`inherit` hands the callee the caller's entire secret store — deploy credentials reaching a
+workflow that only needed a registry password. Beyond the security argument, the call site
+becomes readable: you can tell what a workflow touches without opening it.
+
+### CI-022 — Untrusted input never reaches a shell through `${{ }}`
+
+PR titles, branch names, commit messages, issue and comment bodies, and any
+`repository_dispatch` payload are attacker-controlled. They pass through `env:` and are quoted:
+
+```yaml
+env:
+    TITLE: ${{ github.event.pull_request.title }}
+run: echo "$TITLE"
+```
+
+Direct interpolation is shell injection with the repository token in scope. The same applies to
+`ref:` in a checkout — never build one from unvalidated input.
+
+### CI-023 — Deployments are gated by an environment
+
+A deploy job declares an `environment:`, which scopes its credentials and carries the required
+reviewers. A deployment anyone with write access can trigger, with secrets in scope, is not a
+deployment — it is an incident waiting for a bad day.
+
+### CI-024 — A workflow triggered by an outside contributor gets no secrets
+
+`pull_request_target` and workflows running on forks either run without secrets, or do not run.
+Treat the fork's code as untrusted input, because it is.
+
+______________________________________________________________________
+
+## 4. Cost, latency, attention
+
+### CI-030 — Every job declares `timeout-minutes:`
+
+Set slightly above the observed p99, never left to the platform default. Without it a hung job
+holds a runner for hours; on self-hosted capacity it blocks everyone else's queue.
+
+### CI-031 — Every PR-triggered workflow declares a concurrency group
+
+```yaml
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+```
+
+Superseded runs are cancelled. **Deploy and release workflows use the same grouping with
+`cancel-in-progress: false`** — cancelling a deployment mid-flight is worse than queueing it.
+
+### CI-032 — Skip by measured change, never by faith
+
+Path filters gate expensive jobs on what actually changed. A filter may cause a job to be
+**skipped visibly**; it must never make a required check *pass* without running. A green tick
+that means "not executed" is the single most effective way to destroy trust in a pipeline.
+
+### CI-033 — Cache dependencies and layers
+
+Language toolchain caches (built into the setup actions) and build-layer caching are the
+cheapest latency win available; a pipeline that reinstalls the same dependency tree on every
+run pays for it hundreds of times a day. Cache keys are content-derived (lockfile hash), never
+time-derived.
+
+### CI-034 — A matrix replaces duplicated jobs
+
+Two jobs differing by one value (version, target, platform) are one job with a matrix. Copies
+diverge; the matrix is the single edit point.
+
+### CI-035 — The runner is chosen by workload, and stated
+
+Hosted runners for short, isolated, or externally-triggered work; larger or self-hosted
+capacity for heavy builds and test suites. One exception is deliberate and documented inline:
+**a workflow whose job is to detect that the self-hosted fleet is down must run on a hosted
+runner** — a monitor that shares its subject's failure mode is not a monitor.
+
+______________________________________________________________________
+
+## 5. What the gate must prove
+
+### CI-040 — A red check means the code is wrong
+
+A gate that fails because a repository is not onboarded, a tool is missing, a lockfile is
+absent, or billing lapsed teaches everyone to ignore red — and the next real failure is ignored
+too. Such a gate is fixed or removed the day it appears. A permanently red check is worse than
+no check.
+
+### CI-041 — Quality is a set of named, independent gates
+
+Linting and typing, security linting, dependency audit, container linting, tests with a
+coverage floor, static analysis, secret scanning. Each is its own job with its own name, so the
+failure is self-describing.
+
+### CI-042 — The coverage floor only ratchets upward
+
+The floor is an explicit input at the call site, visible in review. It is raised, never lowered
+in the pull request that breaks it — a floor that follows the code down measures nothing.
+
+### CI-043 — Integration tests get real services, isolated per run
+
+Databases, caches and brokers are declared as services, and every run gets its own namespace
+(database name derived from the commit SHA and job id). Parallel jobs sharing one database
+produce failures that are indistinguishable from flakiness.
+
+### CI-044 — CI runs the commit gate over the whole tree
+
+The local hook covers the diff; CI covers everything, from **the same configuration file**. A
+second, CI-only list of checks drifts from the local one and turns "it passed on my machine"
+into a legitimate complaint.
+
+### CI-045 — The version is computed, never typed
+
+Semantic version derived from the git graph, images and artefacts tagged with it in the same
+run, changelog generated. A hand-edited version string is a merge conflict with a release
+attached.
+
+### CI-046 — Build once, promote the artefact
+
+The artefact tested is the artefact deployed — the same image digest moves through the
+environments. Rebuilding per environment means production runs something no test ever saw.
+
+______________________________________________________________________
+
+## 6. Feedback
+
+### CI-050 — Notify on what people act on
+
+Failures on the integration and production branches, failed deployments, releases. Not every
+green run: a channel that pings on success is a channel nobody reads, and the failure notice
+lands in a stream people have learned to ignore.
+
+### CI-051 — The bot writes to the pull request
+
+Labels, size, conflict detection, dependency links, generated summaries — small dedicated
+workflows whose output lands where the decision is made. This is the part of CI developers
+actually feel.
+
+### CI-052 — Artefacts are named and their retention is deliberate
+
+Retention matches the debugging window, not the platform default. Unowned artefacts are a
+storage bill nobody reads and a search that returns forty identically named files.
+
+______________________________________________________________________
+
+## 7. Review checklist
+
+A workflow change is reviewable against this list in under a minute:
+
+1. Do all jobs declare `permissions:` and `timeout-minutes:`? (CI-020, CI-030)
+2. Third-party actions pinned by SHA, internal by tag — no `@main`? (CI-010, CI-011)
+3. Are secrets an explicit list rather than `inherit`? (CI-021)
+4. Does any `run:` interpolate untrusted `${{ github.event.* }}`? (CI-022)
+5. Concurrency group present — cancelling on PRs, *not* on deploys? (CI-031)
+6. Is the logic in YAML, or in an action / tested script? (CI-002)
+7. Is the runner choice justified by the workload? (CI-035)
+8. New gate: does a failure mean the code is wrong? (CI-040)
+9. Does a skipped job report as skipped, never as passed? (CI-032)
+
+______________________________________________________________________
+
+## 8. Enforcement
+
+| Rule | Mechanism |
+| --- | --- |
+| CI-010, CI-011 | `actionlint` + a pin check in the commit gate; Dependabot for updates |
+| CI-020, CI-021, CI-022 | reviewed in pull request; grep-able patterns, candidates for a hook |
+| CI-030, CI-031 | reviewed in pull request |
+| CI-004, CI-003 | fleet audit script over the workflow corpus |
+| CI-040 | any permanently red check is an issue with an owner |
+
+Rules not yet mechanised are declared as manually reviewed — a rule claiming automation with no
+check behind it is misdeclared (`GOVERNANCE.md` GV-012).


### PR DESCRIPTION
Production promotion `develop` → `main` (merge commit, per the branch model).

Ships #313 — normative annexe `CI-CD.md` (`CI-000`…`CI-052`, 32 rules) and its socle anchor: pipeline architecture, supply-chain pinning, least privilege, cost/attention, what the gate must prove, feedback, plus a 9-point review checklist and an enforcement table.

Refs #278