### PR TITLE
fix(stacks): detect a stack below the repo root, not only at it

### DIFF
--- a/scripts/apply-repo-standard.sh
+++ b/scripts/apply-repo-standard.sh
@@ -182,15 +182,29 @@ deploy_stack_ci() {
 }
 
 # Comma list of pre-commit stacks for a repo: python,docker,jsts,react,fastapi
+# Find a marker file at the repo root OR in a first/second-level subdirectory, skipping
+# vendored trees. The fleet's dominant layout puts the app under backend/ or api/, so a
+# root-only probe classified those repos as non-Python and their Python hooks were never
+# governed (shared-standards #365) — the same root-anchoring mistake as `^tests?/`.
+find_marker() {
+    local repo="$1" name="$2"
+    find "$repo" -maxdepth 3 -name "$name" -not -path '*/node_modules/*' -not -path '*/.git/*' \
+        -not -path '*/.venv/*' -not -path '*/vendor/*' -print -quit 2>/dev/null
+}
+
+# Comma list of pre-commit stacks for a repo: python,docker,jsts,react,fastapi
 detect_pc_stacks() {
-    local repo="$1" s=""
-    { [[ -f "$repo/pyproject.toml" ]] || ls "$repo"/requirements*.txt &>/dev/null; } && s+="python,"
-    { [[ -f "$repo/Dockerfile" ]] || ls "$repo"/docker/Dockerfile* &>/dev/null; } && s+="docker,"
-    if [[ -f "$repo/package.json" ]]; then
+    local repo="$1" s="" pkg
+    { [[ -n "$(find_marker "$repo" 'pyproject.toml')" ]] || [[ -n "$(find_marker "$repo" 'requirements*.txt')" ]]; } && s+="python,"
+    [[ -n "$(find_marker "$repo" 'Dockerfile*')" ]] && s+="docker,"
+    pkg="$(find_marker "$repo" 'package.json')"
+    if [[ -n "$pkg" ]]; then
         s+="jsts,"
-        grep -q '"react"' "$repo/package.json" 2>/dev/null && s+="react,"
+        grep -q '"react"' "$pkg" 2>/dev/null && s+="react,"
     fi
-    { grep -riqs 'fastapi' "$repo/pyproject.toml" "$repo"/requirements*.txt 2>/dev/null; } && s+="fastapi,"
+    { grep -riqs --include='pyproject.toml' --include='requirements*.txt' \
+        --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.venv \
+        'fastapi' "$repo" 2>/dev/null; } && s+="fastapi,"
     echo "${s%,}"
 }
 


### PR DESCRIPTION
## The finding
`detect_pc_stacks` probes `pyproject.toml`, `Dockerfile` and `package.json` **at the repo root only**. The fleet's dominant layout puts the app under `backend/` or `api/`, so those repos are classified as having no stack — and every stack-conditional hook is silently skipped for them.

Same root-anchoring mistake as `^tests?/` (#350), one layer up: the probe assumes a layout the fleet does not use.

## Measured, on 61 fresh clones
**38 repos change classification.**

| repo | detected today | actual |
|---|---|---|
| `dev-nexus` | *(nothing)* | python, docker, jsts, fastapi |
| `devtool` | *(nothing)* | python, docker, jsts, fastapi |
| `discordium` | *(nothing)* | python, docker, jsts, react, fastapi |
| `container-webview` | docker | python, docker, jsts, react, fastapi |
| `chrysa-portfolio-viz` | python | python, docker, jsts, react, fastapi |

Three repos resolved to an **empty** stack list — no governed hook at all beyond the `always` group.

This also explains a leftover from #359: 8 repos still carry the stale `^tests?/` exclude after exclude alignment shipped. Not being python-classified, their python hooks sit outside the merge's `wanted` set, so nothing realigns them. Their `pyproject.toml` lives in `backend/`.

## Change
`find_marker` searches root + two levels, skipping `node_modules`, `.git`, `.venv`, `vendor`. The fastapi probe greps that same scoped tree instead of two fixed paths.

## Verification
- Before/after run over all 61 clones: the 38 deltas above; no repo loses a stack.
- Checked the two repos that could look like false positives — `gestureOS` and `usefull-containers` both carry a real root `pyproject.toml` and actual `.py` files, so they were already python-classified before this change.
- `bash -n` clean.

## Blast radius — stated, not buried
The next distribution will add the stack hooks these repos should always have had: **10 to 16 items each** on the four sampled. That is the intent of the fix, and it is not a no-op — expect substantial sync PRs on the misclassified repos.

Closes #365
