### PR TITLE
fix(standards): remove orphan merge-conflict markers from the canon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,6 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   Values live in external config (`SESSION_IDLE_TIMEOUT`, `SESSION_ABSOLUTE_LIFETIME`) like
   every other constant — a timeout hardcoded in a middleware is both a *no hardcoded constants*
   violation and a security parameter nobody can tune without a deploy.
-||||||| d9f6b8f
 - **Every form is a hostile input surface — validate on the server, always.** A form is the
   place where an unknown person hands the product data of their choosing; the browser is their
   machine, so **nothing enforced only in the client is enforced at all**. `required`,
@@ -672,20 +671,6 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   `Service` is `ClusterIP` except the ingress-fronted entry point; `NodePort`, `LoadBalancer`,
   `hostPort` and `hostNetwork` need an ADR (a `hostPort` also bypasses `NetworkPolicy`).
   Detail: annexe `CONTAINERS-K3S.md` CT-015.
-- **A compose file is minimal — declare only what the stack needs, default the rest.** A
-  `docker-compose*.yml` is a description of *this* stack, not a copy of Compose's defaults. It
-  declares the services, their `build.target`/`image`, `depends_on`, `environment`, volumes,
-  `healthcheck` and `restart` — and **nothing Compose already does for you**. Forbidden as
-  noise: an explicit `networks:` block re-declaring the default bridge and wiring every service
-  to it (Compose already puts all services on a shared default network with service-name DNS —
-  see the ports rule), a redundant `container_name`, a `version:` top-level key (obsolete in
-  Compose v2), commented-out dead services, copy-pasted blocks that a YAML anchor or an
-  `extends`/override file would fold, and env values inlined where an `.env` / `env_file`
-  belongs. Environment- or developer-specific settings (a loopback port bind, a source bind
-  mount for hot-reload, debug flags) live in `docker-compose.override.yml` or a `*.dev.yml`,
-  never in the committed base stack. The test is mechanical: every line in the base compose
-  file is one a reader could not have inferred from Compose's defaults — a line that only
-  restates a default is deleted. Detail: annexe `CONTAINERS-K3S.md` CT-019.
 - **Dev stage must hot-reload.** The `dev` target/service provides live auto-reload so a source edit
   is reflected without a manual rebuild/restart: backend `uvicorn --reload` (or the framework's
   autoreload), frontend the dev server with HMR (`vite`/`npm run dev`), watched via the compose
@@ -777,7 +762,6 @@ deprecated and archived — nothing is added to it, nothing reads from it.
      API it is talking to, it tells the user and offers a reload rather than failing in
      obscure ways. Deployed versions per environment are also visible from the platform side
      (release notes, deployment log), so "what is in production" never requires a shell.
-||||||| f7b98e2
 - **If a user can supply a file, the product accepts an upload.** Wherever the workflow
   involves a file the user already has — an import (CSV, JSON, GPX, ICS…), an avatar or image,
   an attachment or supporting document, a configuration or dataset, a log or a crash dump sent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -671,6 +671,20 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   `Service` is `ClusterIP` except the ingress-fronted entry point; `NodePort`, `LoadBalancer`,
   `hostPort` and `hostNetwork` need an ADR (a `hostPort` also bypasses `NetworkPolicy`).
   Detail: annexe `CONTAINERS-K3S.md` CT-015.
+- **A compose file is minimal — declare only what the stack needs, default the rest.** A
+  `docker-compose*.yml` is a description of *this* stack, not a copy of Compose's defaults. It
+  declares the services, their `build.target`/`image`, `depends_on`, `environment`, volumes,
+  `healthcheck` and `restart` — and **nothing Compose already does for you**. Forbidden as
+  noise: an explicit `networks:` block re-declaring the default bridge and wiring every service
+  to it (Compose already puts all services on a shared default network with service-name DNS —
+  see the ports rule), a redundant `container_name`, a `version:` top-level key (obsolete in
+  Compose v2), commented-out dead services, copy-pasted blocks that a YAML anchor or an
+  `extends`/override file would fold, and env values inlined where an `.env` / `env_file`
+  belongs. Environment- or developer-specific settings (a loopback port bind, a source bind
+  mount for hot-reload, debug flags) live in `docker-compose.override.yml` or a `*.dev.yml`,
+  never in the committed base stack. The test is mechanical: every line in the base compose
+  file is one a reader could not have inferred from Compose's defaults — a line that only
+  restates a default is deleted. Detail: annexe `CONTAINERS-K3S.md` CT-019.
 - **Dev stage must hot-reload.** The `dev` target/service provides live auto-reload so a source edit
   is reflected without a manual rebuild/restart: backend `uvicorn --reload` (or the framework's
   autoreload), frontend the dev server with HMR (`vite`/`npm run dev`), watched via the compose

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -260,7 +260,6 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   Values live in external config (`SESSION_IDLE_TIMEOUT`, `SESSION_ABSOLUTE_LIFETIME`) like
   every other constant — a timeout hardcoded in a middleware is both a *no hardcoded constants*
   violation and a security parameter nobody can tune without a deploy.
-||||||| d9f6b8f
 - **Every form is a hostile input surface — validate on the server, always.** A form is the
   place where an unknown person hands the product data of their choosing; the browser is their
   machine, so **nothing enforced only in the client is enforced at all**. `required`,
@@ -620,7 +619,6 @@ deprecated and archived — nothing is added to it, nothing reads from it.
      API it is talking to, it tells the user and offers a reload rather than failing in
      obscure ways. Deployed versions per environment are also visible from the platform side
      (release notes, deployment log), so "what is in production" never requires a shell.
-||||||| f7b98e2
 - **If a user can supply a file, the product accepts an upload.** Wherever the workflow
   involves a file the user already has — an import (CSV, JSON, GPX, ICS…), an avatar or image,
   an attachment or supporting document, a configuration or dataset, a log or a crash dump sent


### PR DESCRIPTION
`standards/STANDARDS.chrysa.md` (and its inlined `CLAUDE.md` block) carried two orphan diff3 **base markers** — `||||||| d9f6b8f` and `||||||| f7b98e2` — introduced by commit `1732437` (#334): a botched conflict resolution removed the `<<<<<<<` / `=======` / `>>>>>>>` lines but left the base-marker lines. They were leaking into every repo's standards block via `distribute-standards.sh`.

**Analysis (safe deletion, no content lost):** base commit `d9f6b8f` had zero occurrences of the content following each marker — the base hunk was empty; both conflict sides added adjacent new bullets. Each following phrase appears exactly once. Only the marker lines are litter.

**Change — surgical:** delete the 4 orphan marker lines (2 in the socle, 2 in `CLAUDE.md`) and nothing else. Net diff = 4 deletions. The `CLAUDE.md` block is deliberately not regenerated: a full re-inline would also drop the `CT-019` "compose file is minimal" bullet (see below), a decision this PR does not make.

### Separate follow-up (not decided here)
The `CT-019` "A compose file is minimal" bullet is present in the distributed `CLAUDE.md` blocks but absent from BOTH the socle and the `CONTAINERS-K3S.md` annexe on `develop`. So either the rule was intentionally retired from the canon (and the fleet's inlined blocks are stale) or it was lost accidentally (and socle + annexe should restore `CT-019`). Needs an owner decision — flagged, not touched.