### PR TITLE
fix(ruff): a nested pyproject that shadows the root must receive the rules

### DIFF
--- a/console/pyproject.toml
+++ b/console/pyproject.toml
@@ -38,7 +38,7 @@ line-length = 100
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "SIM", "C4"]
+select = ["E", "F", "I", "UP", "B", "SIM", "C4", "C901", "PERF203", "PERF401", "PLR0402", "PLR0911", "PLR0912", "PLR0915", "PLR1714", "PLR1730", "PLR5501", "RUF005", "RUF006", "RUF007", "RUF009", "RUF012", "RUF013", "RUF022", "RUF043", "RUF059", "RUF100"]
 # B008: FastAPI's `Depends(...)` in defaults is the idiomatic DI pattern.
 ignore = ["B008"]
 

--- a/scripts/apply-repo-standard.sh
+++ b/scripts/apply-repo-standard.sh
@@ -267,13 +267,23 @@ find_pyprojects() {
     # Every pyproject that can own Python, not just the first: a monorepo may
     # carry backend/ and agent/ side by side, and returning one silently left
     # the other outside the rule set (measured on satisfactory-factory-manager).
-    local repo="$1" found=1 candidate
+    local repo="$1" found=1 has_root=1 candidate
     if [[ -f "$repo/pyproject.toml" ]]; then
         echo "$repo/pyproject.toml"
-        return 0
+        found=0 has_root=0
     fi
     for candidate in "$repo"/*/pyproject.toml; do
         [[ -f "$candidate" ]] || continue
+        # Returning at the root left a nested config that *shadows* it outside
+        # the rule set: Ruff resolves to the nearest pyproject that declares a
+        # [tool.ruff] section, so chrysa-portfolio-viz/backend — which declares
+        # five — escaped all 20 canonical codes while the root read as compliant.
+        # A nested file with no [tool.ruff] is skipped on purpose: it inherits
+        # the root's rules today, and writing a `select` into it would sever that
+        # inheritance and drop the root's other Ruff settings along with it.
+        if ((has_root == 0)) && ! grep -q '^\[tool\.ruff' "$candidate"; then
+            continue
+        fi
         echo "$candidate"
         found=0
     done


### PR DESCRIPTION
`find_pyprojects()` returned at the repo root and never looked one level down. Ruff resolves to the **nearest pyproject that declares a `[tool.ruff]` section**, so a nested config shadows the root entirely: `chrysa-portfolio-viz/backend` declares five and escaped all 20 canonical codes — while the root measured as compliant, which is how the fleet audit read 100%.

A nested pyproject with **no** `[tool.ruff]` is skipped on purpose: it inherits the root's rules today, and writing a `select` into it would sever that inheritance and drop the root's other Ruff settings.

`shared-standards/console/` had the same hole; fixed here (3 findings surfaced: 1 `RUF100`, 2 `PERF401`).

Contrôles sur les quatre dispositions, plus le dépôt vide :

```
racine seule                          -> racine
racine + imbrique sans [tool.ruff]    -> racine            (herite, on n'y touche pas)
racine + imbrique avec [tool.ruff]    -> racine + imbrique (le trou corrige)
pas de racine + backend/ + agent/     -> les deux          (cas monorepo historique)
aucun pyproject                       -> exit 1
```

Le cas monorepo est là parce qu'une première version du correctif le cassait en silence — le contrôle positif l'a attrapé.

Mesuré sur la flotte : 2 fichiers concernés (`chrysa-portfolio-viz/backend`, `shared-standards/console`). Les 8 packages de `chrysa-lib` et l'exemple `doc-gen` ne déclarent pas de section Ruff et héritent correctement. `chrysa-portfolio-viz/sdk/python` est du code **généré** (`openapi-python-client … --overwrite`) et reste hors périmètre.