### PR TITLE
chore(repos): flag my-resume and orchestrator as archived

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -200,11 +200,11 @@ repos:
     alias_of: lifeos
     runtime: exempt:native
   - name: my-resume
-    status: dev
+    status: archived
     public: false
     runtime: container
   - name: orchestrator
-    status: dev
+    status: archived
     public: false
     runtime: exempt:config
   - name: paperclip


### PR DESCRIPTION
Both repos are archived on GitHub but still carried `status: dev` in `repos.yml`, so run 31039740042 spawned a job for each that could only warn and skip.

Live dev fleet: **59**, not 61. Same drift #305 already reconciled once — nothing re-reads GitHub's archived bit, so it goes stale in silence.