### PR TITLE
fix(scripts): a commented example is not a secrets: inherit violation

### DIFF
--- a/scripts/ci_annexe_audit.py
+++ b/scripts/ci_annexe_audit.py
@@ -187,7 +187,10 @@ def inspect(text: str, name: str) -> list[str]:
             found.append("CI-010")
     if not re.search(r"^\s*permissions:", text, re.M):
         found.append("CI-020")
-    if re.search(r"secrets:\s*inherit", text):
+    # Anchored past the indent so a *commented* example — the usage snippets at the top of
+    # the reusable workflows are written `#       secrets: inherit` — is not counted as a
+    # violation. Three of the twelve CI-021 findings were documentation.
+    if re.search(r"^[ ]*secrets:[ ]*inherit\b", text, re.M):
         found.append("CI-021")
     for block in re.findall(r"run:\s*\|?[\s\S]{0,600}", text):
         if RE_UNTRUSTED.search(block):


### PR DESCRIPTION
The `CI-021` check searched the whole file for `secrets:\s*inherit`, so the usage snippets at the top of the reusable workflows in `chrysa/github-actions` —

```yaml
#   jobs:
#     call:
#       secrets: inherit
```

— were counted as violations. **Three of the twelve** `CI-021` findings were documentation, not code.

That is why the sweep resolved cleanly: it found and fixed **9** real files (`dev-nexus`, `guideline-checker`, `gaming-os`, `discord-bot-back`, `discordium`, `pre-commit-tools`, `PO-GO-DEX`, `satisfactory-factory-manager`, `studioverse`) and skipped none — 9 + 3 documented examples = the 12 reported.

The pattern is now anchored past the indent, so a commented line cannot match. Verified both ways: the doc snippet is no longer flagged, a real `secrets: inherit` still is.

Refs #278
