### PR TITLE
fix(scripts): parse the jobs section correctly on key-sorted workflows

### DIFF
--- a/compliance/ci-annexe.json
+++ b/compliance/ci-annexe.json
@@ -1,95 +1,46 @@
 {
  "repos": {
-  "server": {
-   "_reusable-ci.yml": [
-    "CI-020",
-    "CI-030"
-   ],
-   "bootstrap.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "branch-auto-update.yml": [
-    "CI-010"
-   ],
-   "build.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
+  "agent-config": {
    "ci.yml": [
     "CI-010"
    ],
    "dependabot-auto-merge.yml": [
     "CI-020"
    ],
-   "deploy.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
    "enforce-feature-branch.yml": [
     "CI-020"
    ],
-   "enforce-issue-link.yml": [
-    "CI-010"
-   ],
-   "lint.yml": [
-    "CI-010",
-    "CI-030"
-   ],
-   "notion-services-sync.yml": [
+   "notion-roadmap-sync.yml": [
     "CI-010"
    ],
    "release.yml": [
-    "CI-010"
+    "CI-020"
    ],
-   "terraform-deploy.yml": [
-    "CI-010"
-   ],
-   "terraform.yml": [
-    "CI-010"
-   ],
-   "wiki.yml": [
+   "sonar.yml": [
     "CI-010"
    ]
   },
-  "chrysa-lib": {
-   "_reusable-ci.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
-   ],
-   "branch-auto-update.yml": [
-    "CI-010"
-   ],
+  "ai-aggregator": {
    "ci.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
+    "CI-010"
    ],
    "dependabot-auto-merge.yml": [
-    "CI-030"
+    "CI-020"
    ],
    "dependencies.yml": [
-    "CI-010"
-   ],
-   "docs.yml": [
-    "CI-011"
+    "CI-020"
    ],
    "enforce-feature-branch.yml": [
     "CI-020"
    ],
-   "enforce-issue-link.yml": [
-    "CI-010"
+   "mutation-testing.yml": [
+    "CI-020"
    ],
-   "quality-gate-check.yml": [
-    "CI-010"
+   "pages.yml": [
+    "CI-020"
    ],
    "release.yml": [
-    "CI-010",
-    "CI-020",
-    "CI-030"
+    "CI-020"
    ],
    "sonar.yml": [
     "CI-010"
@@ -142,6 +93,181 @@
     "CI-030"
    ]
   },
+  "automations": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-010"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "notion-badge-sync.yml": [
+    "CI-010"
+   ],
+   "notion-projects-sync.yml": [
+    "CI-010",
+    "CI-020"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "catalog": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ]
+  },
+  "cdn-explorer": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-010"
+   ],
+   "pages.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-020"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "chrysa-claude-template": {
+   "ci.yml": [
+    "CI-010"
+   ]
+  },
+  "chrysa-lib": {
+   "_reusable-ci.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
+   "branch-auto-update.yml": [
+    "CI-010"
+   ],
+   "ci.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-030"
+   ],
+   "dependencies.yml": [
+    "CI-010"
+   ],
+   "docs.yml": [
+    "CI-011"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "enforce-issue-link.yml": [
+    "CI-010"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "chrysa-portfolio-viz": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "chrysa-skills": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "setup-gist-publish.yml": [
+    "CI-011"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "claude-config": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "setup-gist-publish.yml": [
+    "CI-011"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "coach": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-020"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
   "container-webview": {
    "cd.yml": [
     "CI-010"
@@ -151,6 +277,565 @@
     "CI-030"
    ],
    "release.yml": [
+    "CI-010"
+   ]
+  },
+  "D-D": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "debian-guardian": {
+   "ci.yml": [
+    "CI-010",
+    "CI-020"
+   ]
+  },
+  "dev-nexus": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependencies.yml": [
+    "CI-010"
+   ],
+   "mutation-testing.yml": [
+    "CI-010"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-021",
+    "CI-030"
+   ],
+   "secret-scan.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "devtool": {
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "quality-checks.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "discord-bot-back": {
+   "ci.yml": [
+    "CI-021"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-010"
+   ],
+   "pages.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "discordium": {
+   "ci.yml": [
+    "CI-021"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "diy-stream-deck": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "pages.yml": [
+    "CI-010"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "django-app-forge": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "django-autoload": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "django-migration-analyzer": {
+   "ci.yml": [
+    "CI-010"
+   ]
+  },
+  "django-pytest": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "django-query-optimizer": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "django-query-optimizer-vscode": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "django-traceid": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "doc-gen": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "doc-gen-docs.yml": [
+    "CI-010"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-020"
+   ],
+   "pages.yml": [
+    "CI-020"
+   ],
+   "publish.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-020"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "dotfiles": {},
+  "epub-sorter": {
+   "build-release.yaml": [
+    "CI-010",
+    "CI-020"
+   ],
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-020"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "fastapi-autoload": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "fastapi-pytest": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "fastapi-query-optimizer": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "fastapi-traceid": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "feedback-gateway": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "floating-agent": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-020"
+   ],
+   "package.yml": [
+    "CI-010"
+   ],
+   "pages.yml": [
+    "CI-020"
+   ],
+   "pre-commit.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-020"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "floating-knowledge-architect-offline": {
+   "ci.yml": [
+    "CI-010",
+    "CI-020"
+   ]
+  },
+  "gaming-os": {
+   "ci.yml": [
+    "CI-021"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "genealogy-validator": {
+   "action-check.yml": [
+    "CI-030"
+   ],
+   "auto-assign.yml": [
+    "CI-030"
+   ],
+   "auto-update-pre-commit.yml": [
+    "CI-030"
+   ],
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "detect-conflicts.yml": [
+    "CI-030"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-010"
+   ],
+   "pr-dependencies.yml": [
+    "CI-030"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010",
+    "CI-030"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ],
+   "sync-labels.yml": [
+    "CI-030"
+   ],
+   "update-pr-body.yml": [
+    "CI-030"
+   ]
+  },
+  "gestureOS": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "github-actions": {
+   "ci-fullstack.yml": [
+    "CI-010",
+    "CI-021"
+   ],
+   "ci-python-app.yml": [
+    "CI-010",
+    "CI-021"
+   ],
+   "ci-python.yml": [
+    "CI-010",
+    "CI-021"
+   ],
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependencies.yml": [
+    "CI-010"
+   ],
+   "deploy.yml": [
+    "CI-010"
+   ],
+   "lint-python.yml": [
+    "CI-010"
+   ],
+   "mutation-testing.yml": [
+    "CI-010"
+   ],
+   "pages.yml": [
+    "CI-010"
+   ],
+   "pre-commit.yml": [
+    "CI-010"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "secret-scan.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "guideline-checker": {
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-020"
+   ],
+   "pre-commit.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-021"
+   ]
+  },
+  "herdr-rtk-savings": {},
+  "homeassistant-config": {},
+  "lifeos": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-010"
+   ],
+   "pages.yml": [
+    "CI-010"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "link-reader-bot": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-020"
+   ],
+   "publish.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-020"
+   ],
+   "sonar.yml": [
     "CI-010"
    ]
   },
@@ -208,13 +893,341 @@
     "CI-020"
    ]
   },
+  "mediavault": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-020"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "mirrador": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "e2e.yml": [
+    "CI-010"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-010"
+   ],
+   "pages.yml": [
+    "CI-010"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "my-resume": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "orchestrator": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "PO-GO-DEX": {
+   "ci.yml": [
+    "CI-021"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
   "pre-commit-hooks-changelog": {
    "ci.yml": [
     "CI-010"
    ],
    "pythonpackage.yml": [
+    "CI-010"
+   ]
+  },
+  "pre-commit-tools": {
+   "action-check.yml": [
+    "CI-020"
+   ],
+   "approved-label.yml": [
+    "CI-020"
+   ],
+   "auto-assign.yml": [
+    "CI-020"
+   ],
+   "auto-update-pre-commit.yml": [
+    "CI-020"
+   ],
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "detect-conflicts.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "labeler.yml": [
+    "CI-020"
+   ],
+   "mutation-testing.yml": [
+    "CI-020"
+   ],
+   "pr-dependencies.yml": [
+    "CI-020"
+   ],
+   "pre-commit.yml": [
+    "CI-010",
+    "CI-020"
+   ],
+   "publish.yml": [
+    "CI-010"
+   ],
+   "pull-request-size.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-021"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ],
+   "sync-labels.yml": [
+    "CI-020"
+   ],
+   "update-pr-body.yml": [
+    "CI-020"
+   ]
+  },
+  "project-init": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-020"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "projects-claude-config": {},
+  "quality-gatekeeper": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "dependencies.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "satisfactory-factory-manager": {
+   "ci.yml": [
+    "CI-021"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "server": {
+   "_reusable-ci.yml": [
+    "CI-020",
+    "CI-030"
+   ],
+   "bootstrap.yml": [
     "CI-010",
     "CI-030"
+   ],
+   "branch-auto-update.yml": [
+    "CI-010"
+   ],
+   "build.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "deploy.yml": [
+    "CI-010",
+    "CI-020",
+    "CI-030"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "enforce-issue-link.yml": [
+    "CI-010"
+   ],
+   "lint.yml": [
+    "CI-010",
+    "CI-030"
+   ],
+   "notion-services-sync.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "terraform-deploy.yml": [
+    "CI-010"
+   ],
+   "terraform.yml": [
+    "CI-010"
+   ],
+   "wiki.yml": [
+    "CI-010"
+   ]
+  },
+  "shared-standards": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependencies.yml": [
+    "CI-010"
+   ],
+   "distribute-standards.yml": [
+    "CI-010"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "labeler.yml": [
+    "CI-010"
+   ],
+   "pr-dependencies.yml": [
+    "CI-010"
+   ],
+   "quality-gate-check.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
+  },
+  "sport-intelligence-hub": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "studioverse": {
+   "ci.yml": [
+    "CI-021"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
    ]
   },
   "usefull-containers": {
@@ -222,8 +1235,7 @@
     "CI-010"
    ],
    "ci.yml": [
-    "CI-010",
-    "CI-030"
+    "CI-010"
    ],
    "dependabot-auto-merge.yml": [
     "CI-020"
@@ -243,12 +1255,52 @@
    "sonar.yml": [
     "CI-010"
    ]
+  },
+  "windows-docker-state-notification": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ],
+   "enforce-feature-branch.yml": [
+    "CI-020"
+   ],
+   "release.yml": [
+    "CI-010"
+   ],
+   "sonar.yml": [
+    "CI-010"
+   ]
+  },
+  "windows-guardian": {
+   "ci.yml": [
+    "CI-010",
+    "CI-020"
+   ]
+  },
+  "workstation-os": {
+   "ci.yml": [
+    "CI-011"
+   ],
+   "dependabot-auto-merge.yml": [
+    "CI-020"
+   ]
+  },
+  "wsmqtt-monitor": {
+   "ci.yml": [
+    "CI-010"
+   ],
+   "release.yml": [
+    "CI-010"
+   ]
   }
  },
  "totals": {
-  "CI-020": 25,
-  "CI-030": 23,
-  "CI-010": 41,
-  "CI-011": 1
+  "CI-010": 208,
+  "CI-020": 155,
+  "CI-030": 30,
+  "CI-011": 4,
+  "CI-021": 12
  }
 }

