### PR TITLE
feat(standards): profile clone, no-env hook, AG-016, ADR D-0009 (Rain concepts)

### DIFF
--- a/.claude/HOOKS_README.md
+++ b/.claude/HOOKS_README.md
@@ -10,6 +10,7 @@ All hooks are written in Node.js (`.cjs`) and require only the standard library.
 | Hook | Type | File | Blocks? |
 |------|------|------|---------|
 | Secret scanner | `PreToolUse` (Bash → git commit) | `secret-scanner.cjs` | Yes (exit 2) |
+| No-env-files | `PreToolUse` (Bash → git commit) · CLI `--ci` | `check-no-env-files.cjs` | Yes (exit 2) · CI exit 1 |
 | Circuit breaker | `PreToolUse` (Bash → API calls) | `circuit-breaker.cjs` | Yes when open (exit 2) |
 | Frustration detection | `UserPromptSubmit` | `frustration-detection.cjs` | No (injects context) |
 | Verifiable thresholds | `PostToolUse` (Write/Edit) | `verifiable-thresholds.cjs` | No (warnings only) |
@@ -257,6 +258,24 @@ node .claude/hooks/model-debt-inventory.cjs --dir /path/to/repo
 > `PreToolUse:Bash hook error - Failed with non-blocking status code: node:internal/modules/cjs/loader:<line>`.
 > The guard turns a missing hook into a silent no-op, and `$CLAUDE_PROJECT_DIR` makes the
 > path independent of the tool's working directory.
+
+## No-env-files hook (`check-no-env-files.cjs`) — enforces AG-005
+
+Blocks a commit that stages a `.env`-class secret file, and doubles as a CI gate.
+Config is injected at runtime (env / secret store), never committed — Rain-devkit model.
+
+```bash
+# PreToolUse (blocking) — reads the tool payload on stdin
+echo '{"tool_input":{"command":"git commit -m x"}}' | node .claude/hooks/check-no-env-files.cjs
+# Expected: exit 2 if a staged path is `.env` / `.env.<x>` (not *.example|sample|template|dist)
+
+# CI gate — scan the whole tree, wire into `make ci`
+node .claude/hooks/check-no-env-files.cjs --ci .
+# Expected: exit 1 on any tracked/present .env secret file, else 0
+```
+
+**Allowed, never flagged:** `*.env.example`, `*.env.sample`, `*.env.template`, `*.env.dist`.
+**Allowlist file:** `.claude/no-env-allowlist.json` (JSON array of glob patterns).
 
 ## Disabling a hook
 

