### PR TITLE
fix(scripts): when the sweep duplicated a timeout, the repo's own value wins

### DIFF
--- a/compliance/ci-annexe.json
+++ b/compliance/ci-annexe.json
@@ -1,46 +1,95 @@
 {
  "repos": {
-  "agent-config": {
+  "server": {
+   "_reusable-ci.yml": [
+    "CI-020",
+    "CI-030"
+   ],
+   "bootstrap.yml": [
+    "CI-010",
+    "CI-030"
+   ],
+   "branch-auto-update.yml": [
+    "CI-010"
+   ],
+   "build.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
    "ci.yml": [
     "CI-010"
    ],
    "dependabot-auto-merge.yml": [
     "CI-020"
    ],
+   "deploy.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
    "enforce-feature-branch.yml": [
     "CI-020"
    ],
-   "notion-roadmap-sync.yml": [
+   "enforce-issue-link.yml": [
+    "CI-010"
+   ],
+   "lint.yml": [
+    "CI-010",
+    "CI-030"
+   ],
+   "notion-services-sync.yml": [
     "CI-010"
    ],
    "release.yml": [
-    "CI-020"
+    "CI-010"
    ],
-   "sonar.yml": [
+   "terraform-deploy.yml": [
+    "CI-010"
+   ],
+   "terraform.yml": [
+    "CI-010"
+   ],
+   "wiki.yml": [
     "CI-010"
    ]
   },
-  "ai-aggregator": {
-   "ci.yml": [
+  "chrysa-lib": {
+   "_reusable-ci.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
+   "branch-auto-update.yml": [
     "CI-010"
    ],
+   "ci.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
    "dependabot-auto-merge.yml": [
-    "CI-020"
+    "CI-030"
    ],
    "dependencies.yml": [
-    "CI-020"
+    "CI-010"
+   ],
+   "docs.yml": [
+    "CI-011"
    ],
    "enforce-feature-branch.yml": [
     "CI-020"
    ],
-   "mutation-testing.yml": [
-    "CI-020"
+   "enforce-issue-link.yml": [
+    "CI-010"
    ],
-   "pages.yml": [
-    "CI-020"
+   "quality-gate-check.yml": [
+    "CI-010"
    ],
    "release.yml": [
-    "CI-020"
+    "CI-010",
+    "CI-020",
+    "CI-030"
    ],
    "sonar.yml": [
     "CI-010"
@@ -93,181 +142,6 @@
     "CI-030"
    ]
   },
-  "automations": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "notion-badge-sync.yml": [
-    "CI-010"
-   ],
-   "notion-projects-sync.yml": [
-    "CI-010",
-    "CI-020"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "catalog": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ]
-  },
-  "cdn-explorer": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "chrysa-claude-template": {
-   "ci.yml": [
-    "CI-010"
-   ]
-  },
-  "chrysa-lib": {
-   "_reusable-ci.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "branch-auto-update.yml": [
-    "CI-010"
-   ],
-   "ci.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-030"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "docs.yml": [
-    "CI-011"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "enforce-issue-link.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "chrysa-portfolio-viz": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "chrysa-skills": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "setup-gist-publish.yml": [
-    "CI-011"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "claude-config": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "setup-gist-publish.yml": [
-    "CI-011"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "coach": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
   "container-webview": {
    "cd.yml": [
     "CI-010"
@@ -277,565 +151,6 @@
     "CI-030"
    ],
    "release.yml": [
-    "CI-010"
-   ]
-  },
-  "D-D": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "debian-guardian": {
-   "ci.yml": [
-    "CI-010",
-    "CI-020"
-   ]
-  },
-  "dev-nexus": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-021",
-    "CI-030"
-   ],
-   "secret-scan.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "devtool": {
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "quality-checks.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "discord-bot-back": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "discordium": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "diy-stream-deck": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-app-forge": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-autoload": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-migration-analyzer": {
-   "ci.yml": [
-    "CI-010"
-   ]
-  },
-  "django-pytest": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-query-optimizer": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-query-optimizer-vscode": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-traceid": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "doc-gen": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "doc-gen-docs.yml": [
-    "CI-010"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "pages.yml": [
-    "CI-020"
-   ],
-   "publish.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "dotfiles": {},
-  "epub-sorter": {
-   "build-release.yaml": [
-    "CI-010",
-    "CI-020"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "fastapi-autoload": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "fastapi-pytest": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "fastapi-query-optimizer": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "fastapi-traceid": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "feedback-gateway": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "floating-agent": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "package.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-020"
-   ],
-   "pre-commit.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "floating-knowledge-architect-offline": {
-   "ci.yml": [
-    "CI-010",
-    "CI-020"
-   ]
-  },
-  "gaming-os": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "genealogy-validator": {
-   "action-check.yml": [
-    "CI-030"
-   ],
-   "auto-assign.yml": [
-    "CI-030"
-   ],
-   "auto-update-pre-commit.yml": [
-    "CI-030"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "detect-conflicts.yml": [
-    "CI-030"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pr-dependencies.yml": [
-    "CI-030"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ],
-   "sync-labels.yml": [
-    "CI-030"
-   ],
-   "update-pr-body.yml": [
-    "CI-030"
-   ]
-  },
-  "gestureOS": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "github-actions": {
-   "ci-fullstack.yml": [
-    "CI-010",
-    "CI-021"
-   ],
-   "ci-python-app.yml": [
-    "CI-010",
-    "CI-021"
-   ],
-   "ci-python.yml": [
-    "CI-010",
-    "CI-021"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "deploy.yml": [
-    "CI-010"
-   ],
-   "lint-python.yml": [
-    "CI-010"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "pre-commit.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "secret-scan.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "guideline-checker": {
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "pre-commit.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-021"
-   ]
-  },
-  "herdr-rtk-savings": {},
-  "homeassistant-config": {},
-  "lifeos": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "link-reader-bot": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "publish.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
     "CI-010"
    ]
   },
@@ -893,106 +208,6 @@
     "CI-020"
    ]
   },
-  "mediavault": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "mirrador": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "e2e.yml": [
-    "CI-010"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "my-resume": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "orchestrator": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "PO-GO-DEX": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
   "pre-commit-hooks-changelog": {
    "ci.yml": [
     "CI-010"
@@ -1000,237 +215,6 @@
    "pythonpackage.yml": [
     "CI-010",
     "CI-030"
-   ]
-  },
-  "pre-commit-tools": {
-   "action-check.yml": [
-    "CI-020"
-   ],
-   "approved-label.yml": [
-    "CI-020"
-   ],
-   "auto-assign.yml": [
-    "CI-020"
-   ],
-   "auto-update-pre-commit.yml": [
-    "CI-020"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "detect-conflicts.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "labeler.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "pr-dependencies.yml": [
-    "CI-020"
-   ],
-   "pre-commit.yml": [
-    "CI-010",
-    "CI-020"
-   ],
-   "publish.yml": [
-    "CI-010"
-   ],
-   "pull-request-size.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-021"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ],
-   "sync-labels.yml": [
-    "CI-020"
-   ],
-   "update-pr-body.yml": [
-    "CI-020"
-   ]
-  },
-  "project-init": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "projects-claude-config": {},
-  "quality-gatekeeper": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "satisfactory-factory-manager": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "server": {
-   "_reusable-ci.yml": [
-    "CI-020",
-    "CI-030"
-   ],
-   "bootstrap.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "branch-auto-update.yml": [
-    "CI-010"
-   ],
-   "build.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "deploy.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "enforce-issue-link.yml": [
-    "CI-010"
-   ],
-   "lint.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "notion-services-sync.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "terraform-deploy.yml": [
-    "CI-010"
-   ],
-   "terraform.yml": [
-    "CI-010"
-   ],
-   "wiki.yml": [
-    "CI-010"
-   ]
-  },
-  "shared-standards": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "distribute-standards.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "labeler.yml": [
-    "CI-010"
-   ],
-   "pr-dependencies.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "sport-intelligence-hub": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "studioverse": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
    ]
   },
   "usefull-containers": {
@@ -1259,52 +243,12 @@
    "sonar.yml": [
     "CI-010"
    ]
-  },
-  "windows-docker-state-notification": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "windows-guardian": {
-   "ci.yml": [
-    "CI-010",
-    "CI-020"
-   ]
-  },
-  "workstation-os": {
-   "ci.yml": [
-    "CI-011"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ]
-  },
-  "wsmqtt-monitor": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
   }
  },
  "totals": {
-  "CI-010": 208,
-  "CI-020": 155,
-  "CI-030": 34,
-  "CI-011": 4,
-  "CI-021": 12
+  "CI-020": 25,
+  "CI-030": 23,
+  "CI-010": 41,
+  "CI-011": 1
  }
 }

--- a/scripts/ci_annexe_audit.py
+++ b/scripts/ci_annexe_audit.py
@@ -179,12 +179,21 @@ def dedupe_timeouts(text: str) -> str:
 
     That sweep replaced a `runs-on:` line globally with a count of 1, so on a file whose jobs
     share the same runner the insertion landed on the *first* job once per sibling — producing
-    a duplicate YAML key, which actionlint rejects outright.
+    a duplicate YAML key, which actionlint rejects outright. It also hit jobs that already
+    declared a timeout, leaving two different values; the repo's own value wins, since it was
+    chosen for that job and the swept one is only a default.
     """
+
+    def keep_one(match: re.Match[str]) -> str:
+        indent = match.group("indent")
+        values = re.findall(r"timeout-minutes:[ ]*(\d+)", match.group(0))
+        chosen = next((v for v in values if int(v) != DEFAULT_TIMEOUT), values[0])
+        return f"{indent}timeout-minutes: {chosen}\n"
+
     return re.sub(
-        r"^(?P<indent>[ ]+)timeout-minutes:[ ]*(?P<value>\d+)[ ]*\n"
-        r"(?:(?P=indent)timeout-minutes:[ ]*(?P=value)[ ]*\n)+",
-        lambda m: f"{m.group('indent')}timeout-minutes: {m.group('value')}\n",
+        r"^(?P<indent>[ ]+)timeout-minutes:[ ]*\d+[ ]*\n"
+        r"(?:(?P=indent)timeout-minutes:[ ]*\d+[ ]*\n)+",
+        keep_one,
         text,
         flags=re.M,
     )


### PR DESCRIPTION
Follow-up to #324. The dedup pass collapsed only *identical* duplicates, so two files kept a duplicate key with **different** values — the first sweep had injected `timeout-minutes: 30` next to a deliberate `timeout-minutes: 15` (`linkendin-resume/pages.yml`, `usefull-containers/ci.yml`).

The repo's own value now wins: it was chosen for that job, the swept one is only a default.

Measured damage from the original bug: **13 files across 7 repos**. Eleven were repaired by #324; these two needed this pass.

Refs #278