--- a/scripts/ci_annexe_audit.py
+++ b/scripts/ci_annexe_audit.py
@@ -45,7 +45,10 @@ DEPLOY_HINTS = ("deploy", "release", "publish", "promote", "cd")
 DEFAULT_TIMEOUT = 30
 
 RE_USES = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.M)
-RE_JOB = re.compile(r"^(?P<indent>\s{2,})(?P<name>[A-Za-z0-9_-]+):\s*$", re.M)
+# `\s` also matches the preceding newline, which inflated the measured indent of the first
+# job by one and made the min-indent selection pick a nested key instead. Indentation is
+# spaces.
+RE_JOB = re.compile(r"^(?P<indent>[ ]{2,})(?P<name>[A-Za-z0-9_-]+):[ \t]*$", re.M)
 RE_UNTRUSTED = re.compile(
     r"\$\{\{\s*github\.event\.(?:pull_request\.(?:title|body|head\.ref|head\.label)"
     r"|issue\.(?:title|body)|comment\.body|review\.body|head_commit\.message"
@@ -83,9 +86,15 @@ def file_indent(text: str) -> str:
 
     A block written at 4 spaces inside a 2-space file is valid YAML but fails `yamllint`
     (`wrong indentation: expected 2 but found 4`), which turns a conformance fix into a red
-    lint job. Derive the step from the first nested key rather than assuming one.
+    lint job.
+
+    The step is measured under `jobs:`, never from the first indented line of the file: on a
+    key-sorted workflow the concurrency block *this script wrote* can sit at the top, so the
+    naive reading measures our own output and happily keeps a wrong indentation forever.
     """
-    for line in text.splitlines():
+    jobs = re.search(r"^jobs:\s*$", text, re.M)
+    body = text[jobs.end():] if jobs else text
+    for line in body.splitlines():
         match = re.match(r"^( +)\S", line)
         if match:
             return match.group(1)
@@ -123,10 +132,18 @@ def is_deploy(name: str, text: str) -> bool:
 
 def job_blocks(text: str) -> list[tuple[str, str]]:
     """(job name, block) for each entry under a top-level `jobs:` mapping."""
-    start = re.search(r"^jobs:\s*$", text, re.M)
+    # `\s*$` in multiline mode swallows the newline *and* the next line's indentation, so
+    # the first job key lost its indent and never matched RE_JOB — the parser then locked
+    # onto whatever came next (often a trigger under `on:` on a key-sorted file).
+    start = re.search(r"^jobs:[ \t]*$", text, re.M)
     if not start:
         return []
     body = text[start.end():]
+    # Stop at the next top-level key: on a key-sorted workflow `jobs:` can come first, and
+    # everything after it — `on:`, `permissions:` — would otherwise be read as more jobs.
+    next_top = re.search(r"^\S", body, re.M)
+    if next_top:
+        body = body[: next_top.start()]
     matches = list(RE_JOB.finditer(body))
     top = min((m.group("indent") for m in matches), key=len, default=None)
     if top is None:


### PR DESCRIPTION
Three parsing defects in the sweep, all silent — files were reported as fixed while left untouched. Found by reading a workflow the audit still flagged after the sweep had "passed" on it.

1. `RE_JOB` used `\s{2,}` for the indent. `\s` also matches the **preceding newline**, so the first job measured one character deeper than its siblings and lost the min-indent selection to a nested key (`steps:`, `with:`) or to a trigger.
2. `^jobs:\s*$` swallowed the next line's indentation, so the first job key never matched at all.
3. The jobs section ran to end-of-file. On a **key-sorted workflow** (yaml-sorter puts `jobs:` first) the `on:` and `permissions:` blocks were parsed as more jobs — `pull_request` was being treated as a job name.

Consequence on `audit-platform/auto-assign.yml`: `add-reviews` never received its timeout, and `file_indent` — which read the *first* indented line of the file — was measuring the concurrency block this script had itself written at the top, so the wrong indentation was preserved on every re-run. `file_indent` now measures under `jobs:` as well.

Verified on that file: job detected, timeout applied, YAML parses, idempotent, and the only remaining finding is `CI-020` (permissions — a judgement call, not swept).

Refs #278