### PR TITLE
release: readable standardised code, no gratuitous lambdas

### DIFF
--- a/scripts/ci_annexe_audit.py
+++ b/scripts/ci_annexe_audit.py
@@ -174,9 +174,25 @@ def inspect(text: str, name: str) -> list[str]:
     return sorted(set(found))
 
 
+def dedupe_timeouts(text: str) -> str:
+    """Drop a repeated `timeout-minutes:` line left by the first sweep.
+
+    That sweep replaced a `runs-on:` line globally with a count of 1, so on a file whose jobs
+    share the same runner the insertion landed on the *first* job once per sibling — producing
+    a duplicate YAML key, which actionlint rejects outright.
+    """
+    return re.sub(
+        r"^(?P<indent>[ ]+)timeout-minutes:[ ]*(?P<value>\d+)[ ]*\n"
+        r"(?:(?P=indent)timeout-minutes:[ ]*(?P=value)[ ]*\n)+",
+        lambda m: f"{m.group('indent')}timeout-minutes: {m.group('value')}\n",
+        text,
+        flags=re.M,
+    )
+
+
 def fix(text: str, name: str) -> str | None:
     """Deterministic fixes only: concurrency group (CI-031) and job timeout (CI-030)."""
-    patched = text
+    patched = dedupe_timeouts(text)
 
     if re.search(r"^\s*pull_request(_target)?:", patched, re.M) and not re.search(
         r"^concurrency:", patched, re.M

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -527,6 +527,39 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   to skip the test. This is what makes the *max function lines 50* / *complexity ≤ 10* gates
   achievable rather than gamed, and it is the mechanism behind the coverage floor: coverage reached
   only through end-to-end paths, with untestable god-functions underneath, does not satisfy this rule.
+- **Code is read far more often than it is written — optimise for the reader, and standardise
+  the form.** Two properties, and both are reviewable:
+  1. **Readable.** A reader — human or agent — understands *what* a unit does from its name and
+     signature, and *why* from the surrounding names, without reconstructing it line by line.
+     Concretely: intention-revealing names (`is_dispatchable`, not `check`, `flag`, `tmp`, `data`,
+     `d`, `x`), no abbreviation that is not domain vocabulary, guard clauses instead of nested
+     `if`s, one idea per line, explicit over clever. A comment explains a *why* that the code
+     cannot carry; a comment that restates the code is noise, and a comment that compensates for
+     an unreadable line is the wrong fix — rename or extract instead.
+  2. **Standardised.** The same intent is written the same way everywhere: the formatter and the
+     linter own the form (Ruff format + Ruff lint on Python, ESLint + Prettier on TS), and their
+     verdict is not negotiated in review. Style is never a review topic — the tool already
+     decided. Two files solving the same problem in two different shapes is a defect even when
+     both work.
+- **Avoid lambdas and anonymous constructs — a named function is the default.** An anonymous
+  function has no name, so it cannot be described, called from a test, or found in a traceback:
+  the stack frame reads `<lambda>` and the reviewer reads a puzzle. Rules:
+  - **Python: a `lambda` is only ever an inline key/predicate that fits on the line it is used
+    on** (`sorted(items, key=lambda i: i.rank)`). Assigning a lambda to a name is forbidden —
+    `f = lambda x: …` is a `def` written badly (Ruff `E731`). Anything with a branch, a call
+    chain, or its own rule becomes a `def` with a name, and prefer `operator.attrgetter`/
+    `itemgetter` where they say it more plainly.
+  - **TypeScript/JS: arrows stay as short callbacks** (`map`/`filter`/`reduce`, one-to-three-line
+    predicates) or as a component's inline handler when it merely forwards. A handler carrying
+    logic is a named function, hoisted out of the render path.
+  - **Forbidden in every language**: an anonymous function longer than ~3 lines, a nested named
+    function over 5 lines (extract it to the top level), a lambda used to defer or fake a
+    dependency where an injected object belongs, and clever one-liners — a nested comprehension
+    with two `for`s and a condition, a chained ternary — that trade a reader's minute for a
+    writer's second.
+  The test is mechanical: if you cannot give the expression a name that fits in three words, it
+  is doing too much to stay anonymous. Mechanisation: Ruff (`E731`, `C901`, `PLR0912`, `SIM`),
+  ESLint (`func-style: declaration`, `max-nested-callbacks: 2`, `complexity`).
 - **Basic optimisations and known anti-patterns are caught in review and in CI.** Code is written
   correct-then-obvious first — **no speculative micro-optimisation**, no premature caching, no
   hand-tuned trick without a measurement (profile before optimising; `perf` claims come with


### PR DESCRIPTION
Production promotion `develop` → `main` (merge commit, per the branch model).

Ships #325 — two socle rules:

- **Code is read far more often than written**: intention-revealing names, guard clauses over nesting, comments that carry a *why*; and the formatter/linter own the form, so **style is never a review topic**.
- **Avoid lambdas and anonymous constructs**: a named function is the default. An anonymous function has no name, so it cannot be described, tested in isolation, or found in a traceback (`<lambda>` in the frame). Python lambdas stay inline key predicates and are never assigned (Ruff `E731`); TS arrows stay short callbacks; anything over ~3 lines or carrying a branch becomes a named function.

Refs #278