### PR TITLE
fix(pre-commit): anchor the test excludes on any path depth

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,21 +42,21 @@ repos:
   # TODO: add detect-duplicated-copilot-instructions after chrysa/pre-commit-tools#163 is merged and released
   # --- python (all Python repos) ---
   - id: debugger-detection
-    exclude: '^(tests?/|README\.md|docs/)'
+    exclude: '(^|/)tests?/|^(README\.md|docs/)'
   - id: python-print-detection
-    exclude: '^(tests?/|README\.md|docs/)'
+    exclude: '(^|/)tests?/|^(README\.md|docs/)'
   - id: python-pprint-detection
-    exclude: '^(tests?/|README\.md|docs/)'
+    exclude: '(^|/)tests?/|^(README\.md|docs/)'
   - id: no-bare-except
   - id: python-logger-detection
-    exclude: '^(tests?/|README\.md|docs/)'
+    exclude: '(^|/)tests?/|^(README\.md|docs/)'
   - id: python-unreachable-code
   - id: python-no-unittest-import
   # Mechanise the code-quality rules of the standards block: typed raises,
   # lookup table over dispatch ladder, and the mutable-default anti-pattern.
   # Fixtures deliberately raise builtins as detector input, hence the exclude.
   - id: python-untyped-raise
-    exclude: '^tests?/'
+    exclude: '(^|/)tests?/'
   - id: python-mutable-default
   - id: python-dispatch-ladder
   # The agent loads .claude/ at session start; an empty mirror loads no skill


### PR DESCRIPTION
## Problem
`^tests?/` matches only a root-level `tests/`. Repos whose suite lives one level down — `backend/tests/` in `chrysa-portfolio-viz`, `devtool`, … — have their test files linted as product code by `debugger-detection`, `python-print-detection`, `python-pprint-detection`, `python-logger-detection` and `python-untyped-raise`.

Measured consequence: 7 of the 16 `python-untyped-raise` findings in `chrysa-portfolio-viz` sit in `backend/tests/`, where fakes deliberately `raise RuntimeError('cache down')` to simulate a dead cache. Typing those would be wrong — the exclude was written to cover them and silently does not.

## Change
`(^|/)tests?/` on the five python hooks. `README.md` and `docs/` stay root-anchored — they are root artefacts by nature.

## Verification
Regexes checked against representative paths (pre-commit applies them with `re.search` on repo-relative paths):

| Path | Excluded |
|---|---|
| `tests/test_x.py` | yes |
| `backend/tests/test_x.py` | yes (was **no**) |
| `backend/app/oidc.py` | no |
| `src/contests/mod.py` | no — no loose substring match |
| `app/latest/x.py` | no |

Fixes #345