### PR TITLE
feat(standards): perf/cost budgets (CI-053) + AI quality/eval (AG-012–015)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -672,6 +672,20 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   `Service` is `ClusterIP` except the ingress-fronted entry point; `NodePort`, `LoadBalancer`,
   `hostPort` and `hostNetwork` need an ADR (a `hostPort` also bypasses `NetworkPolicy`).
   Detail: annexe `CONTAINERS-K3S.md` CT-015.
+- **A compose file is minimal — declare only what the stack needs, default the rest.** A
+  `docker-compose*.yml` is a description of *this* stack, not a copy of Compose's defaults. It
+  declares the services, their `build.target`/`image`, `depends_on`, `environment`, volumes,
+  `healthcheck` and `restart` — and **nothing Compose already does for you**. Forbidden as
+  noise: an explicit `networks:` block re-declaring the default bridge and wiring every service
+  to it (Compose already puts all services on a shared default network with service-name DNS —
+  see the ports rule), a redundant `container_name`, a `version:` top-level key (obsolete in
+  Compose v2), commented-out dead services, copy-pasted blocks that a YAML anchor or an
+  `extends`/override file would fold, and env values inlined where an `.env` / `env_file`
+  belongs. Environment- or developer-specific settings (a loopback port bind, a source bind
+  mount for hot-reload, debug flags) live in `docker-compose.override.yml` or a `*.dev.yml`,
+  never in the committed base stack. The test is mechanical: every line in the base compose
+  file is one a reader could not have inferred from Compose's defaults — a line that only
+  restates a default is deleted. Detail: annexe `CONTAINERS-K3S.md` CT-019.
 - **Dev stage must hot-reload.** The `dev` target/service provides live auto-reload so a source edit
   is reflected without a manual rebuild/restart: backend `uvicorn --reload` (or the framework's
   autoreload), frontend the dev server with HMR (`vite`/`npm run dev`), watched via the compose

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -169,6 +169,15 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   and a documented idempotency/timeout/limits/circuit-breaker/rollback envelope. Untrusted
   execution is sandboxed with network off by default; no agent auto-merges to `main`.
   Detail: annexe `AGENTIC-CAPABILITIES.md`.
+- **An AI feature is evaluated, not just shipped.** An agent *acting* is governed above; an
+  AI feature's *output quality* is a separate obligation. Prompts, models, parameters and
+  tools are **versioned**; every critical AI task carries an **evaluation dataset** and
+  non-regression tests measuring quality, hallucinations, refusals, latency and cost; each
+  answer records the model, its version, the prompt and the sources it used, so it can be
+  reproduced and audited; and the product degrades to a **fallback model or a no-AI mode**,
+  with human validation proportionate to the risk and an explicit policy for what data is
+  sent to a model. A feature whose quality is asserted by feel rather than measured is a
+  defect. Detail: annexe `AGENTIC-CAPABILITIES.md` AG-012–AG-015.
 - **An agent writes only where the owner owns.** An AI agent may open issues, pull requests,
   comments, branches and releases **only on repositories the owner owns** — the `chrysa`
   account and the organisations under the owner's control. On any third-party repository
@@ -820,6 +829,12 @@ deprecated and archived — nothing is added to it, nothing reads from it.
 - Test coverage **>= 85%** by default. A repo may override upward, never below 80%.
 - Lint warnings: **0**. Mypy clean. SonarCloud rating **A**, 0 security hotspot.
 - Max function lines 50 · max file lines 500 · cyclomatic complexity heuristic <= 10.
+- **Performance and cost budgets are declared per profile and enforced.** Frontend bundle,
+  Docker image size, startup time, memory, CPU, latency, throughput, storage and log volume
+  each carry a budget; AI paths additionally budget tokens, cost, latency, concurrency and
+  cache. CI measures them and **blocks significant regressions** (info → warning → error); an
+  overrun carries a justification, an impact measurement and a reduction plan — never a silent
+  pass. Detail: annexe `CI-CD.md` CI-053.
 
 ## Design system
 

--- a/standards/annexes/AGENTIC-CAPABILITIES.md
+++ b/standards/annexes/AGENTIC-CAPABILITIES.md
@@ -63,6 +63,28 @@ Strong confirmation and an immutable audit trail are mandatory for such actions.
 A capability is first built inside its first consuming project. Extraction into a shared
 brick happens only at the **second real consumer** — not in anticipation.
 
