### PR TITLE
feat(standards): CT-019 — a compose file declares intent, not Compose defaults

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -529,6 +529,20 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   `Service` is `ClusterIP` except the ingress-fronted entry point; `NodePort`, `LoadBalancer`,
   `hostPort` and `hostNetwork` need an ADR (a `hostPort` also bypasses `NetworkPolicy`).
   Detail: annexe `CONTAINERS-K3S.md` CT-015.
+- **A compose file is minimal — declare only what the stack needs, default the rest.** A
+  `docker-compose*.yml` is a description of *this* stack, not a copy of Compose's defaults. It
+  declares the services, their `build.target`/`image`, `depends_on`, `environment`, volumes,
+  `healthcheck` and `restart` — and **nothing Compose already does for you**. Forbidden as
+  noise: an explicit `networks:` block re-declaring the default bridge and wiring every service
+  to it (Compose already puts all services on a shared default network with service-name DNS —
+  see the ports rule), a redundant `container_name`, a `version:` top-level key (obsolete in
+  Compose v2), commented-out dead services, copy-pasted blocks that a YAML anchor or an
+  `extends`/override file would fold, and env values inlined where an `.env` / `env_file`
+  belongs. Environment- or developer-specific settings (a loopback port bind, a source bind
+  mount for hot-reload, debug flags) live in `docker-compose.override.yml` or a `*.dev.yml`,
+  never in the committed base stack. The test is mechanical: every line in the base compose
+  file is one a reader could not have inferred from Compose's defaults — a line that only
+  restates a default is deleted. Detail: annexe `CONTAINERS-K3S.md` CT-019.
 - **Dev stage must hot-reload.** The `dev` target/service provides live auto-reload so a source edit
   is reflected without a manual rebuild/restart: backend `uvicorn --reload` (or the framework's
   autoreload), frontend the dev server with HMR (`vite`/`npm run dev`), watched via the compose

--- a/standards/annexes/CONTAINERS-K3S.md
+++ b/standards/annexes/CONTAINERS-K3S.md
@@ -181,6 +181,60 @@ When the frontend detects that the backend version changed under it, or that its
 longer matches the API it talks to, it says so and offers a reload instead of failing in
 obscure ways.
 
+### CT-019 — The compose file is minimal — it declares intent, not defaults
+
+A `docker-compose*.yml` describes **this** stack: its services, their build target or image,
+`depends_on`, `environment`/`env_file`, volumes, `healthcheck`, and `restart`. It declares
+nothing Compose already provides. A line that only restates a Compose default is noise, and
+noise hides the one line that matters.
+
+**Removed as noise:**
+
+- **`version:`** — obsolete under Compose v2; its presence only emits a warning.
+- **An explicit default network.** Compose puts every service on a shared default network
+  with service-name DNS. A `networks:` block that re-declares that bridge and attaches each
+  service to it re-states a default (and misleads about CT-015). Declare a network **only**
+  when the topology is non-default — a second isolated segment, an external network, a driver
+  option.
+- **`container_name:`** unless a fixed name is genuinely required — it defeats scaling and
+  collides between stacks.
+- **Commented-out services / dead blocks** — git history is the archive.
+- **Copy-pasted service blocks** — factor shared config with a YAML anchor (`&x`/`*x`) or an
+  `extends`, per *no code duplication*.
+- **Inlined env values** where an `.env` / `env_file` belongs.
+
+**Kept out of the base file, pushed to an override:** loopback port binds, source bind mounts
+for hot-reload, debug flags — anything environment- or developer-specific lives in
+`docker-compose.override.yml` or a `*.dev.yml` (CT-015, and *Dev stage must hot-reload*).
+
+```yaml
+# minimal — every line is intent Compose could not infer
+services:
+    api:
+        build:
+            target: production
+        env_file: .env
+        depends_on: [database]
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+        restart: unless-stopped
+        ports:
+            - "8000:8000"      # the one public surface (CT-015)
+    database:
+        image: postgres:16
+        env_file: .env
+        volumes:
+            - pgdata:/var/lib/postgresql/data
+        restart: unless-stopped
+
+volumes:
+    pgdata:
+# no version:, no networks: (default bridge is enough), no container_name:
+```
+
+The test is mechanical: delete any line and ask whether Compose's default already does it —
+if yes, the line was noise. Counted by CT-024.
+
 ______________________________________________________________________
 
 ## 3. Expected k3s topology
@@ -240,7 +294,9 @@ IPs, or ports · probes, resource limits, and security policies present · **pub
 counted per compose file (CT-015): a `ports:` on a database, cache, broker, or metrics
 endpoint fails the check, and a `0.0.0.0` publish outside the public entry point is
 flagged** · **OCI version labels present and non-empty, and deployment manifests referencing
-a digest rather than a moving tag (CT-016)**.
+a digest rather than a moving tag (CT-016)** · **compose files carry no obsolete `version:`
+key, no default-network re-declaration, and no commented-out or duplicated service blocks
+(CT-019)**.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
Adds the rule to the socle (*Non-negotiable conventions*) and its detail as annexe CT-019 in `CONTAINERS-K3S.md`.

Mechanical test: every line in the base compose file is one a reader could not have inferred from Compose's defaults — a line that only restates a default is deleted.