--- a/.claude/hooks/check-no-env-files.cjs
+++ b/.claude/hooks/check-no-env-files.cjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * check-no-env-files.cjs — enforce AG-005 (secrets out of git) at write time.
+ *
+ * Concept lifted from the Rain devkit's `check-no-env-files.sh` / Vault-seed model:
+ * a project never ships a `.env`. Config is injected at runtime (env vars, a secret
+ * store), never committed and never sitting decrypted in the tree.
+ *
+ * Two modes:
+ *   PreToolUse (Bash → git commit)  — BLOCKS (exit 2) when a `.env`-class file is staged.
+ *   CLI  `node check-no-env-files.cjs --ci [dir]`  — scans the tree, exits 1 on any hit
+ *                                                    (wire into `make ci` / quality gate).
+ *
+ * Allowed, never flagged: `*.env.example`, `*.env.sample`, `*.env.template`, `*.env.dist`,
+ * and anything under the allowlist file `.claude/no-env-allowlist.json` (array of globs).
+ *
+ * Best-effort and defensive: any internal error exits 0 (PreToolUse) so it never wedges a
+ * session on malformed input — enforcement of record is the `--ci` gate.
+ */
+"use strict";
+
+const { execSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const BLOCK = 2; // PreToolUse deny
+const CI_FAIL = 1; // CLI gate failure
+
+// A path is a secret-bearing env file when its basename is `.env` or starts `.env.`,
+// EXCEPT the sample/example/template/dist variants which carry no real secret.
+const ENV_RE = /(^|\/)\.env(\.[^/]*)?$/;
+const SAFE_SUFFIX_RE = /\.(example|sample|template|dist)$/;
+
+function isEnvSecretFile(p) {
+  const base = p.split("/").pop() || p;
+  if (!ENV_RE.test("/" + base)) return false;
+  if (SAFE_SUFFIX_RE.test(base)) return false;
+  return true;
+}
+
+function loadAllowlist(root) {
+  try {
+    const f = path.join(root, ".claude", "no-env-allowlist.json");
+    const arr = JSON.parse(fs.readFileSync(f, "utf8"));
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function allowed(p, allowlist) {
+  return allowlist.some((glob) => {
+    const re = new RegExp(
+      "^" + glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$",
+    );
+    return re.test(p);
+  });
+}
+
+// ---- CLI / CI mode -----------------------------------------------------------
+function ciScan(dir) {
+  const root = path.resolve(dir || ".");
+  const allowlist = loadAllowlist(root);
+  const hits = [];
+  const SKIP = new Set([".git", "node_modules", ".venv", "dist", "build", "__pycache__"]);
+  (function walk(d) {
+    let entries;
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (!SKIP.has(e.name)) walk(path.join(d, e.name));
+        continue;
+      }
+      const abs = path.join(d, e.name);
+      const rel = path.relative(root, abs);
+      if (isEnvSecretFile(rel) && !allowed(rel, allowlist)) hits.push(rel);
+    }
+  })(root);
+
+  if (hits.length) {
+    process.stderr.write(
+      "AG-005 violation — committed/present .env file(s):\n" +
+        hits.map((h) => "  - " + h).join("\n") +
+        "\nMove secrets to the runtime injection layer (env vars / secret store). " +
+        "Ship a `.env.example` instead.\n",
+    );
+    process.exit(CI_FAIL);
+  }
+  process.exit(0);
+}
+
+// ---- PreToolUse mode ---------------------------------------------------------
+function readHookInput() {
+  try {
+    return JSON.parse(fs.readFileSync(0, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function isGitCommit(cmd) {
+  return /\bgit\b[^\n]*\bcommit\b/.test(cmd || "");
+}
+
+function stagedEnvFiles(root) {
+  try {
+    const out = execSync("git diff --cached --name-only --diff-filter=ACM", {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const allowlist = loadAllowlist(root);
+    return out
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .filter((p) => isEnvSecretFile(p) && !allowed(p, allowlist));
+  } catch {
+    return [];
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--ci")) {
+    const dir = args.find((a) => !a.startsWith("--"));
+    return ciScan(dir);
+  }
+
+  const input = readHookInput();
+  if (!input) process.exit(0);
+  const cmd = input?.tool_input?.command || "";
+  if (!isGitCommit(cmd)) process.exit(0);
+
+  const root = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const hits = stagedEnvFiles(root);
+  if (!hits.length) process.exit(0);
+
+  process.stderr.write(
+    "BLOCKED (AG-005): commit stages a .env secret file:\n" +
+      hits.map((h) => "  - " + h).join("\n") +
+      "\nUnstage it (`git restore --staged <file>`), keep secrets out of git. " +
+      "Ship `.env.example`. Bypass a false positive via .claude/no-env-allowlist.json.\n",
+  );
+  process.exit(BLOCK);
+}
+
+main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,6 +53,12 @@
             "name": "circuit-breaker",
             "timeout": 5000,
             "type": "command"
+          },
+          {
+            "command": "sh -c 'f=\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-no-env-files.cjs\"; [ ! -f \"$f\" ] || node \"$f\"'",
+            "name": "check-no-env-files",
+            "timeout": 5000,
+            "type": "command"
           }
         ],
         "matcher": "Bash"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ make lint     # Run pre-commit on all files
 | Hook | Event | Purpose |
 |------|-------|---------|
 | secret-scanner.cjs | PreToolUse (git commit) | Block secrets from being committed |
+| check-no-env-files.cjs | PreToolUse (git commit) · CLI `--ci` | Block `.env` secret files (AG-005) — config injected at runtime |
 | circuit-breaker.cjs | PreToolUse (API calls) | Prevent repeated failing API calls |
 | frustration-detection.cjs | UserPromptSubmit | Inject context on frustrating prompts |
 | verifiable-thresholds.cjs | PostToolUse (file writes) | Warn on quality threshold violations |

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -168,3 +168,69 @@ predecessor PR with a `Depends-On: <PR URL>` line in the PR description (see
 also supports Gerrit and GitLab dependency URLs and Go/Python/JS/Ansible/container
 dependency injection, which the fleet does not yet use but may adopt later without
 further ADR changes.
+
+---
+
+## D-0009 — Claude config distribution: per-repo inlining vs a centralised plugin
+
+**Date**: 2026-08-08
+**Status**: proposed
+**Deciders**: owner
+**Pillars touched**: none
+
+### Context
+
+The Rain devkit (external org, audited 2026-08-08) proposes a **centralised Claude model**:
+business repos carry **no** `CLAUDE.md` and **no** `.claude/`; a single devkit repo owns the
+skills/agents/hooks and each workspace gets a symlink `CLAUDE.md -> devkit/assistant/CLAUDE.fragment.md`,
+so `git pull` in one repo updates the Claude context everywhere.
+
+The chrysa fleet does the **opposite today** and by settled convention: the standards block is
+the *only artifact inlined* into every consumer repo (`CLAUDE.md` "Normative annexes"), and
+*every code repo depends on `project-init`* — scaffolded at birth and kept in sync by
+`scripts/distribute-standards.sh`. Shared skills are already loaded on demand from
+`shared-standards/.claude/skills/`, and a plugin-marketplace mechanism already exists in the
+fleet (`herdr-rtk-savings`, `.claude-plugin/marketplace.json`). So the fleet already sits
+between the two poles: **inlined standards** + **centrally-sourced skills**.
+
+### Decision
+
+Keep the inlined-per-repo standards block as canon; do **not** adopt the symlink model. Evaluate
+promoting the shared skills/agents/hooks into a **single fleet Claude plugin** (marketplace,
+like herdr) that every repo declares instead of copying `.claude/` contents — an additive,
+git-native distribution, not a symlink.
+
+### Fatal hypothesis
+
+A central plugin distributes skill/agent/hook **updates** across the fleet with materially less
+drift and effort than the current per-repo copy via `distribute-standards.sh`, **without**
+breaking the "a fresh agent finds everything from committed files alone" property.
+
+### Kill-test
+
+Prototype the plugin on 2 repos. Measure over 30 days: (a) mean time to propagate one skill
+change to all consuming repos, and (b) number of repos where a dropped-in agent, with no plugin
+resolution, fails to find a rule it needs. If propagation time is **not** at least 50% below the
+`distribute-standards.sh` PR-fanout baseline, **or** any repo fails the fresh-agent legibility
+test because context now lives outside the repo, the hypothesis is false → stay per-repo.
+
+### Validation gate
+
+Green only if: standards block stays inlined (unchanged), the plugin carries *only* the evolving
+skills/agents/hooks, and the 2-repo prototype passes both kill-test metrics. Then roll to the
+fleet via `distribute-standards`. Otherwise close as `Killed` and keep the copy model.
+
+### Options considered
+
+| Option | Why not |
+| ------ | ------- |
+| Symlink `CLAUDE.md -> devkit/fragment` (Rain model) | Cross-repo symlink is not tracked by git per-repo, breaks on relocation, Windows-hostile, and voids the "legible from committed files alone" rule. |
+| Status quo (copy everything via distribute-standards) | Works, but a skill change is a ~60-PR fanout; the duplication the canon forbids elsewhere. |
+| Full centralisation (repos carry no `.claude/`) | Conflicts with *repo provenance* and *repo legible to an agent*; a repo must stand alone. |
+
+### Consequences
+
+Additive if accepted: repos keep their inlined standards and gain a declared plugin for the
+moving parts; the `.claude/skills` copy is replaced by a `rev`-pinned plugin reference (same model
+as `chrysa/pre-commit-tools` and `chrysa/github-actions`). Debt: one more marketplace to version.
+Blast radius if `Killed`: revert the 2 prototype repos to the copy model — no fleet change made.

--- a/repos.yml
+++ b/repos.yml
@@ -283,3 +283,27 @@ repos:
     status: dev
     public: false
     runtime: container
+
+# ── profiles ──────────────────────────────────────────────────────────────────
+# Role-scoped clone sets, consumed by scripts/clone-profile.sh (Rain-devkit model:
+# a front dev never clones the libs, an infra dev never clones the React apps).
+# `full` is NOT listed here — it resolves to every status:dev repo via list-dev-repos.sh.
+#
+# Curated 2026-08-08 from real repo descriptions + primary language. A repo may sit in
+# several profiles (a fullstack app is both `front` and `back`). `lib` and `config` track
+# the `runtime:` tiers above; `front`/`back`/`ai`/`infra` are by product nature. Membership
+# is inline lists so the awk parser in clone-profile.sh can read them. Keep names in sync
+# with the entries above. Judgment calls flagged inline.
+profiles:
+  # reusable dev bricks (runtime: exempt:lib) — imported, not run standalone
+  lib: [chrysa-lib, django-app-forge, django-autoload, django-pytest, django-query-optimizer, django-traceid, django-migration-analyzer, epub-sorter, fastapi-autoload, fastapi-pytest, fastapi-query-optimizer, fastapi-traceid, guideline-checker, pre-commit-hooks-changelog, pre-commit-tools, project-init]
+  # config / knowledge / manifests / Claude-config (runtime: exempt:config)
+  config: [agent-config, catalog, chrysa-skills, claude-config, chrysa-claude-template, dotfiles, github-actions, homeassistant-config, projects-claude-config, usefull-containers, shared-standards]
+  # UI-primary apps (web front-end is the main deliverable)
+  front: [chrysa-portfolio-viz, container-webview, dev-nexus, devtool, gaming-os, cdn-explorer, discordium, studioverse, mediavault, D-D, PO-GO-DEX, linkendin-resume, my-resume, diy-stream-deck, wsmqtt-monitor, guideline-checker]
+  # back-end services / APIs (FastAPI/Django services, gateways, bots)
+  back: [ai-aggregator, audit-platform, discord-bot-back, discordium, feedback-gateway, link-reader-bot, mirrador, genealogy-validator, sport-intelligence-hub, doc-gen, content-organizer, wsmqtt-monitor, daedalus-document-factory]
+  # LLM / AI-centric products (inference, RAG, observability, assistants)
+  ai: [ai-aggregator, mirrador, content-organizer, doc-gen, floating-agent, lifeos, coach, daedalus-document-factory, dev-nexus]
+  # deployment / host / fleet tooling / observability
+  infra: [catalog, server, github-actions, shared-standards, dotfiles, project-init, agent-config, claude-config, projects-claude-config, chrysa-claude-template]

--- a/scripts/clone-profile.sh
+++ b/scripts/clone-profile.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# clone-profile.sh — clone only the fleet repos a given role needs (Rain-devkit "profile" model).
+#
+# A front dev never clones Helm charts; an infra dev never clones the React apps.
+# The profile → membership map lives in repos.yml under `profiles:` (source of truth,
+# hand-tuned). This script resolves it and shallow-clones the missing repos into a
+# workspace dir. It NEVER writes a `.env` and never touches secrets (see AG-005).
+#
+# Usage:
+#   clone-profile.sh <profile> [--dir DIR] [--dry-run] [--org ORG] [--depth N]
+#   clone-profile.sh --list                 # show profiles and their members
+#
+#   PROFILE ∈ full | front | back | ai | infra | lib | config   (see repos.yml `profiles:`)
+#
+# Examples:
+#   clone-profile.sh front --dir ~/work/chrysa
+#   clone-profile.sh full  --dry-run
+#
+# Exit: 0 ok · 2 bad args / repos.yml missing · 3 unknown profile
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STD_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPOS_YML="${REPOS_YML:-$STD_ROOT/repos.yml}"
+
+ORG="${CHRYSA_ORG:-chrysa}"
+DIR="."
+DEPTH="1"
+DRY=0
+PROFILE=""
+LIST=0
+
+die() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit "${2:-2}"; }
+info() { printf '\033[36m•\033[0m %s\n' "$*"; }
+ok() { printf '\033[32m✓\033[0m %s\n' "$*"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dir) shift; DIR="${1:?--dir needs a path}" ;;
+    --org) shift; ORG="${1:?--org needs a value}" ;;
+    --depth) shift; DEPTH="${1:?--depth needs a value}" ;;
+    --dry-run) DRY=1 ;;
+    --list) LIST=1 ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    -*) die "unknown flag: $1" ;;
+    *) PROFILE="$1" ;;
+  esac
+  shift
+done
+
+[ -f "$REPOS_YML" ] || die "repos.yml not found: $REPOS_YML"
+
+# Extract the `profiles:` block members for a profile name.
+# Block shape in repos.yml:
+#   profiles:
+#     front: [dashboard, my-resume, ...]
+#     back:  [ai-aggregator, ...]
+profile_members() {
+  awk -v want="$1" '
+    /^profiles:/ { inblk=1; next }
+    inblk && /^[a-zA-Z]/ { inblk=0 }          # left the block (next top-level key)
+    inblk {
+      line=$0
+      sub(/^[[:space:]]+/, "", line)
+      if (line ~ /^#/ || line == "") next     # skip comments / blank lines
+      # match "name: [ ... ]" or "name:" continued — we only support inline lists here
+      if (line ~ "^" want ":") {
+        sub("^" want ":[[:space:]]*", "", line)
+        gsub(/[][]/, "", line)
+        gsub(/,/, " ", line)
+        print line
+      }
+    }
+  ' "$REPOS_YML"
+}
+
+profile_names() {
+  awk '
+    /^profiles:/ { inblk=1; next }
+    inblk && /^[a-zA-Z]/ { inblk=0 }
+    inblk {
+      line=$0; sub(/^[[:space:]]+/, "", line)
+      if (line ~ /^#/ || line == "") next
+      if (line ~ /:/) { sub(/:.*/, "", line); print line }
+    }
+  ' "$REPOS_YML"
+}
+
+if [ "$LIST" -eq 1 ]; then
+  printf '\n  Profiles (from %s):\n\n' "$REPOS_YML"
+  for p in $(profile_names); do
+    printf '  \033[36m%-8s\033[0m %s\n' "$p" "$(profile_members "$p")"
+  done
+  printf '\n'
+  exit 0
+fi
+
+[ -n "$PROFILE" ] || die "missing profile — try: $(basename "$0") --list"
+
+# `full` = every status:dev repo (delegates to the existing source-of-truth script).
+if [ "$PROFILE" = "full" ]; then
+  MEMBERS="$("$SCRIPT_DIR/list-dev-repos.sh" --lines 2>/dev/null | tr '\n' ' ')"
+else
+  MEMBERS="$(profile_members "$PROFILE")"
+  [ -n "${MEMBERS// /}" ] || die "unknown or empty profile: $PROFILE (see --list)" 3
+fi
+
+info "profile=$PROFILE  org=$ORG  dir=$DIR  depth=$DEPTH"
+[ "$DRY" -eq 1 ] && info "DRY-RUN — nothing will be cloned"
+
+mkdir -p "$DIR"
+cloned=0 skipped=0
+for repo in $MEMBERS; do
+  [ -n "$repo" ] || continue
+  dest="$DIR/$repo"
+  if [ -d "$dest/.git" ]; then
+    skipped=$((skipped + 1))
+    info "skip (exists): $repo"
+    continue
+  fi
+  if [ "$DRY" -eq 1 ]; then
+    info "would clone: $ORG/$repo -> $dest"
+    continue
+  fi
+  if gh repo clone "$ORG/$repo" "$dest" -- --depth "$DEPTH" >/dev/null 2>&1; then
+    cloned=$((cloned + 1)); ok "cloned: $repo"
+  else
+    printf '\033[33m!\033[0m clone failed (skipping): %s\n' "$repo" >&2
+  fi
+done
+
+printf '\n'
+ok "profile '$PROFILE': cloned=$cloned skipped=$skipped"
+printf '  \033[33mNote:\033[0m no .env written. Inject config at runtime (env / secret store) — AG-005.\n\n'

--- a/standards/annexes/AGENTIC-CAPABILITIES.md
+++ b/standards/annexes/AGENTIC-CAPABILITIES.md
@@ -87,6 +87,25 @@ external model without a documented authorisation.
 
 ______________________________________________________________________
 
+### AG-016 — Agent autonomy scales with layer determinism
+
+AG-003 grades confirmation by the risk of a single **action**. AG-016 grades an **agent's**
+standing autonomy by the determinism of the **layer** it works in — the two compose.
+
+An agent operating a deterministic layer (data model, repositories, API/GraphQL contract,
+provider ACL, deploy manifests) may run at **high autonomy**: its correctness is checkable
+against a fixed rule or schema. An agent operating a non-deterministic layer (canvas /
+visual rendering, voice, RAG, LLM prompting) runs **assisted only** — output requires human
+judgment, so it gets no prescriptive skill and every result is validated before it lands.
+
+Consequences:
+- High-autonomy agents still obey per-action gates: infra/deploy agents **never `apply`
+  automatically** and **never merge to main** (AG-009), whatever their layer autonomy.
+- A non-deterministic layer must not be given a prescriptive rule-skill; its guidance is
+  advisory. Encoding "assisted" as "automatic" is a defect.
+- Each agent declares its layer and autonomy tier (`high` | `assisted`) in its manifest
+  (AG-001), so the grading is auditable, not implicit.
+
 ## 2. CI gates (progressive rollout)
 
 Add as `info`, promote to `warning`, then `error` once existing debt is cleared:
@@ -97,4 +116,6 @@ Add as `info`, promote to `warning`, then `error` once existing debt is cleared:
 - capability manifest validation;
 - dry-run, idempotency, timeout, and rollback tests;
 - R3–R5 actions requiring the expected confirmation;
-- evaluation-set non-regression on critical AI tasks (AG-013).
+- evaluation-set non-regression on critical AI tasks (AG-013);
+- agent manifest declares layer + autonomy tier, non-deterministic layers stay `assisted` (AG-016);
+- `.env` secret files staged or present in the tree (AG-005, `check-no-env-files.cjs --ci`).


### PR DESCRIPTION
Integrates the reusable concepts from the Rain-devkit audit (2026-08-08) into the canon.
All additive; no fleet fan-out in this PR (see note).

## What
- **Profile-based clone** — `repos.yml` gains a `profiles:` block (front/back/ai/infra/lib/config, curated from real repo descriptions) + `scripts/clone-profile.sh`: `clone-profile.sh front --dir ~/work` clones only that role's repos. `full` delegates to `list-dev-repos.sh`.
- **`check-no-env-files.cjs` hook** — enforces **AG-005** (secrets out of git): blocks a commit staging a `.env` secret (exit 2), plus a `--ci` scan mode (exit 1). Allows `*.env.example|sample|template|dist`; allowlist `.claude/no-env-allowlist.json`. Wired in `settings.json`, documented in `HOOKS_README` + CLAUDE.md Key Hooks.
- **AG-016** (`AGENTIC-CAPABILITIES.md`) — agent autonomy scales with **layer determinism** (data/GraphQL = high; canvas/AI = assisted, no prescriptive skill). Extends AG-003 (action-risk) with layer-risk. + 2 CI-gate bullets.
- **ADR D-0009** (`DECISIONS.md`, status `proposed`) — per-repo inlining vs a centralised Claude plugin. Recommends **against** the Rain symlink model; proposes evaluating a fleet plugin (herdr-style) with a refutable kill-test.

## Verification
- `node --check` on the hook, `bash -n` on the script, JSON valid on settings.
- Hook: blocks `.env` (exit 2), allows `.env.example` (exit 0), `--ci` exits 1 on a planted `.env`.
- `clone-profile.sh --list` / `--dry-run` OK; `full` = 59 dev repos.
- `list-dev-repos.sh` still parses `repos.yml` unchanged.

## Note — hook fan-out is NOT in this PR
`distribute-standards.sh` currently carries the CLAUDE.md block + skills + agents + workflows, **not** `.claude/hooks/`. Propagating `check-no-env` to consumer repos needs a separate mechanism change (teach distribute-standards to sync hooks + merge the settings entry) — deliberately out of scope here, tracked as follow-up. This PR lands the concept in the canon.