+### AG-012 — AI functions are versioned
+
+Prompts, models, parameters, and the tool set an AI feature uses are versioned like code. A
+change to any of them is a traceable change, not an invisible drift.
+
+### AG-013 — Critical AI tasks have an evaluation set
+
+Every critical AI task ships an **evaluation dataset** and non-regression tests run in CI.
+Quality, hallucinations, refusals, latency, and cost are **measured**, not asserted by feel.
+
+### AG-014 — Every AI answer is traceable
+
+An AI output records the model, its version, the prompt, and the sources it used, so any
+answer can be reproduced and audited after the fact.
+
+### AG-015 — An AI feature degrades to a fallback
+
+The product provides a fallback model or a no-AI mode wherever it can, and **human validation
+is proportionate to the risk** of the action. The policy for what data is sent to a model is
+explicit (pillar 1 · `PROJECT-DECOUPLING.md`) — no per-person or sensitive data reaches an
+external model without a documented authorisation.
+
 ______________________________________________________________________
 
 ## 2. CI gates (progressive rollout)
@@ -74,4 +96,5 @@ Add as `info`, promote to `warning`, then `error` once existing debt is cleared:
 - shell calls not wrapped by an adapter;
 - capability manifest validation;
 - dry-run, idempotency, timeout, and rollback tests;
-- R3–R5 actions requiring the expected confirmation.
+- R3–R5 actions requiring the expected confirmation;
+- evaluation-set non-regression on critical AI tasks (AG-013).

--- a/standards/annexes/CI-CD.md
+++ b/standards/annexes/CI-CD.md
@@ -298,6 +298,15 @@ actually feel.
 Retention matches the debugging window, not the platform default. Unowned artefacts are a
 storage bill nobody reads and a search that returns forty identically named files.
 
+### CI-053 — Performance and cost budgets
+
+Each profile declares explicit **budgets** — frontend bundle, Docker image size, startup
+time, memory, CPU, latency, throughput, storage, and log volume — and the pipeline measures
+them and **blocks significant regressions** (`info` → `warning` → `error`, like every other
+gate). AI paths additionally budget **tokens, cost, latency, concurrency, and cache**. A
+budget overrun is never silently accepted: it carries a justification, an impact measurement,
+and a reduction plan.
+
 ______________________________________________________________________
 
 ## 7. Review checklist
@@ -313,6 +322,7 @@ A workflow change is reviewable against this list in under a minute:
 7. Is the runner choice justified by the workload? (CI-035)
 8. New gate: does a failure mean the code is wrong? (CI-040)
 9. Does a skipped job report as skipped, never as passed? (CI-032)
+10. Are the profile's performance and cost budgets measured, with regressions blocked? (CI-053)
 
 ______________________________________________________________________
 
@@ -325,6 +335,7 @@ ______________________________________________________________________
 | CI-030, CI-031 | reviewed in pull request |
 | CI-004, CI-003 | fleet audit script over the workflow corpus |
 | CI-040 | any permanently red check is an issue with an owner |
+| CI-053 | per-profile budget file; CI measures and blocks significant regressions |
 
 Rules not yet mechanised are declared as manually reviewed — a rule claiming automation with no
 check behind it is misdeclared (`GOVERNANCE.md` GV-012).


### PR DESCRIPTION
Backfills the two transverse standards adopted in Notion (page `3ae59293`, *Standards transverses prioritaires*, 2026-07-31) that were **not yet in the repo canon**. The other 10 `STD-*` map onto existing socle/annexe rules and needed no change.

## Added
- **`STD-PERF-001` → `CI-053` (annexe `CI-CD.md`)** — performance and cost budgets per profile (bundle, image, startup, memory, CPU, latency, throughput, storage, logs; AI paths budget tokens/cost/latency/concurrency/cache). Socle anchor under **Quality gates**.
- **`STD-AI-QUALITY-001` → `AG-012`–`AG-015` (annexe `AGENTIC-CAPABILITIES.md`)** — versioned prompts/models/params/tools, evaluation dataset + non-regression, answer traceability, fallback/no-AI mode + risk-proportionate human validation. Socle anchor next to *Agent actions are governed*.
- `CLAUDE.md` managed standards block re-inlined from the socle (`distribute-standards.sh --standards-only`).

## ⚠️ Separate pre-existing defect (NOT fixed here)
`standards/STANDARDS.chrysa.md` on `develop` carries **orphan merge-conflict markers** (`||||||| d9f6b8f` ~l.263, `||||||| f7b98e2` ~l.623) — a botched resolution that also leaks into every repo's inlined block via `distribute-standards.sh`. Resolving it needs a diff against the base commits, so it is left out of this scoped PR and flagged for a dedicated fix.