### PR TITLE
fix(ci): drop the duplicated timeout-minutes in distribute-standards

### DIFF
--- a/.github/workflows/distribute-standards.yml
+++ b/.github/workflows/distribute-standards.yml
@@ -33,7 +33,6 @@ jobs:
     discover:
         runs-on: ubuntu-latest
         timeout-minutes: 30
-        timeout-minutes: 30
         name: Resolve target repos
         outputs:
             matrix: ${{ steps.list.outputs.matrix }}


### PR DESCRIPTION
`Lint workflows` is red on `develop`:

```
.github/workflows/distribute-standards.yml:36:9: key "timeout-minutes" is duplicated in "discover" job. previously defined at line:35,col:9
```

The CI-030 sweep (#317) inserted a second `timeout-minutes` on the `discover` job. One key per job; the rest of this repo's workflows were scanned for the same pattern — no other occurrence.

Found while promoting the container-port standard (#318), whose release PR it was blocking.

Refs #278