### PR TITLE
feat(standards): favicon + app icons on every web surface (FE-052)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,9 +501,11 @@ deprecated and archived — nothing is added to it, nothing reads from it.
      **schema.org JSON-LD** appropriate to its type (`Article`, `Product`, `Organization`,
      `BreadcrumbList`, `SoftwareApplication`…), plus the metadata that makes a link
      self-describing: `<title>`, `meta description`, canonical link, Open Graph/Twitter
-     cards, `hreflang` on localised pages, `sitemap.xml` and `robots.txt`. The structured
+     cards, `hreflang` on localised pages, a **favicon + app icons + web app manifest**
+     (`theme-color` included), and `sitemap.xml` and `robots.txt`. The structured
      data **describes what is actually on the page** — mismatched markup is a defect, not
-     an SEO trick.
+     an SEO trick. A tab left with the browser's default globe icon is an unfinished page
+     (FE-052).
   4. **Semantic code and data shapes.** Intention-revealing names over comments, typed
      contracts over free-form dicts, ISO-8601 dates and explicit units/currency in payloads,
      stable machine-readable codes on errors (see *typed errors*). A field named `data`,

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -358,9 +358,11 @@ deprecated and archived — nothing is added to it, nothing reads from it.
      **schema.org JSON-LD** appropriate to its type (`Article`, `Product`, `Organization`,
      `BreadcrumbList`, `SoftwareApplication`…), plus the metadata that makes a link
      self-describing: `<title>`, `meta description`, canonical link, Open Graph/Twitter
-     cards, `hreflang` on localised pages, `sitemap.xml` and `robots.txt`. The structured
+     cards, `hreflang` on localised pages, a **favicon + app icons + web app manifest**
+     (`theme-color` included), and `sitemap.xml` and `robots.txt`. The structured
      data **describes what is actually on the page** — mismatched markup is a defect, not
-     an SEO trick.
+     an SEO trick. A tab left with the browser's default globe icon is an unfinished page
+     (FE-052).
   4. **Semantic code and data shapes.** Intention-revealing names over comments, typed
      contracts over free-form dicts, ISO-8601 dates and explicit units/currency in payloads,
      stable machine-readable codes on errors (see *typed errors*). A field named `data`,

--- a/standards/annexes/FRONTEND.md
+++ b/standards/annexes/FRONTEND.md
@@ -214,6 +214,17 @@ These are stated in the socle and are not restated here:
 - i18n from V1 — **including error and fallback screens**, which are localised like any
   other surface (FE-050). Dates and numbers are formatted with the active locale (FE-051).
 
+### FE-052 — Every page ships a favicon and app icons
+
+Every web surface declares, in the document `<head>`, a **favicon** (SVG preferred, with an
+`.ico` fallback for legacy browsers), an **`apple-touch-icon`** for iOS home-screen use, and a
+**web app manifest** (`manifest.webmanifest` with `name`, `short_name`, `theme-color`,
+`background_color`, and PNG `icons` at 192 and 512 px). The icons are **real committed assets**
+referenced by the head — a `link rel="icon"` pointing at a 404 is a defect. The favicon is part
+of the **brand kit** (a design-system asset, not a per-repo afterthought) and, where the format
+allows (SVG with `prefers-color-scheme`), adapts to light and dark. A tab left showing the
+browser's default globe icon is an unfinished page.
+
 ______________________________________________________________________
 
 ## 6. Environment & configuration


### PR DESCRIPTION
Adds an explicit **favicon / app-icon** requirement to the web standards.

## Added — `FE-052` (annexe `FRONTEND.md`, §5)
Every web surface declares in the document `<head>`:
- a **favicon** — SVG preferred, `.ico` fallback for legacy browsers;
- an **`apple-touch-icon`** for iOS home-screen;
- a **web app manifest** (`manifest.webmanifest`: `name`, `short_name`, `theme-color`, `background_color`, PNG `icons` at 192 & 512).

They are **real committed assets** (a `link rel="icon"` → 404 is a defect), the favicon is a **brand-kit / design-system asset** (not a per-repo afterthought) and adapts to light/dark where the SVG format allows. The browser's default globe icon marks an unfinished page.

## Anchored in the socle
The favicon + app icons + manifest are added to the *"Everything is semantic"* metadata list (next to `<title>`, `meta description`, canonical, OG/Twitter, sitemap, robots), pointing to `FE-052`.

`CLAUDE.md` standards block re-inlined (safe now — CT-019 restored, conflict markers cleared on `develop`).