### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,21 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   `loading="lazy"` media, on-demand heavy components) behind a **shape-accurate placeholder**
   that reserves the final dimensions — a skeleton, not a spinner, so arrival shifts no layout.
   Detail: annexe `FRONTEND.md` §2–§3, §7.
+- **The frontend says when the backend is unreachable or unstable.** Silence is the worst
+  failure mode: a spinner that never resolves, a list that stays empty, a form that swallows a
+  submit all read as "the app is broken and lying about it". The API client classifies every
+  failure into application state — `unreachable`, `unstable`, `degraded`, `unauthorised`
+  (a session problem, not an outage), `offline` (the browser's fault, worded as such) — and a
+  **persistent, non-blocking banner in the root shell** states it for the whole app, while each
+  container still resolves its own error state. The message says what happened and what to do
+  (*"Server unreachable — reconnecting in 12 s"*, never a raw status code), keeps a manual
+  **Retry** available, **disables destructive or unsaved actions** instead of failing silently
+  on submit, and **preserves in-progress form input** for re-submission on recovery. Reconnection
+  uses bounded exponential backoff with jitter — an unbounded retry loop against a struggling
+  backend is a defect — and success clears the state and refetches. The banner is a live region
+  (`role="alert"` / `role="status"`) and its behaviour is tested against a network error and a
+  503. A frontend Definition of Done includes its **API-down state**. Detail: annexe
+  `FRONTEND.md` FE-050.
 - **Every repo declares its profile and DDD level** (`project_profile`, `ddd_level`,
   `bounded_context`, `standards_version`) — architecture is proportionate to business
   complexity, and small tools are not over-architected. Detail: annexe `ARCHITECTURE-DDD.md`.
@@ -313,6 +328,37 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   dependency, no submodule used as a runtime link, no access to another project's database or
   private models. Each consumer wraps the external contract in a local adapter and degrades
   cleanly when the provider is gone. Detail: annexe `PROJECT-DECOUPLING.md`.
+- **Per-person data implies a user account — no exceptions dressed up as simplicity.** The
+  moment a product stores or manipulates anything whose *value depends on who is looking*
+  — preferences, saved filters and views, favourites, drafts, history, progress, notes,
+  annotations, uploads, notification settings, API keys, per-person results — it has **real
+  user accounts** behind the identity hierarchy above. The trigger is the data, not the size
+  of the app: a "small internal tool" that remembers your filters is already storing personal
+  data for several people.
+  1. **Ownership is modelled, not implied.** Every per-person row carries its owner
+     (`user_id` foreign key), and every read/write is scoped by it in the repository layer —
+     not filtered in the UI, not trusted from a request parameter. An endpoint that returns
+     another user's row because the id was guessed is the same defect whether the data is a
+     medical record or a colour theme.
+  2. **`localStorage` is a cache, never the system of record.** Browser storage holds what
+     the user can afford to lose on a new device; anything they would be upset to lose lives
+     server-side under their account. A product whose personalisation exists only in one
+     browser has no personalisation — it has a cookie.
+  3. **A shared password is not an account.** One credential handed to several people makes
+     every action unattributable, every revocation a fleet-wide password change, and every
+     export meaningless. Same for "profiles" selected from a dropdown with no authentication:
+     that is a preference switch pretending to be identity.
+  4. **Account plumbing is part of the feature, not a later epic** — sign-up/invite, sign-in,
+     password or SSO recovery, session expiry, and **deletion of the account with its data**
+     ship together with the first per-person field. Retrofitting ownership onto a table that
+     already holds everyone's rows is a migration, an audit, and an apology.
+  5. **Anonymous stays anonymous.** A genuinely public, read-only surface (a landing page, a
+     public catalogue) needs no account — and therefore must not quietly accumulate
+     per-person state either. If a feature needs to remember the visitor, it needs an account;
+     "we'll just key it by browser fingerprint" is tracking, not architecture.
+  This is the precondition of *portable personalisation data* (strategic pillar 3): an export
+  command only means something when the data has an owner. Detail on the identity path itself:
+  the rule below.
 - **Identity goes through the cluster SSO first.** Every interactive product deployed in the
   cluster integrates the **common cluster SSO** as its primary sign-in. The priority protocol is
   **OpenID Connect over OAuth 2.x** (SAML only where an enterprise context requires it), and the
@@ -541,6 +587,20 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   frontend may use a minimal internal web server to serve its own built assets, but it does **not**
   proxy other services. Baking a reverse proxy into an app container is a defect (couples the app to
   infra, duplicates the platform, and breaks the ownership boundary).
+- **Only a publicly useful port is published — everything else stays on the container network.**
+  A `ports:` entry exists **only** for what a human or an external system outside the stack
+  genuinely consumes: in practice the product's public entry point, and nothing else. Databases,
+  caches, brokers and their management UIs, search engines, object storage, internal APIs,
+  metrics/`/debug` endpoints and dev tooling communicate **by service name over the container
+  network** (`expose:`, or nothing at all — service DNS is enough); publishing one is a defect.
+  This is not hygiene, it is exposure: on a Docker host a published port is inserted into
+  `nftables`/`iptables` **ahead of** `ufw`/`firewalld`, so `ports: "5432:5432"` puts the database
+  on the public internet even when the host firewall denies everything. When a host-side tool
+  genuinely needs access, bind the loopback explicitly (`127.0.0.1:5432:5432`) in a local
+  override — never in the committed base stack. In Kubernetes the same rule reads: every
+  `Service` is `ClusterIP` except the ingress-fronted entry point; `NodePort`, `LoadBalancer`,
+  `hostPort` and `hostNetwork` need an ADR (a `hostPort` also bypasses `NetworkPolicy`).
+  Detail: annexe `CONTAINERS-K3S.md` CT-015.
 - **Dev stage must hot-reload.** The `dev` target/service provides live auto-reload so a source edit
   is reflected without a manual rebuild/restart: backend `uvicorn --reload` (or the framework's
   autoreload), frontend the dev server with HMR (`vite`/`npm run dev`), watched via the compose
@@ -559,6 +619,34 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   to `/setup`** rather than crashing or showing a generic error. An admin **configuration panel**
   (auth-gated CRUD API) manages runtime config with a versioned audit trail, hot-reload where
   possible (else a `RESTART_REQUIRED` flag), and JSON export/import for backup and cross-env cloning.
+- **If a user can supply a file, the product accepts an upload.** Wherever the workflow
+  involves a file the user already has — an import (CSV, JSON, GPX, ICS…), an avatar or image,
+  an attachment or supporting document, a configuration or dataset, a log or a crash dump sent
+  for support — the surface ships a **real upload path**. Telling the user to paste the
+  contents into a textarea, to drop the file on the server themselves, to send it by mail, or
+  to re-type what they already hold is a defect, not a simplification: it moves work onto the
+  person who has the least tooling for it.
+  1. **A real control, not a styled `<div>`** — a native `<input type="file">` with a
+     programmatic label (accept multiple only when the flow does), reachable and operable by
+     keyboard, plus drag-and-drop as an *addition* for pointer users, never as the only way in.
+     Accepted formats and the size limit are stated **before** the user picks, not discovered
+     through a rejection.
+  2. **Feedback while it travels** — visible progress, a cancel, and a result state per file
+     (accepted / rejected with the reason / retryable). Anything that can take more than a
+     couple of seconds is resumable or chunked, and a failed upload never silently loses the
+     user's selection.
+  3. **The server trusts nothing the client says.** Type is determined by inspecting the
+     content, not the extension nor the client-provided MIME; size is capped server-side;
+     the filename is sanitised and never used as a filesystem path; archives are bounded
+     (decompression limits). Rejections come back as typed errors with a message that says
+     what to do.
+  4. **Stored behind a port, not in the tree** — files go to an object store or a dedicated
+     volume through a `BlobStore`-style adapter (strategic pillar 5), never into the repo,
+     the web root, or a path the user can traverse. Content is served through the
+     application's authorisation, or by a signed, expiring URL — never by guessable path.
+  5. **What comes in must be able to come out.** Every uploaded file is listable, replaceable,
+     downloadable and deletable by the user who owns it, and is included in the data export
+     (strategic pillar 3). An upload with no delete and no export is lock-in with a progress bar.
 - **A floating assistant where it earns its place — never as decoration.** Any human-facing
   product whose users face a **non-obvious surface** (a dense cockpit, a multi-step form or
   wizard, a query/graph/config console, an admin panel with domain jargon) ships an **in-app
@@ -656,6 +744,39 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   to skip the test. This is what makes the *max function lines 50* / *complexity ≤ 10* gates
   achievable rather than gamed, and it is the mechanism behind the coverage floor: coverage reached
   only through end-to-end paths, with untestable god-functions underneath, does not satisfy this rule.
+- **Code is read far more often than it is written — optimise for the reader, and standardise
+  the form.** Two properties, and both are reviewable:
+  1. **Readable.** A reader — human or agent — understands *what* a unit does from its name and
+     signature, and *why* from the surrounding names, without reconstructing it line by line.
+     Concretely: intention-revealing names (`is_dispatchable`, not `check`, `flag`, `tmp`, `data`,
+     `d`, `x`), no abbreviation that is not domain vocabulary, guard clauses instead of nested
+     `if`s, one idea per line, explicit over clever. A comment explains a *why* that the code
+     cannot carry; a comment that restates the code is noise, and a comment that compensates for
+     an unreadable line is the wrong fix — rename or extract instead.
+  2. **Standardised.** The same intent is written the same way everywhere: the formatter and the
+     linter own the form (Ruff format + Ruff lint on Python, ESLint + Prettier on TS), and their
+     verdict is not negotiated in review. Style is never a review topic — the tool already
+     decided. Two files solving the same problem in two different shapes is a defect even when
+     both work.
+- **Avoid lambdas and anonymous constructs — a named function is the default.** An anonymous
+  function has no name, so it cannot be described, called from a test, or found in a traceback:
+  the stack frame reads `<lambda>` and the reviewer reads a puzzle. Rules:
+  - **Python: a `lambda` is only ever an inline key/predicate that fits on the line it is used
+    on** (`sorted(items, key=lambda i: i.rank)`). Assigning a lambda to a name is forbidden —
+    `f = lambda x: …` is a `def` written badly (Ruff `E731`). Anything with a branch, a call
+    chain, or its own rule becomes a `def` with a name, and prefer `operator.attrgetter`/
+    `itemgetter` where they say it more plainly.
+  - **TypeScript/JS: arrows stay as short callbacks** (`map`/`filter`/`reduce`, one-to-three-line
+    predicates) or as a component's inline handler when it merely forwards. A handler carrying
+    logic is a named function, hoisted out of the render path.
+  - **Forbidden in every language**: an anonymous function longer than ~3 lines, a nested named
+    function over 5 lines (extract it to the top level), a lambda used to defer or fake a
+    dependency where an injected object belongs, and clever one-liners — a nested comprehension
+    with two `for`s and a condition, a chained ternary — that trade a reader's minute for a
+    writer's second.
+  The test is mechanical: if you cannot give the expression a name that fits in three words, it
+  is doing too much to stay anonymous. Mechanisation: Ruff (`E731`, `C901`, `PLR0912`, `SIM`),
+  ESLint (`func-style: declaration`, `max-nested-callbacks: 2`, `complexity`).
 - **Basic optimisations and known anti-patterns are caught in review and in CI.** Code is written
   correct-then-obvious first — **no speculative micro-optimisation**, no premature caching, no
   hand-tuned trick without a measurement (profile before optimising; `perf` claims come with


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@fde5fe9d26bdbc61d48198e88d869d837b509aef`
Managed files (inline transverse standards block in `CLAUDE.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards