### PR TITLE
feat(standards): CI on every repo (CI-006) + CD on deployable products (CI-047)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1092,11 +1092,17 @@ setup, invoke the repo's own gate (`pre-commit`, `make ci`) — and every line o
 carries is a line that lives in the wrong repo. A pipeline has one job: **tell the truth
 about the code, fast, without becoming a codebase of its own**. Full rules, with ids and a
 review checklist: annexe [`CI-CD.md`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md)
-(`CI-000`…`CI-052`) — pipeline architecture, supply-chain pinning, least privilege,
+(`CI-000`…`CI-053`) — pipeline architecture, supply-chain pinning, least privilege,
 cost/latency, what the gate must prove, feedback.
 
-Four of its rules are load-bearing enough to state here:
+Five of its rules are load-bearing enough to state here:
 
+- **Every repo runs CI, and every deployable product ships CD** (`CI-006`, `CI-047`). There is
+  no repository without a pipeline: CI runs the repo's own gate (`make ci` / `pre-commit`) on
+  every push and PR, scaled to the `runtime:` tier. A deployable product (`runtime: container`)
+  or a published library delivers through an **automated, environment-gated** pipeline — never a
+  laptop deploy — and what CD ships **announces its version** in production (the `/version`
+  endpoint + admin surface already required below).
 - **A red check means the code is wrong** (`CI-040`). A gate that fails because a repo is not
   onboarded, a tool is missing or billing lapsed trains everyone to ignore red — and the next
   real failure is ignored too. Fix it or remove it the day it appears.

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -949,11 +949,17 @@ setup, invoke the repo's own gate (`pre-commit`, `make ci`) — and every line o
 carries is a line that lives in the wrong repo. A pipeline has one job: **tell the truth
 about the code, fast, without becoming a codebase of its own**. Full rules, with ids and a
 review checklist: annexe [`CI-CD.md`](https://github.com/chrysa/shared-standards/blob/main/standards/annexes/CI-CD.md)
-(`CI-000`…`CI-052`) — pipeline architecture, supply-chain pinning, least privilege,
+(`CI-000`…`CI-053`) — pipeline architecture, supply-chain pinning, least privilege,
 cost/latency, what the gate must prove, feedback.
 
-Four of its rules are load-bearing enough to state here:
+Five of its rules are load-bearing enough to state here:
 
+- **Every repo runs CI, and every deployable product ships CD** (`CI-006`, `CI-047`). There is
+  no repository without a pipeline: CI runs the repo's own gate (`make ci` / `pre-commit`) on
+  every push and PR, scaled to the `runtime:` tier. A deployable product (`runtime: container`)
+  or a published library delivers through an **automated, environment-gated** pipeline — never a
+  laptop deploy — and what CD ships **announces its version** in production (the `/version`
+  endpoint + admin surface already required below).
 - **A red check means the code is wrong** (`CI-040`). A gate that fails because a repo is not
   onboarded, a tool is missing or billing lapsed trains everyone to ignore red — and the next
   real failure is ignored too. Fix it or remove it the day it appears.

--- a/standards/annexes/CI-CD.md
+++ b/standards/annexes/CI-CD.md
@@ -55,6 +55,18 @@ per repository.
 It lists the reusable workflows (purpose, inputs, outputs, runner) and draws the job graph of
 each entry point. A pipeline nobody can read is a pipeline nobody dares change, and it ossifies.
 
+### CI-006 — Every repo runs CI
+
+There is **no repository without CI**. Every repo has a workflow that runs its gate on every
+push and pull request to `develop`, and on every PR to `main`. What the gate runs scales with
+the `runtime:` tier (`repos.yml`): an **application** runs the full `make ci` (lint, typecheck,
+tests + coverage, build, quality gate); an **`exempt:lib`** runs its suite in a container
+(`docker-test`) plus lint; an **`exempt:config`** validates and lints what it ships (YAML,
+manifests) with no application gate; an **`exempt:native`** runs its tests where the host
+allows. The gate is the one a developer runs locally (`pre-commit`, `make ci`), invoked by glue
+— not re-implemented in YAML. A repo with no pipeline, or one whose check is green only because
+nothing ran, is a defect (`CI-040`, `CI-032`).
+
 ______________________________________________________________________
 
 ## 2. Supply chain
@@ -277,6 +289,22 @@ notices until a user asks what changed.
 The artefact tested is the artefact deployed — the same image digest moves through the
 environments. Rebuilding per environment means production runs something no test ever saw.
 
+### CI-047 — Every deployable product ships continuous delivery
+
+Where a product is meant to run somewhere, its deployment is a **pipeline, not a person**. A
+**deployable product** (`runtime: container` — a service or an app) has a **CD workflow** that,
+on the release of `main` (or a tagged release), deploys the already-tested promoted artefact
+(`CI-046`) to its environment automatically — gated by an `environment:` with its reviewers
+(`CI-023`) and using the deploy concurrency group that never cancels a deploy mid-flight
+(`CI-031`). No manual deploy from a laptop, no hand-copied image tag. A **distributable library**
+delivers by **publishing its package** (GHCR / PyPI via OIDC Trusted Publishing) as its CD;
+`exempt:config` and `exempt:native` repos have no CD. "When needed" is the test: a product that
+is *released* but reaches production by a human running commands is missing its CD. What CD puts
+in production **announces its version** — the deployed service and frontend surface the running
+application version, image digest and environment, as already required by the socle's *the
+container is versioned separately … an admin can see what is actually deployed* rule — so a
+deploy is observable, never a silent swap.
+
 ______________________________________________________________________
 
 ## 6. Feedback
@@ -334,6 +362,7 @@ ______________________________________________________________________
 | CI-020, CI-021, CI-022 | reviewed in pull request; grep-able patterns, candidates for a hook |
 | CI-030, CI-031 | reviewed in pull request |
 | CI-004, CI-003 | fleet audit script over the workflow corpus |
+| CI-006, CI-047 | fleet audit: every repo has a CI workflow; every `runtime: container` repo has a CD workflow |
 | CI-040 | any permanently red check is an issue with an owner |
 | CI-053 | per-profile budget file; CI measures and blocks significant regressions |
 


### PR DESCRIPTION
Adds two **presence** rules the CI-CD annexe was missing (it described *how* to build a pipeline, never that every repo must *have* one), and cross-references — without duplicating — the existing version-display rule.

## Added
- **`CI-006` — Every repo runs CI.** No repository without a pipeline: each repo runs its own gate (`make ci` / `pre-commit`) on push and PR, **scaled to the `runtime:` tier** — application → full `make ci`; `exempt:lib` → suite in a container (`docker-test`) + lint; `exempt:config` → validate/lint what it ships; `exempt:native` → tests where the host allows. A repo with no pipeline, or a green check because nothing ran, is a defect (`CI-040`, `CI-032`).
- **`CI-047` — Every deployable product ships CD.** A deployable product (`runtime: container`) has an **automated, environment-gated** CD workflow that deploys the already-tested promoted artefact (`CI-046`, `CI-023`, `CI-031`) — no laptop deploy. A library delivers by **publishing its package** (GHCR/PyPI via OIDC); `exempt:config` / `exempt:native` have no CD. "When needed" = deployable products & published libs.
- Socle **GitHub Actions** section: new load-bearing bullet (`CI-006` + `CI-047`); enforcement row (fleet audit); `CI-000…CI-053` range corrected.

## Version display — already canon, not duplicated
"Un affichage des versions dans les produits délivrés" is already required by the socle rule *"the container is versioned separately … an admin can see what is actually deployed"* (`/version` endpoint + image digest + git SHA + env, and the frontend surfacing its own build version with mismatch detection). `CI-047` **cross-references** it rather than restating it, per *no code/spec duplication*.

`CLAUDE.md` standards block re-inlined (safe: CT-019 present, no markers on `develop`).