### PR TITLE
fix(pre-commit): un-anchor the tests/ excludes so nested test trees match

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,21 +42,21 @@ repos:
   # TODO: add detect-duplicated-copilot-instructions after chrysa/pre-commit-tools#163 is merged and released
   # --- python (all Python repos) ---
   - id: debugger-detection
-    exclude: '^(tests?/|README\.md|docs/)'
+    exclude: '(^|/)tests?/|^(README\.md|docs/)'
   - id: python-print-detection
-    exclude: '^(tests?/|README\.md|docs/)'
+    exclude: '(^|/)tests?/|^(README\.md|docs/)'
   - id: python-pprint-detection
-    exclude: '^(tests?/|README\.md|docs/)'
+    exclude: '(^|/)tests?/|^(README\.md|docs/)'
   - id: no-bare-except
   - id: python-logger-detection
-    exclude: '^(tests?/|README\.md|docs/)'
+    exclude: '(^|/)tests?/|^(README\.md|docs/)'
   - id: python-unreachable-code
   - id: python-no-unittest-import
   # Mechanise the code-quality rules of the standards block: typed raises,
   # lookup table over dispatch ladder, and the mutable-default anti-pattern.
   # Fixtures deliberately raise builtins as detector input, hence the exclude.
   - id: python-untyped-raise
-    exclude: '^tests?/'
+    exclude: '(^|/)tests?/'
   - id: python-mutable-default
   - id: python-dispatch-ladder
   # The agent loads .claude/ at session start; an empty mirror loads no skill
@@ -68,9 +68,9 @@ repos:
     stages: [pre-push]
   # --- fastapi (FastAPI repos only — remove if not applicable) ---
   - id: fastapi-missing-response-model
-    exclude: '^tests/'
+    exclude: '(^|/)tests/'
   - id: fastapi-missing-links
-    exclude: '^tests/'
+    exclude: '(^|/)tests/'
   - id: no-sync-in-async
   # --- docker (repos with Dockerfiles — remove if not applicable) ---
   - id: dockerfile-no-latest


### PR DESCRIPTION
## Problem
Every `tests/` exclude in the canonical baseline is root-anchored, so `^tests?/` matches `tests/foo.py` but never `backend/tests/foo.py` — the layout most repos on the fleet actually use. Hooks written to spare test code fire on it.

Concrete: 7 of the 16 `python-untyped-raise` findings in `chrysa-portfolio-viz` are test fakes (`raise RuntimeError('cache down')` inside a stub simulating a broken cache) under `backend/tests/` — exactly the case the exclude exists for.

## Change
`^tests?/` → `(^|/)tests?/` on the 7 affected hooks (debugger / print / pprint / logger detection, `python-untyped-raise`, `fastapi-missing-response-model`, `fastapi-missing-links`). `README.md` and `docs/` stay root-anchored where they share the pattern.

Distribution is additive (`pre-commit-merge.py` preserves existing repo entries), so consumers pick the new pattern up on their next standards sync; nothing is removed from a repo.

Fixes #350