### PR TITLE
fix(pre-commit-merge): govern the code-quality hooks as python-stack hooks

### DIFF
--- a/scripts/github_actions_pin.py
+++ b/scripts/github_actions_pin.py
@@ -137,6 +137,17 @@ def sweep_repo(repo: str, target: str, apply: bool) -> tuple[str, str]:
     return "patched", ", ".join(sorted(stale))
 
 
+# sweep_repo() state -> (report line, tally bucket). A new state is a new row here,
+# not a new branch in main() (standards: prefer a lookup table to a state machine).
+STATE_REPORT: dict[str, tuple[str, str | None]] = {
+    "ok": ("ok {repo}", None),
+    "absent": ("·  {repo} · no workflows", None),
+    "drift": ("⚠  {repo} · {detail}", "drift"),
+    "patched": ("✅ {repo} · {detail}", "drift"),
+}
+_UNKNOWN_STATE = ("❌ {repo} · {detail}", "failure")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--apply", action="store_true", help="open PRs instead of auditing")
@@ -160,16 +171,12 @@ def main() -> int:
     drift, failures = [], []
     for repo in repos:
         state, detail = sweep_repo(repo, target, args.apply)
-        if state == "ok":
-            print(f"ok {repo}")
-        elif state == "absent":
-            print(f"·  {repo} · no workflows")
-        elif state == "drift":
-            drift.append(repo); print(f"⚠  {repo} · {detail}")
-        elif state == "patched":
-            drift.append(repo); print(f"✅ {repo} · {detail}")
-        else:
-            failures.append((repo, detail)); print(f"❌ {repo} · {detail}")
+        template, bucket = STATE_REPORT.get(state, _UNKNOWN_STATE)
+        print(template.format(repo=repo, detail=detail))
+        if bucket == "drift":
+            drift.append(repo)
+        elif bucket == "failure":
+            failures.append((repo, detail))
 
     print(f"\nchecked={len(repos)} drift={len(drift)} failures={len(failures)}")
     return 1 if (failures or (drift and not args.apply)) else 0

--- a/scripts/pre-commit-merge.py
+++ b/scripts/pre-commit-merge.py
@@ -133,6 +133,10 @@ HOOK_GROUPS = {
         "debugger-detection", "python-print-detection", "python-pprint-detection",
         "no-bare-except", "python-logger-detection", "python-unreachable-code",
         "no-hardcoded-localhost", "regression-gate",
+        # Detectors for the code-quality rules of the standards block. Measured dry
+        # across the 63 status:dev repos before arming: 47 untyped raises (13 of them
+        # in tests, hence the baseline exclude), 5 dispatch ladders, 0 mutable defaults.
+        "python-untyped-raise", "python-mutable-default", "python-dispatch-ladder",
     },
     "docker": {"dockerfile-no-latest"},
     "jsts": {


### PR DESCRIPTION
## Context
The three detectors added in `pre-commit-tools#316` (`python-untyped-raise`, `python-mutable-default`, `python-dispatch-ladder`) are in the canonical `.pre-commit-config.yaml` but were never added to `HOOK_GROUPS`. Since `hook_enforced()` returns `True` for any id outside `GOVERNED`, they were distributed to **every** repo regardless of `--stacks` — verified remotely in `claude-config`, `gaming-os`, `container-webview`, none of which carry Python.

## Change
- The three ids move into `HOOK_GROUPS["python"]` — selected by the python stack, no longer slipping through the ungoverned branch. No repo loses a hook (the merge never deletes); the change governs what future merges push where.
- `scripts/github_actions_pin.py`: the 4-branch `state` ladder in `main()` becomes a `STATE_REPORT` lookup table, so this repo stops violating the rule its own hook enforces. A new state is a new row, not a new branch.

## Fleet measurement (dry, 63 status:dev repos, before/independent of this PR)
| Hook | Findings |
|---|---|
| `python-untyped-raise` | 47 (`RuntimeError` ×43, `Exception` ×4) — 13 of them in tests, already covered by the baseline `exclude: ^tests?/` |
| `python-dispatch-ladder` | 5, no false positive on inspection |
| `python-mutable-default` | 0 |

Concentrated on 5 repos (chrysa-portfolio-viz 16, django-migration-analyzer 9, pre-commit-hooks-changelog 6, sport-intelligence-hub 4, doc-gen 4); 48 repos are already clean.

## Verification
- Both hooks run clean over `scripts/` after the ladder fix (exit 0).
- `ruff check` on both touched files: only the two pre-existing findings on `sweep_repo` (`C901`, `PLR0911`), reproduced on a clean tree — untouched by this PR.

Fixes #336