### PR TITLE
docs(pre-commit-merge): date the measured figure and record its outcome

### DIFF
--- a/scripts/pre-commit-merge.py
+++ b/scripts/pre-commit-merge.py
@@ -134,8 +134,10 @@ HOOK_GROUPS = {
         "no-bare-except", "python-logger-detection", "python-unreachable-code",
         "no-hardcoded-localhost", "regression-gate",
         # Detectors for the code-quality rules of the standards block. Measured dry
-        # across the 63 status:dev repos before arming: 47 untyped raises (13 of them
-        # in tests, hence the baseline exclude), 5 dispatch ladders, 0 mutable defaults.
+        # on 2026-08-03 across the status:dev fleet (63 repos then, 61 today after the
+        # archived-flag reconciliation in #305): 47 untyped raises (13 of them in tests,
+        # hence the baseline exclude), 5 dispatch ladders, 0 mutable defaults. Remediated
+        # to 0 in product code on 2026-08-05, re-verified on fresh clones.
         "python-untyped-raise", "python-mutable-default", "python-dispatch-ladder",
     },
     "docker": {"dockerfile-no-latest"},


### PR DESCRIPTION
The comment justifying the three code-quality detectors cited **63 status:dev repos** with no date. The fleet is **61** since #305 reconciled `repos.yml` with GitHub's archived flag — so the figure reads as wrong to anyone checking today, while it was accurate when written.

An undated measurement is a claim nobody can situate: the next reader either trusts a stale number or re-measures to find out, which is exactly the cost the comment existed to spare.

Now states both counts and why they differ, plus what the measurement led to — remediated to 0 findings in product code on 2026-08-05, re-verified on fresh clones.

Closes #370