### PR TITLE
release: per-person data implies a user account

### DIFF
--- a/compliance/ci-annexe.json
+++ b/compliance/ci-annexe.json
@@ -1,46 +1,95 @@
 {
  "repos": {
-  "agent-config": {
+  "server": {
+   "_reusable-ci.yml": [
+    "CI-020",
+    "CI-030"
+   ],
+   "bootstrap.yml": [
+    "CI-010",
+    "CI-030"
+   ],
+   "branch-auto-update.yml": [
+    "CI-010"
+   ],
+   "build.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
    "ci.yml": [
     "CI-010"
    ],
    "dependabot-auto-merge.yml": [
     "CI-020"
    ],
+   "deploy.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
    "enforce-feature-branch.yml": [
     "CI-020"
    ],
-   "notion-roadmap-sync.yml": [
+   "enforce-issue-link.yml": [
+    "CI-010"
+   ],
+   "lint.yml": [
+    "CI-010",
+    "CI-030"
+   ],
+   "notion-services-sync.yml": [
     "CI-010"
    ],
    "release.yml": [
-    "CI-020"
+    "CI-010"
    ],
-   "sonar.yml": [
+   "terraform-deploy.yml": [
+    "CI-010"
+   ],
+   "terraform.yml": [
+    "CI-010"
+   ],
+   "wiki.yml": [
     "CI-010"
    ]
   },
-  "ai-aggregator": {
-   "ci.yml": [
+  "chrysa-lib": {
+   "_reusable-ci.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
+   "branch-auto-update.yml": [
     "CI-010"
    ],
+   "ci.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
    "dependabot-auto-merge.yml": [
-    "CI-020"
+    "CI-030"
    ],
    "dependencies.yml": [
-    "CI-020"
+    "CI-010"
+   ],
+   "docs.yml": [
+    "CI-011"
    ],
    "enforce-feature-branch.yml": [
     "CI-020"
    ],
-   "mutation-testing.yml": [
-    "CI-020"
+   "enforce-issue-link.yml": [
+    "CI-010"
    ],
-   "pages.yml": [
-    "CI-020"
+   "quality-gate-check.yml": [
+    "CI-010"
    ],
    "release.yml": [
-    "CI-020"
+    "CI-010",
+    "CI-020",
+    "CI-030"
    ],
    "sonar.yml": [
     "CI-010"
@@ -93,181 +142,6 @@
     "CI-030"
    ]
   },
-  "automations": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "notion-badge-sync.yml": [
-    "CI-010"
-   ],
-   "notion-projects-sync.yml": [
-    "CI-010",
-    "CI-020"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "catalog": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ]
-  },
-  "cdn-explorer": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "chrysa-claude-template": {
-   "ci.yml": [
-    "CI-010"
-   ]
-  },
-  "chrysa-lib": {
-   "_reusable-ci.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "branch-auto-update.yml": [
-    "CI-010"
-   ],
-   "ci.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-030"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "docs.yml": [
-    "CI-011"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "enforce-issue-link.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "chrysa-portfolio-viz": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "chrysa-skills": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "setup-gist-publish.yml": [
-    "CI-011"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "claude-config": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "setup-gist-publish.yml": [
-    "CI-011"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "coach": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
   "container-webview": {
    "cd.yml": [
     "CI-010"
@@ -277,565 +151,6 @@
     "CI-030"
    ],
    "release.yml": [
-    "CI-010"
-   ]
-  },
-  "D-D": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "debian-guardian": {
-   "ci.yml": [
-    "CI-010",
-    "CI-020"
-   ]
-  },
-  "dev-nexus": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-021",
-    "CI-030"
-   ],
-   "secret-scan.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "devtool": {
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "quality-checks.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "discord-bot-back": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "discordium": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "diy-stream-deck": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-app-forge": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-autoload": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-migration-analyzer": {
-   "ci.yml": [
-    "CI-010"
-   ]
-  },
-  "django-pytest": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-query-optimizer": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-query-optimizer-vscode": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "django-traceid": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "doc-gen": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "doc-gen-docs.yml": [
-    "CI-010"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "pages.yml": [
-    "CI-020"
-   ],
-   "publish.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "dotfiles": {},
-  "epub-sorter": {
-   "build-release.yaml": [
-    "CI-010",
-    "CI-020"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "fastapi-autoload": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "fastapi-pytest": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "fastapi-query-optimizer": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "fastapi-traceid": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "feedback-gateway": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "floating-agent": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "package.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-020"
-   ],
-   "pre-commit.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "floating-knowledge-architect-offline": {
-   "ci.yml": [
-    "CI-010",
-    "CI-020"
-   ]
-  },
-  "gaming-os": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "genealogy-validator": {
-   "action-check.yml": [
-    "CI-030"
-   ],
-   "auto-assign.yml": [
-    "CI-030"
-   ],
-   "auto-update-pre-commit.yml": [
-    "CI-030"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "detect-conflicts.yml": [
-    "CI-030"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pr-dependencies.yml": [
-    "CI-030"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ],
-   "sync-labels.yml": [
-    "CI-030"
-   ],
-   "update-pr-body.yml": [
-    "CI-030"
-   ]
-  },
-  "gestureOS": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "github-actions": {
-   "ci-fullstack.yml": [
-    "CI-010",
-    "CI-021"
-   ],
-   "ci-python-app.yml": [
-    "CI-010",
-    "CI-021"
-   ],
-   "ci-python.yml": [
-    "CI-010",
-    "CI-021"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "deploy.yml": [
-    "CI-010"
-   ],
-   "lint-python.yml": [
-    "CI-010"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "pre-commit.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "secret-scan.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "guideline-checker": {
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "pre-commit.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-021"
-   ]
-  },
-  "herdr-rtk-savings": {},
-  "homeassistant-config": {},
-  "lifeos": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "link-reader-bot": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "publish.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
     "CI-010"
    ]
   },
@@ -893,106 +208,6 @@
     "CI-020"
    ]
   },
-  "mediavault": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "mirrador": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "e2e.yml": [
-    "CI-010"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-010"
-   ],
-   "pages.yml": [
-    "CI-010"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "my-resume": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "orchestrator": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "PO-GO-DEX": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
   "pre-commit-hooks-changelog": {
    "ci.yml": [
     "CI-010"
@@ -1000,237 +215,6 @@
    "pythonpackage.yml": [
     "CI-010",
     "CI-030"
-   ]
-  },
-  "pre-commit-tools": {
-   "action-check.yml": [
-    "CI-020"
-   ],
-   "approved-label.yml": [
-    "CI-020"
-   ],
-   "auto-assign.yml": [
-    "CI-020"
-   ],
-   "auto-update-pre-commit.yml": [
-    "CI-020"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "detect-conflicts.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "labeler.yml": [
-    "CI-020"
-   ],
-   "mutation-testing.yml": [
-    "CI-020"
-   ],
-   "pr-dependencies.yml": [
-    "CI-020"
-   ],
-   "pre-commit.yml": [
-    "CI-010",
-    "CI-020"
-   ],
-   "publish.yml": [
-    "CI-010"
-   ],
-   "pull-request-size.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-021"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ],
-   "sync-labels.yml": [
-    "CI-020"
-   ],
-   "update-pr-body.yml": [
-    "CI-020"
-   ]
-  },
-  "project-init": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-020"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "projects-claude-config": {},
-  "quality-gatekeeper": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "dependencies.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "satisfactory-factory-manager": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "server": {
-   "_reusable-ci.yml": [
-    "CI-020",
-    "CI-030"
-   ],
-   "bootstrap.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "branch-auto-update.yml": [
-    "CI-010"
-   ],
-   "build.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "deploy.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "enforce-issue-link.yml": [
-    "CI-010"
-   ],
-   "lint.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "notion-services-sync.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "terraform-deploy.yml": [
-    "CI-010"
-   ],
-   "terraform.yml": [
-    "CI-010"
-   ],
-   "wiki.yml": [
-    "CI-010"
-   ]
-  },
-  "shared-standards": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependencies.yml": [
-    "CI-010"
-   ],
-   "distribute-standards.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "labeler.yml": [
-    "CI-010"
-   ],
-   "pr-dependencies.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "quality-gate-check.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
-  },
-  "sport-intelligence-hub": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "studioverse": {
-   "ci.yml": [
-    "CI-021"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
    ]
   },
   "usefull-containers": {
@@ -1259,52 +243,12 @@
    "sonar.yml": [
     "CI-010"
    ]
-  },
-  "windows-docker-state-notification": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ],
-   "enforce-feature-branch.yml": [
-    "CI-020"
-   ],
-   "release.yml": [
-    "CI-010"
-   ],
-   "sonar.yml": [
-    "CI-010"
-   ]
-  },
-  "windows-guardian": {
-   "ci.yml": [
-    "CI-010",
-    "CI-020"
-   ]
-  },
-  "workstation-os": {
-   "ci.yml": [
-    "CI-011"
-   ],
-   "dependabot-auto-merge.yml": [
-    "CI-020"
-   ]
-  },
-  "wsmqtt-monitor": {
-   "ci.yml": [
-    "CI-010"
-   ],
-   "release.yml": [
-    "CI-010"
-   ]
   }
  },
  "totals": {
-  "CI-010": 208,
-  "CI-020": 155,
-  "CI-030": 34,
-  "CI-011": 4,
-  "CI-021": 12
+  "CI-020": 25,
+  "CI-030": 23,
+  "CI-010": 41,
+  "CI-011": 1
  }
 }

--- a/scripts/ci_annexe_audit.py
+++ b/scripts/ci_annexe_audit.py
@@ -179,12 +179,21 @@ def dedupe_timeouts(text: str) -> str:
 
     That sweep replaced a `runs-on:` line globally with a count of 1, so on a file whose jobs
     share the same runner the insertion landed on the *first* job once per sibling — producing
-    a duplicate YAML key, which actionlint rejects outright.
+    a duplicate YAML key, which actionlint rejects outright. It also hit jobs that already
+    declared a timeout, leaving two different values; the repo's own value wins, since it was
+    chosen for that job and the swept one is only a default.
     """
+
+    def keep_one(match: re.Match[str]) -> str:
+        indent = match.group("indent")
+        values = re.findall(r"timeout-minutes:[ ]*(\d+)", match.group(0))
+        chosen = next((v for v in values if int(v) != DEFAULT_TIMEOUT), values[0])
+        return f"{indent}timeout-minutes: {chosen}\n"
+
     return re.sub(
-        r"^(?P<indent>[ ]+)timeout-minutes:[ ]*(?P<value>\d+)[ ]*\n"
-        r"(?:(?P=indent)timeout-minutes:[ ]*(?P=value)[ ]*\n)+",
-        lambda m: f"{m.group('indent')}timeout-minutes: {m.group('value')}\n",
+        r"^(?P<indent>[ ]+)timeout-minutes:[ ]*\d+[ ]*\n"
+        r"(?:(?P=indent)timeout-minutes:[ ]*\d+[ ]*\n)+",
+        keep_one,
         text,
         flags=re.M,
     )

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -128,6 +128,21 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   `loading="lazy"` media, on-demand heavy components) behind a **shape-accurate placeholder**
   that reserves the final dimensions — a skeleton, not a spinner, so arrival shifts no layout.
   Detail: annexe `FRONTEND.md` §2–§3, §7.
+- **The frontend says when the backend is unreachable or unstable.** Silence is the worst
+  failure mode: a spinner that never resolves, a list that stays empty, a form that swallows a
+  submit all read as "the app is broken and lying about it". The API client classifies every
+  failure into application state — `unreachable`, `unstable`, `degraded`, `unauthorised`
+  (a session problem, not an outage), `offline` (the browser's fault, worded as such) — and a
+  **persistent, non-blocking banner in the root shell** states it for the whole app, while each
+  container still resolves its own error state. The message says what happened and what to do
+  (*"Server unreachable — reconnecting in 12 s"*, never a raw status code), keeps a manual
+  **Retry** available, **disables destructive or unsaved actions** instead of failing silently
+  on submit, and **preserves in-progress form input** for re-submission on recovery. Reconnection
+  uses bounded exponential backoff with jitter — an unbounded retry loop against a struggling
+  backend is a defect — and success clears the state and refetches. The banner is a live region
+  (`role="alert"` / `role="status"`) and its behaviour is tested against a network error and a
+  503. A frontend Definition of Done includes its **API-down state**. Detail: annexe
+  `FRONTEND.md` FE-050.
 - **Every repo declares its profile and DDD level** (`project_profile`, `ddd_level`,
   `bounded_context`, `standards_version`) — architecture is proportionate to business
   complexity, and small tools are not over-architected. Detail: annexe `ARCHITECTURE-DDD.md`.

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -476,6 +476,34 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   to `/setup`** rather than crashing or showing a generic error. An admin **configuration panel**
   (auth-gated CRUD API) manages runtime config with a versioned audit trail, hot-reload where
   possible (else a `RESTART_REQUIRED` flag), and JSON export/import for backup and cross-env cloning.
+- **If a user can supply a file, the product accepts an upload.** Wherever the workflow
+  involves a file the user already has — an import (CSV, JSON, GPX, ICS…), an avatar or image,
+  an attachment or supporting document, a configuration or dataset, a log or a crash dump sent
+  for support — the surface ships a **real upload path**. Telling the user to paste the
+  contents into a textarea, to drop the file on the server themselves, to send it by mail, or
+  to re-type what they already hold is a defect, not a simplification: it moves work onto the
+  person who has the least tooling for it.
+  1. **A real control, not a styled `<div>`** — a native `<input type="file">` with a
+     programmatic label (accept multiple only when the flow does), reachable and operable by
+     keyboard, plus drag-and-drop as an *addition* for pointer users, never as the only way in.
+     Accepted formats and the size limit are stated **before** the user picks, not discovered
+     through a rejection.
+  2. **Feedback while it travels** — visible progress, a cancel, and a result state per file
+     (accepted / rejected with the reason / retryable). Anything that can take more than a
+     couple of seconds is resumable or chunked, and a failed upload never silently loses the
+     user's selection.
+  3. **The server trusts nothing the client says.** Type is determined by inspecting the
+     content, not the extension nor the client-provided MIME; size is capped server-side;
+     the filename is sanitised and never used as a filesystem path; archives are bounded
+     (decompression limits). Rejections come back as typed errors with a message that says
+     what to do.
+  4. **Stored behind a port, not in the tree** — files go to an object store or a dedicated
+     volume through a `BlobStore`-style adapter (strategic pillar 5), never into the repo,
+     the web root, or a path the user can traverse. Content is served through the
+     application's authorisation, or by a signed, expiring URL — never by guessable path.
+  5. **What comes in must be able to come out.** Every uploaded file is listable, replaceable,
+     downloadable and deletable by the user who owns it, and is included in the data export
+     (strategic pillar 3). An upload with no delete and no export is lock-in with a progress bar.
 - **A floating assistant where it earns its place — never as decoration.** Any human-facing
   product whose users face a **non-obvious surface** (a dense cockpit, a multi-step form or
   wizard, a query/graph/config console, an admin panel with domain jargon) ships an **in-app

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -170,6 +170,37 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   dependency, no submodule used as a runtime link, no access to another project's database or
   private models. Each consumer wraps the external contract in a local adapter and degrades
   cleanly when the provider is gone. Detail: annexe `PROJECT-DECOUPLING.md`.
+- **Per-person data implies a user account — no exceptions dressed up as simplicity.** The
+  moment a product stores or manipulates anything whose *value depends on who is looking*
+  — preferences, saved filters and views, favourites, drafts, history, progress, notes,
+  annotations, uploads, notification settings, API keys, per-person results — it has **real
+  user accounts** behind the identity hierarchy above. The trigger is the data, not the size
+  of the app: a "small internal tool" that remembers your filters is already storing personal
+  data for several people.
+  1. **Ownership is modelled, not implied.** Every per-person row carries its owner
+     (`user_id` foreign key), and every read/write is scoped by it in the repository layer —
+     not filtered in the UI, not trusted from a request parameter. An endpoint that returns
+     another user's row because the id was guessed is the same defect whether the data is a
+     medical record or a colour theme.
+  2. **`localStorage` is a cache, never the system of record.** Browser storage holds what
+     the user can afford to lose on a new device; anything they would be upset to lose lives
+     server-side under their account. A product whose personalisation exists only in one
+     browser has no personalisation — it has a cookie.
+  3. **A shared password is not an account.** One credential handed to several people makes
+     every action unattributable, every revocation a fleet-wide password change, and every
+     export meaningless. Same for "profiles" selected from a dropdown with no authentication:
+     that is a preference switch pretending to be identity.
+  4. **Account plumbing is part of the feature, not a later epic** — sign-up/invite, sign-in,
+     password or SSO recovery, session expiry, and **deletion of the account with its data**
+     ship together with the first per-person field. Retrofitting ownership onto a table that
+     already holds everyone's rows is a migration, an audit, and an apology.
+  5. **Anonymous stays anonymous.** A genuinely public, read-only surface (a landing page, a
+     public catalogue) needs no account — and therefore must not quietly accumulate
+     per-person state either. If a feature needs to remember the visitor, it needs an account;
+     "we'll just key it by browser fingerprint" is tracking, not architecture.
+  This is the precondition of *portable personalisation data* (strategic pillar 3): an export
+  command only means something when the data has an owner. Detail on the identity path itself:
+  the rule below.
 - **Identity goes through the cluster SSO first.** Every interactive product deployed in the
   cluster integrates the **common cluster SSO** as its primary sign-in. The priority protocol is
   **OpenID Connect over OAuth 2.x** (SAML only where an enterprise context requires it), and the

--- a/standards/annexes/FRONTEND.md
+++ b/standards/annexes/FRONTEND.md
@@ -145,6 +145,43 @@ arriving"). It toggles `aria-busy="true" → "false"` on the region it governs a
 Navigation goes through the router (see the socle's *URL-addressable navigation*); a full
 page reload as a navigation mechanism is a defect.
 
+### FE-050 — The frontend says when the backend is unreachable or unstable
+
+A frontend whose API is down must **say so**, in its own words, at the moment it knows. Silence
+is the worst failure mode: a spinner that never resolves, a list that stays empty, a form that
+swallows a submit — all three read as "the app is broken and lying about it", and the user's
+next move is to retry the same action or leave.
+
+- **Detect, don't guess.** The single API client (FE-030) classifies every failure and exposes
+  the result as application state: `unreachable` (network error, DNS, CORS, timeout),
+  `unstable` (5xx, repeated timeouts, a circuit-breaker that opened), `degraded` (a health
+  endpoint reporting a dependency down), `unauthorised` (401/403 — a session problem, **not**
+  an outage), `offline` (`navigator.onLine === false`, which is the *browser's* fault and must
+  be worded as such). Deriving this from a component's local `catch` gives one screen the
+  truth and leaves the rest of the app lying.
+- **One global surface, plus local truth.** A persistent, non-blocking banner in the root
+  shell states the connection state for the whole app; each container still resolves its own
+  error state (FE-037). The banner never covers the content, never steals focus, and
+  disappears by itself once a call succeeds.
+- **Say what happened, what it means, and what to do.** *"Server unreachable — reconnecting
+  in 12 s"*, not *"Error"*, not a raw status code, not a stack trace. A manual **Retry** stays
+  available next to the message, and any destructive or unsaved action is disabled while the
+  backend is unreachable rather than failing silently on submit.
+- **Recovery is automatic and visible.** Reconnection attempts use bounded exponential backoff
+  with jitter, the banner shows the next attempt, and success clears the state and refetches
+  what the screen needs. An unbounded retry loop hammering a struggling backend is a defect
+  (mirrors the socle's *failures are contained, and observable*).
+- **Unsaved work survives the outage.** In-progress form input is kept client-side while the
+  backend is unavailable and re-submittable on recovery — losing what the user typed because
+  the network blinked is a data-loss bug, not a network problem.
+- **Accessible and testable.** The banner is a live region (`role="status"` for degraded,
+  `role="alert"` for unreachable) so screen-reader users learn about it too, and it is
+  exercised in tests: MSW returns a network error and a 503, and the test asserts the message,
+  the disabled destructive action, and the recovery path (FE-041).
+
+A frontend Definition of Done includes its **API-down state**, exactly like the loading and
+empty ones.
+
 ______________________________________________________________________
 
 ## 4. Frontend tests


### PR DESCRIPTION
New socle rule, placed just before *Identity goes through the cluster SSO first* (which it feeds into).

**The trigger is the data, not the size of the app.** The moment a product stores or manipulates anything whose value depends on *who is looking* — preferences, saved filters and views, favourites, drafts, history, progress, notes, uploads, notification settings, API keys — it gets **real user accounts**. A "small internal tool" that remembers your filters is already storing personal data for several people.

1. **Ownership is modelled, not implied** — every per-person row carries its owner (`user_id`), and every read/write is scoped in the repository layer, not filtered in the UI and never trusted from a request parameter. Returning another user's row because the id was guessed is the same defect whether the payload is a medical record or a colour theme.
2. **`localStorage` is a cache, never the system of record** — browser storage holds what the user can afford to lose on a new device. A product whose personalisation exists only in one browser has no personalisation, it has a cookie.
3. **A shared password is not an account** — it makes every action unattributable, every revocation a fleet-wide password change, and every export meaningless. A "profile" picked from a dropdown with no authentication is a preference switch pretending to be identity.
4. **Account plumbing ships with the first per-person field** — sign-up/invite, sign-in, recovery, session expiry, and deletion of the account *with its data*. Retrofitting ownership onto a table that already holds everyone's rows is a migration, an audit, and an apology.
5. **Anonymous stays anonymous** — a genuinely public read-only surface needs no account, and must not quietly accumulate per-person state either; "we'll key it by browser fingerprint" is tracking, not architecture.

This is the precondition of strategic pillar 3 (*portable personalisation data*): an export command only means something when the data has an owner.

Refs #278
