### PR TITLE
fix(scripts): drop the duplicate timeout the first sweep left behind

### DIFF
--- a/scripts/ci_annexe_audit.py
+++ b/scripts/ci_annexe_audit.py
@@ -174,9 +174,25 @@ def inspect(text: str, name: str) -> list[str]:
     return sorted(set(found))
 
 
+def dedupe_timeouts(text: str) -> str:
+    """Drop a repeated `timeout-minutes:` line left by the first sweep.
+
+    That sweep replaced a `runs-on:` line globally with a count of 1, so on a file whose jobs
+    share the same runner the insertion landed on the *first* job once per sibling — producing
+    a duplicate YAML key, which actionlint rejects outright.
+    """
+    return re.sub(
+        r"^(?P<indent>[ ]+)timeout-minutes:[ ]*(?P<value>\d+)[ ]*\n"
+        r"(?:(?P=indent)timeout-minutes:[ ]*(?P=value)[ ]*\n)+",
+        lambda m: f"{m.group('indent')}timeout-minutes: {m.group('value')}\n",
+        text,
+        flags=re.M,
+    )
+
+
 def fix(text: str, name: str) -> str | None:
     """Deterministic fixes only: concurrency group (CI-031) and job timeout (CI-030)."""
-    patched = text
+    patched = dedupe_timeouts(text)
 
     if re.search(r"^\s*pull_request(_target)?:", patched, re.M) and not re.search(
         r"^concurrency:", patched, re.M


### PR DESCRIPTION
Third defect from the same root cause as #322, and the most damaging: the first sweep called `str.replace(runs_on_line, …, 1)` **once per job missing a timeout**. On a file whose jobs share `runs-on: ubuntu-latest`, every one of those calls matched the *first* job's line — so the first job accumulated a **duplicate `timeout-minutes` key** while the later jobs got none.

A duplicate key is not cosmetic: actionlint rejects the file outright, so *Lint workflows* went red on the swept repos. Seen on `distribute-standards.yml` in this repo (`discover` job, the same value twice).

The sweep now collapses repeated `timeout-minutes` lines before patching, which means a re-run **repairs the files the first run broke** — verified idempotent, and the sibling job still gets its own timeout.

Refs #278