### PR TITLE
feat(standards): version the container apart from the app, and show what is deployed

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -547,6 +547,35 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   to `/setup`** rather than crashing or showing a generic error. An admin **configuration panel**
   (auth-gated CRUD API) manages runtime config with a versioned audit trail, hot-reload where
   possible (else a `RESTART_REQUIRED` flag), and JSON export/import for backup and cross-env cloning.
+- **The container is versioned separately from the application it hosts, and an admin can see
+  what is actually deployed.** An image and an app are two artefacts with two lifecycles: a
+  rebuild that only picks up a new base image, a patched OS library or a changed entrypoint
+  produces a **new image version carrying the same application version** — and a redeploy of
+  the same app on a fresh image is exactly the change an incident review needs to see. So the
+  two versions are recorded and surfaced side by side; conflating them turns "we redeployed"
+  into an untraceable event.
+  1. **Both identities travel with the image.** Every image carries OCI labels — at minimum
+     `org.opencontainers.image.version` (the image's own version),
+     `org.opencontainers.image.revision` (git SHA), `org.opencontainers.image.created`, plus
+     the application version it packages. They are build arguments injected by CI, never
+     hand-edited.
+  2. **Deployments pin a digest, never a moving tag.** `:latest` is not a version; a
+     manifest or compose file references `image@sha256:…` (or an immutable tag) so what runs
+     is exactly what was tested — see *build once, promote the artefact* (`CI-046`).
+  3. **The service publishes what it is** — a small, unauthenticated-safe endpoint
+     (`/version` or the health payload) returning the **application version**, the **image
+     tag and digest**, the git SHA, the build timestamp and the environment name. No secret,
+     no dependency inventory: enough to answer "which build is this?" and nothing more.
+  4. **The frontend shows it to admins, and knows its own.** The admin surface (config panel,
+     about screen, footer of an admin page) displays the **frontend build version** — embedded
+     at build time, not read at runtime — next to the backend's application version, image
+     digest and environment. A support conversation that starts with "which version are you
+     on?" and cannot be answered from the interface is a defect.
+  5. **A version mismatch is surfaced, not silently tolerated.** When the frontend detects
+     that the backend's version changed under it, or that its own build no longer matches the
+     API it is talking to, it tells the user and offers a reload rather than failing in
+     obscure ways. Deployed versions per environment are also visible from the platform side
+     (release notes, deployment log), so "what is in production" never requires a shell.
 - **If a user can supply a file, the product accepts an upload.** Wherever the workflow
   involves a file the user already has — an import (CSV, JSON, GPX, ICS…), an avatar or image,
   an attachment or supporting document, a configuration or dataset, a log or a crash dump sent

--- a/standards/annexes/CONTAINERS-K3S.md
+++ b/standards/annexes/CONTAINERS-K3S.md
@@ -134,6 +134,53 @@ also silently bypasses `NetworkPolicy` (CT-023).
 Development compose files follow the same rule; a port opened "just to look at it" is opened
 on the loopback, in an override file, never in the committed base stack.
 
+### CT-016 — The image version and the application version are two different things
+
+An image and the application it packages have separate lifecycles: rebuilding on a patched
+base image, a new OS library or a changed entrypoint yields a **new image version carrying
+the same application version**. Both are recorded, and neither is inferred from the other.
+
+Every image carries OCI labels, injected as build arguments by CI and never hand-edited:
+
+```dockerfile
+ARG APP_VERSION
+ARG IMAGE_VERSION
+ARG GIT_SHA
+ARG BUILD_DATE
+LABEL org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.source="https://github.com/chrysa/<repo>" \
+      chrysa.application.version="${APP_VERSION}"
+```
+
+Deployments reference an **immutable digest** (`image@sha256:…`), never `:latest` — a moving
+tag makes "what is running" unanswerable and breaks *build once, promote the artefact*
+(`CI-046`). A rollback is then a digest change, not a rebuild.
+
+### CT-017 — A running workload states which build it is
+
+Every service exposes its identity on a lightweight endpoint (`/version`, or the health
+payload): application version, image tag **and digest**, git SHA, build timestamp,
+environment name. It carries no secret and no dependency inventory — enough to answer
+"which build is this?", nothing more, so it stays safe behind the same exposure rules as the
+rest of the API.
+
+The value is read from the environment injected at deploy time (`APP_VERSION`, `IMAGE_DIGEST`,
+`GIT_SHA`), never hardcoded and never derived from a file inside the image that a rebuild
+would not update.
+
+### CT-018 — Deployed versions are visible to an operator without a shell
+
+The admin surface of the product shows the **frontend build version** — embedded at build
+time — alongside the backend's application version, image digest and environment. `kubectl`
+or `docker inspect` is a fallback for a debugging session, not the primary way to answer
+"what is deployed right now".
+
+When the frontend detects that the backend version changed under it, or that its build no
+longer matches the API it talks to, it says so and offers a reload instead of failing in
+obscure ways.
+
 ______________________________________________________________________
 
 ## 3. Expected k3s topology
@@ -192,7 +239,8 @@ private certificates or public TLS config in images · no hardcoded infrastructu
 IPs, or ports · probes, resource limits, and security policies present · **published ports
 counted per compose file (CT-015): a `ports:` on a database, cache, broker, or metrics
 endpoint fails the check, and a `0.0.0.0` publish outside the public entry point is
-flagged**.
+flagged** · **OCI version labels present and non-empty, and deployment manifests referencing
+a digest rather than a moving tag (CT-016)**.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
An image and the application it packages have **two lifecycles**. A rebuild that only picks up a patched base image, a new OS library or a changed entrypoint produces a *new image version carrying the same application version* — and a redeploy of the same app on a fresh image is exactly the change an incident review needs to see. Conflating them turns "we redeployed" into an untraceable event.

**Socle rule** (`Setup wizard & config panel` neighbourhood — the admin surface section):

1. **Both identities travel with the image** — OCI labels (`org.opencontainers.image.version`, `.revision`, `.created`) plus the packaged application version, injected as build args by CI, never hand-edited.
2. **Deployments pin a digest, never a moving tag** — `image@sha256:…`, so what runs is what was tested (`CI-046`, *build once, promote the artefact*). A rollback becomes a digest change, not a rebuild.
3. **The service publishes what it is** — `/version` (or the health payload): application version, image tag **and digest**, git SHA, build timestamp, environment. No secret, no dependency inventory.
4. **The frontend shows it to admins, and knows its own** — the admin surface displays the **frontend build version**, embedded at build time, next to the backend version, image digest and environment. A support conversation that starts with *"which version are you on?"* and cannot be answered from the interface is a defect.
5. **A version mismatch is surfaced** — when the backend changes under the frontend, it says so and offers a reload instead of failing obscurely.

**Annexe `CONTAINERS-K3S.md`**: `CT-016` (two versions, OCI labels, digest pinning, with a Dockerfile example), `CT-017` (a running workload states which build it is, values read from deploy-time env — never from a file a rebuild would not update), `CT-018` (deployed versions visible without a shell; `kubectl`/`docker inspect` is a debugging fallback, not the primary answer).

`CT-024` (deployment CI checks) now also covers: OCI version labels present and non-empty, and manifests referencing a digest rather than a moving tag.

Refs #278
