### PR TITLE
feat(standards): target ISO/IEC 27001 alongside GDPR (GV-040/GV-041)

### DIFF
--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -1114,6 +1114,27 @@ Every repo ships a session lifecycle so an AI agent keeps context across session
 - **Session end**: `make hindsight` (`/hindsight`) — updates `primer.md` + `progress.md`, clears
   `session.md`, optional Obsidian export (`OBSIDIAN=<path>`).
 
+## Compliance targets
+
+The fleet is held to two external compliance frameworks. Neither is a separate corpus — each
+is operationalised by rules already in this canon; declaring the target names the obligation
+those rules must satisfy, and certification is a governance program on top, not a code change.
+
+- **GDPR / RGPD — by construction.** Every product that touches personal data records its
+  lawful basis and purpose, minimises and time-bounds what it stores, keeps PII out of logs
+  and test data, and supports export / rectification / erasure by a documented command. This
+  is *per-person data implies a user account* and *portable personalisation data* applied to a
+  legal obligation. Detail: annexe `GOVERNANCE.md` GV-040.
+- **ISO/IEC 27001 — the security baseline.** Information security is a governed, documented
+  ISMS, not ad-hoc practice. Access control, cryptography, logging and audit, operations and
+  change control, supplier security, and incident management each map onto an existing canon
+  rule (cluster SSO & session security, secrets handling, observability & audit trail, CI
+  gates & protected `main`, project decoupling & supply-chain pinning, typed/contained errors),
+  so conformance is reached by satisfying those — not a parallel checklist. The organizational
+  artefacts ISO 27001 also demands (ISMS scope, risk assessment & treatment, Statement of
+  Applicability, internal audit) are a versioned governance backlog under `docs/`. Detail:
+  annexe `GOVERNANCE.md` GV-041.
+
 ## Governance — strategic pillars & ADR format
 
 Five non-negotiables hold across every chrysa project, whatever the stack. Breaking one

--- a/standards/annexes/GOVERNANCE.md
+++ b/standards/annexes/GOVERNANCE.md
@@ -90,3 +90,44 @@ several documents. Prose references the contract; it does not duplicate its valu
 
 Known consumers to keep aligned: `.claude/thresholds.json`, `.quality-gate.json`,
 `guideline-checker/guidelines/`.
+
+______________________________________________________________________
+
+## 5. External compliance
+
+The fleet is held to two external compliance frameworks. Neither is a parallel corpus: each is
+operationalised by rules that already exist in the canon. Declaring the target does not by
+itself grant certification — it names the obligation the existing rules must satisfy.
+
+### GV-040 — GDPR / RGPD by construction
+
+Any product handling personal data is **compliant by design**, not by a later audit: lawful
+basis or consent and purpose are recorded, data is minimised and its retention bounded, and
+export / rectification / erasure of a person's data is served by a documented command
+(pillar 3 · *portable personalisation data*). No PII in logs, traces, screenshots, test
+fixtures, or prompts without an explicit justification; development and demos use synthetic or
+anonymised data. Operationalised by the *per-person data implies a user account* and privacy
+rules in the socle, and the `rgpd-compliance` skill.
+
+### GV-041 — ISO/IEC 27001 as the security baseline
+
+The fleet targets **ISO/IEC 27001** compliance: information security is a governed, documented
+Information Security Management System (ISMS), not ad-hoc practice. The Annex A control
+families map onto existing canon rules — conformance is reached by satisfying those, not by a
+separate checklist:
+
+| ISO/IEC 27001 Annex A theme | Canon rule that satisfies it |
+| --- | --- |
+| Access control (A.5.15–18, A.8.2–5) | cluster SSO + identity hierarchy, session security & revocation (socle) · least privilege `AG-002` |
+| Cryptography (A.8.24) | TLS in the platform layer, secrets out of git, modern password hashing, encryption at rest for sensitive data (socle · `AG-005`) |
+| Logging & monitoring (A.8.15–16) | structured logs, correlated audit trail, Sentry → issues, observability backend (socle · `AG-008`) |
+| Operations & change (A.8.9, A.8.32) | CI gates, build-once-promote (`CI-046`), protected `main`, ADRs for structural change |
+| Supplier & supply-chain (A.5.19–23, A.8.30) | versioned contracts (`PROJECT-DECOUPLING`), pinned dependencies + SBOM + signed artefacts (`CI-*`) |
+| Incident management (A.5.24–28) | typed & contained errors, automatic issue creation, management backoffice + runbooks (socle) |
+| Privacy (A.5.34) | `GV-040` |
+
+What ISO 27001 additionally requires is **organizational, not code**: a documented ISMS scope,
+a risk assessment and treatment plan, a Statement of Applicability (SoA), defined security
+roles, and periodic internal audit plus management review. Those artefacts are versioned under
+`docs/` (or a dedicated governance repo) and tracked as a governance backlog — the code rules
+above are necessary for certification but not sufficient on their own.


### PR DESCRIPTION
Declares the fleet's two external **compliance targets** in the canon. GDPR was only implicit (scattered data-minimisation mentions); ISO/IEC 27001 was absent.

## Added
- **Socle — new `## Compliance targets` section** naming GDPR/RGPD and ISO/IEC 27001, each pointing at the existing rules that operationalise it.
- **`GOVERNANCE.md` — new section 5 "External compliance":**
  - **`GV-040` — GDPR/RGPD by construction** (lawful basis, minimisation, retention, export/rectification/erasure, no PII in logs/tests; ties to *per-person account* + *portable data* + the `rgpd-compliance` skill).
  - **`GV-041` — ISO/IEC 27001 as the security baseline** — Annex A control families mapped onto existing canon rules (access control → SSO/session; crypto → secrets/TLS/hashing; logging → observability/audit `AG-008`; ops & change → CI + protected `main`; supplier → decoupling + supply-chain pinning; incident mgmt → typed/contained errors + backoffice; privacy → `GV-040`). The organizational ISMS artefacts (scope, risk assessment & treatment, SoA, internal audit) are noted as a governance backlog, not code.

Design choice: ISO 27001 is expressed as **conformance through existing rules**, not a parallel security corpus — so it does not duplicate or contradict the current standards.

## Note
`CLAUDE.md` block **not re-inlined** in this PR: a full re-inline from the current socle would collaterally drop the `CT-019` "compose file is minimal" bullet still missing from the socle (flagged in #381). Re-inline should happen once #381 / the CT-019 question is resolved. The socle also still carries the two orphan conflict markers fixed by #381 (inherited from `develop`, not added here).