### PR TITLE
feat(standards): per-person data implies a user account

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -170,6 +170,37 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   dependency, no submodule used as a runtime link, no access to another project's database or
   private models. Each consumer wraps the external contract in a local adapter and degrades
   cleanly when the provider is gone. Detail: annexe `PROJECT-DECOUPLING.md`.
+- **Per-person data implies a user account — no exceptions dressed up as simplicity.** The
+  moment a product stores or manipulates anything whose *value depends on who is looking*
+  — preferences, saved filters and views, favourites, drafts, history, progress, notes,
+  annotations, uploads, notification settings, API keys, per-person results — it has **real
+  user accounts** behind the identity hierarchy above. The trigger is the data, not the size
+  of the app: a "small internal tool" that remembers your filters is already storing personal
+  data for several people.
+  1. **Ownership is modelled, not implied.** Every per-person row carries its owner
+     (`user_id` foreign key), and every read/write is scoped by it in the repository layer —
+     not filtered in the UI, not trusted from a request parameter. An endpoint that returns
+     another user's row because the id was guessed is the same defect whether the data is a
+     medical record or a colour theme.
+  2. **`localStorage` is a cache, never the system of record.** Browser storage holds what
+     the user can afford to lose on a new device; anything they would be upset to lose lives
+     server-side under their account. A product whose personalisation exists only in one
+     browser has no personalisation — it has a cookie.
+  3. **A shared password is not an account.** One credential handed to several people makes
+     every action unattributable, every revocation a fleet-wide password change, and every
+     export meaningless. Same for "profiles" selected from a dropdown with no authentication:
+     that is a preference switch pretending to be identity.
+  4. **Account plumbing is part of the feature, not a later epic** — sign-up/invite, sign-in,
+     password or SSO recovery, session expiry, and **deletion of the account with its data**
+     ship together with the first per-person field. Retrofitting ownership onto a table that
+     already holds everyone's rows is a migration, an audit, and an apology.
+  5. **Anonymous stays anonymous.** A genuinely public, read-only surface (a landing page, a
+     public catalogue) needs no account — and therefore must not quietly accumulate
+     per-person state either. If a feature needs to remember the visitor, it needs an account;
+     "we'll just key it by browser fingerprint" is tracking, not architecture.
+  This is the precondition of *portable personalisation data* (strategic pillar 3): an export
+  command only means something when the data has an owner. Detail on the identity path itself:
+  the rule below.
 - **Identity goes through the cluster SSO first.** Every interactive product deployed in the
   cluster integrates the **common cluster SSO** as its primary sign-in. The priority protocol is
   **OpenID Connect over OAuth 2.x** (SAML only where an enterprise context requires it), and the


### PR DESCRIPTION
New socle rule, placed just before *Identity goes through the cluster SSO first* (which it feeds into).

**The trigger is the data, not the size of the app.** The moment a product stores or manipulates anything whose value depends on *who is looking* — preferences, saved filters and views, favourites, drafts, history, progress, notes, uploads, notification settings, API keys — it gets **real user accounts**. A "small internal tool" that remembers your filters is already storing personal data for several people.

1. **Ownership is modelled, not implied** — every per-person row carries its owner (`user_id`), and every read/write is scoped in the repository layer, not filtered in the UI and never trusted from a request parameter. Returning another user's row because the id was guessed is the same defect whether the payload is a medical record or a colour theme.
2. **`localStorage` is a cache, never the system of record** — browser storage holds what the user can afford to lose on a new device. A product whose personalisation exists only in one browser has no personalisation, it has a cookie.
3. **A shared password is not an account** — it makes every action unattributable, every revocation a fleet-wide password change, and every export meaningless. A "profile" picked from a dropdown with no authentication is a preference switch pretending to be identity.
4. **Account plumbing ships with the first per-person field** — sign-up/invite, sign-in, recovery, session expiry, and deletion of the account *with its data*. Retrofitting ownership onto a table that already holds everyone's rows is a migration, an audit, and an apology.
5. **Anonymous stays anonymous** — a genuinely public read-only surface needs no account, and must not quietly accumulate per-person state either; "we'll key it by browser fingerprint" is tracking, not architecture.

This is the precondition of strategic pillar 3 (*portable personalisation data*): an export command only means something when the data has an owner.

Refs #278
