### PR TITLE
feat(standards): a game is DRM-free and fully playable solo offline (AR-045)

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -547,6 +547,20 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   to `/setup`** rather than crashing or showing a generic error. An admin **configuration panel**
   (auth-gated CRUD API) manages runtime config with a versioned audit trail, hot-reload where
   possible (else a `RESTART_REQUIRED` flag), and JSON export/import for backup and cross-env cloning.
+- **A game is DRM-free and fully playable solo offline.** The single-player experience is
+  complete **without a network, an account, or a licence check** — unplug the machine and the
+  game still starts, saves, loads, and can be finished. **No DRM of any kind**: no licence
+  server, no phone-home activation, no online entitlement check, no always-on requirement, no
+  third-party wrapper gating launch. A copy someone owns keeps working when the servers are
+  gone, the company is gone, or the network is down; a build that will not start offline is a
+  defect, not an anti-piracy measure. Saves are **local, open and portable** (JSON/SQLite in
+  the platform's user directory, copyable, not encrypted against their owner) — the
+  *portable personalisation data* pillar applied to a save file. Online features (multiplayer,
+  leaderboards, cloud sync, telemetry, stores) are **additive layers over a complete offline
+  game**: losing one degrades a feature, never the ability to play. The offline path is
+  **tested with the network disabled**, on a machine that never signed in — an offline mode
+  nobody exercises is one that has already stopped working. Detail: annexe
+  `ARCHITECTURE-DDD.md` AR-045.
 - **Every product that is operated ships a management backoffice.** As soon as a product has
   users, content, or work that someone has to *run* — accounts to unlock, an import that
   failed, a job stuck in a queue, a flag to flip — it ships an authenticated **admin

--- a/standards/annexes/ARCHITECTURE-DDD.md
+++ b/standards/annexes/ARCHITECTURE-DDD.md
@@ -187,3 +187,29 @@ tests/  Product.Domain.Tests/ Product.Application.Tests/ Product.Infrastructure.
 - `ScriptableObject` = data/configuration, not a global mutable logic container.
 - Game loop, rendering, input, and Unity services are adapters around the domain.
 - Critical systems are deterministic and testable outside a scene.
+
+### AR-045 — A game is DRM-free and fully playable solo offline
+
+The single-player experience is **complete without a network, an account, or a licence
+check**. Unplug the machine and the game still starts, saves, loads, and can be finished.
+
+- **No DRM of any kind** — no licence server, no phone-home activation, no online
+  entitlement check, no always-on requirement, no third-party wrapper (Denuvo and
+  equivalents) that gates launch. A copy someone owns keeps working when the servers are
+  gone, the company is gone, or the network is down. A build that will not start offline is
+  a defect, not an anti-piracy measure.
+- **Saves are local, open, and portable** — a readable format (JSON/SQLite) under the
+  platform's standard user directory, copyable to another machine, not tied to an account or
+  encrypted against its owner. This is the strategic pillar *portable personalisation data*
+  applied to a save file.
+- **Online is additive, never load-bearing.** Multiplayer, leaderboards, cloud sync,
+  telemetry and stores are opt-in layers over a complete offline game. Losing any of them
+  degrades a feature; it never blocks the campaign, the progression, or the ability to launch.
+- **No content behind a live service in a single-player game** — assets, levels and unlocks
+  ship in the build. A "day-one download" that gates the game itself, or content streamed
+  from a server that will one day be switched off, breaks the guarantee.
+- **The offline path is tested, not assumed** — a build is validated with the network
+  disabled, on a machine that has never signed in. An offline mode nobody exercises is an
+  offline mode that has already stopped working.
+
+This applies to any repo declaring the `game` profile, whatever the engine.


### PR DESCRIPTION
Adds **AR-045** to the architecture annexe (which already carries the `game` profile and `AR-044 — Unity / games`), plus its socle anchor — annexes are not inlined into consumer repos, so a rule with no socle anchor is invisible to anyone reading a local `CLAUDE.md`.

**The single-player experience is complete without a network, an account, or a licence check.** Unplug the machine and the game still starts, saves, loads, and can be finished.

- **No DRM of any kind** — no licence server, no phone-home activation, no online entitlement check, no always-on requirement, no third-party wrapper (Denuvo and equivalents) gating launch. A copy someone owns keeps working when the servers are gone, the company is gone, or the network is down. A build that will not start offline is a defect, not an anti-piracy measure.
- **Saves are local, open, and portable** — readable format under the platform's standard user directory, copyable, not tied to an account or encrypted against its owner. This is the *portable personalisation data* pillar applied to a save file.
- **Online is additive, never load-bearing** — multiplayer, leaderboards, cloud sync, telemetry and stores sit over a complete offline game. Losing one degrades a feature; it never blocks the campaign or the launch.
- **No single-player content behind a live service** — assets, levels and unlocks ship in the build. Content streamed from a server that will one day be switched off breaks the guarantee.
- **The offline path is tested, not assumed** — validated with the network disabled, on a machine that never signed in. An offline mode nobody exercises is one that has already stopped working.

Applies to any repo declaring the `game` profile, whatever the engine.
