### PR TITLE
fix(standards): clone-profile parses yaml-sorter block format

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -1,309 +1,356 @@
-# repos.yml — chrysa repo classification for config normalization (OPS-190).
-# Generated 2026-06-06 from gh repo list chrysa + local checkout. Hand-tune as needed.
-# status: dev (apply full standard) | non-dev (config/static, skip CI+Docker) | archived (skip).
-# public: true emits LICENSE (MIT); false skips it.
-# runtime: container-runtime policy — "projects run ONLY in containers unless nature forbids".
-#   container       — runs as a service; MUST ship Dockerfile(s) + compose + HEALTHCHECK + docker-up/down/test.
-#   exempt:lib      — distributed/imported (lib, plugin, pre-commit hook, GitHub Action, CLI tool); keep docker-test only.
-#   exempt:config   — no executable runtime (config, knowledge/Obsidian, deployment manifests, container-def collections).
-#   exempt:native   — bound to host OS / device / cloud platform / editor (Windows, webcam, GAS, VS Code ext, infra/Helm).
-#   pending         — pre-code scaffold; flips to `container` once app code lands (enforced at first code via project-init).
-#   Audited by audit-docker-compliance.sh. See standards/STANDARDS.chrysa.md (Container-runtime policy).
-repos:
-  - name: agent-config
-    status: dev
-    public: false
-    runtime: exempt:config
-  - name: ai-aggregator
-    status: dev
-    public: false
-    runtime: container
-  - name: audit-platform
-    status: dev
-    public: false
-    runtime: container
-  - name: automations
-    status: dev
-    public: false
-    runtime: exempt:native
-  - name: catalog
-    status: dev
-    public: false
-    runtime: exempt:config
-  - name: cdn-explorer
-    status: dev
-    public: true
-    runtime: container
-  - name: chrysa-knowledge
-    status: archived
-    public: false
-    runtime: exempt:config
-  - name: chrysa-lib
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: chrysa-portfolio-viz
-    status: dev
-    public: false
-    runtime: container
-  - name: chrysa-skills
-    status: dev
-    public: false
-    runtime: exempt:config
-  - name: claude-config
-    status: dev
-    public: false
-    runtime: exempt:config
-  - name: coach
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: container-webview
-    status: dev
-    public: true
-    runtime: container
-  - name: D-D
-    status: dev
-    public: false
-    runtime: container
-  - name: dev-nexus
-    status: dev
-    public: false
-    runtime: container
-  - name: devtool
-    status: dev
-    public: false
-    runtime: container
-  - name: discord-bot-back
-    status: dev
-    public: false
-    runtime: container
-  - name: discordium
-    status: dev
-    public: false
-    runtime: container
-  - name: diy-stream-deck
-    status: dev
-    public: true
-    runtime: exempt:native
-  - name: django-app-forge
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: django-autoload
-    status: dev
-    public: true
-    runtime: exempt:lib
-  - name: django-pytest
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: django-query-optimizer
-    status: dev
-    public: true
-    runtime: exempt:lib
-  - name: django-query-optimizer-vscode
-    status: dev
-    public: true
-    runtime: exempt:native
-  - name: django-traceid
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: doc-gen
-    status: dev
-    public: false
-    runtime: container
-  - name: dotfiles
-    status: non-dev
-    public: false
-    runtime: exempt:config
-  - name: epub-sorter
-    status: dev
-    public: true
-    runtime: exempt:lib
-  - name: fastapi-autoload
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: fastapi-pytest
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: fastapi-query-optimizer
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: fastapi-traceid
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: feedback-gateway
-    status: dev
-    public: false
-    runtime: container
-  - name: floating-agent
-    status: dev
-    public: true
-    runtime: exempt:native
-  - name: game-solver-platform
-    status: archived
-    public: false
-    runtime: exempt:config
-  - name: gaming-os
-    status: dev
-    public: false
-    runtime: container
-  - name: genealogy-validator
-    status: dev
-    public: false
-    runtime: container
-  - name: gestureOS
-    status: dev
-    public: true
-    runtime: exempt:native
-  - name: github-actions
-    status: dev
-    public: true
-    runtime: exempt:config
-  - name: guideline-checker
-    status: dev
-    public: true
-    runtime: exempt:lib
-  - name: homeassistant-config
-    status: non-dev
-    public: false
-    runtime: exempt:config
-  - name: lifeos
-    status: dev
-    public: true
-    runtime: exempt:native
-  - name: linkendin-resume
-    status: dev
-    public: true
-    runtime: container
-  - name: link-reader-bot
-    status: dev
-    public: false
-    runtime: container
-  - name: mediavault
-    status: dev
-    public: false
-    runtime: exempt:config
-  - name: mirrador
-    status: dev
-    public: false
-    runtime: container
-  - name: my-assistant
-    status: alias
-    public: false
-    alias_of: lifeos
-    runtime: exempt:native
-  - name: my-resume
-    status: archived
-    public: false
-    runtime: container
-  - name: orchestrator
-    status: archived
-    public: false
-    runtime: exempt:config
-  - name: paperclip
-    status: archived
-    public: false
-    runtime: exempt:config
-  - name: PO-GO-DEX
-    status: dev
-    public: false
-    runtime: container
-  - name: pre-commit-hooks-changelog
-    status: dev
-    public: true
-    runtime: exempt:lib
-  - name: pre-commit-tools
-    status: dev
-    public: true
-    runtime: exempt:lib
-  - name: project-init
-    status: dev
-    public: true
-    runtime: exempt:lib
-  - name: quality-gatekeeper
-    status: dev
-    public: false
-    runtime: pending
-  - name: satisfactory-automated_calculator
-    status: archived
-    public: true
-    runtime: exempt:native
-  - name: satisfactory-factory-manager
-    status: dev
-    public: false
-    runtime: container
-  - name: server
-    status: dev
-    public: false
-    runtime: exempt:native
-  - name: shared-standards
-    status: dev
-    public: true
-    runtime: exempt:config
-  - name: sport-intelligence-hub
-    status: dev
-    public: false
-    runtime: container
-  - name: studioverse
-    status: dev
-    public: false
-    runtime: container
-  - name: usefull-containers
-    status: dev
-    public: true
-    runtime: exempt:config
-  - name: workstation-os
-    status: dev
-    public: false
-    runtime: exempt:native
-  - name: windows-docker-state-notification
-    status: dev
-    public: false
-    runtime: exempt:native
-  - name: debian-guardian
-    status: dev
-    public: false
-    runtime: exempt:native
-  - name: django-migration-analyzer
-    status: dev
-    public: false
-    runtime: exempt:lib
-  - name: windows-guardian
-    status: dev
-    public: false
-    runtime: exempt:native
-  - name: wsmqtt-monitor
-    status: dev
-    public: false
-    runtime: container
-
-# ── profiles ──────────────────────────────────────────────────────────────────
-# Role-scoped clone sets, consumed by scripts/clone-profile.sh (Rain-devkit model:
-# a front dev never clones the libs, an infra dev never clones the React apps).
-# `full` is NOT listed here — it resolves to every status:dev repo via list-dev-repos.sh.
-#
-# Curated 2026-08-08 from real repo descriptions + primary language. A repo may sit in
-# several profiles (a fullstack app is both `front` and `back`). `lib` and `config` track
-# the `runtime:` tiers above; `front`/`back`/`ai`/`infra` are by product nature. Membership
-# is inline lists so the awk parser in clone-profile.sh can read them. Keep names in sync
-# with the entries above. Judgment calls flagged inline.
 profiles:
-  # reusable dev bricks (runtime: exempt:lib) — imported, not run standalone
-  lib: [chrysa-lib, django-app-forge, django-autoload, django-pytest, django-query-optimizer, django-traceid, django-migration-analyzer, epub-sorter, fastapi-autoload, fastapi-pytest, fastapi-query-optimizer, fastapi-traceid, guideline-checker, pre-commit-hooks-changelog, pre-commit-tools, project-init]
-  # config / knowledge / manifests / Claude-config (runtime: exempt:config)
-  config: [agent-config, catalog, chrysa-skills, claude-config, chrysa-claude-template, dotfiles, github-actions, homeassistant-config, projects-claude-config, usefull-containers, shared-standards]
-  # UI-primary apps (web front-end is the main deliverable)
-  front: [chrysa-portfolio-viz, container-webview, dev-nexus, devtool, gaming-os, cdn-explorer, discordium, studioverse, mediavault, D-D, PO-GO-DEX, linkendin-resume, my-resume, diy-stream-deck, wsmqtt-monitor, guideline-checker]
-  # back-end services / APIs (FastAPI/Django services, gateways, bots)
-  back: [ai-aggregator, audit-platform, discord-bot-back, discordium, feedback-gateway, link-reader-bot, mirrador, genealogy-validator, sport-intelligence-hub, doc-gen, content-organizer, wsmqtt-monitor, daedalus-document-factory]
-  # LLM / AI-centric products (inference, RAG, observability, assistants)
-  ai: [ai-aggregator, mirrador, content-organizer, doc-gen, floating-agent, lifeos, coach, daedalus-document-factory, dev-nexus]
-  # deployment / host / fleet tooling / observability
-  infra: [catalog, server, github-actions, shared-standards, dotfiles, project-init, agent-config, claude-config, projects-claude-config, chrysa-claude-template]
+  ai:
+  - ai-aggregator
+  - mirrador
+  - content-organizer
+  - doc-gen
+  - floating-agent
+  - lifeos
+  - coach
+  - daedalus-document-factory
+  - dev-nexus
+  back:
+  - ai-aggregator
+  - audit-platform
+  - discord-bot-back
+  - discordium
+  - feedback-gateway
+  - link-reader-bot
+  - mirrador
+  - genealogy-validator
+  - sport-intelligence-hub
+  - doc-gen
+  - content-organizer
+  - wsmqtt-monitor
+  - daedalus-document-factory
+  config:
+  - agent-config
+  - catalog
+  - chrysa-skills
+  - claude-config
+  - chrysa-claude-template
+  - dotfiles
+  - github-actions
+  - homeassistant-config
+  - projects-claude-config
+  - usefull-containers
+  - shared-standards
+  front:
+  - chrysa-portfolio-viz
+  - container-webview
+  - dev-nexus
+  - devtool
+  - gaming-os
+  - cdn-explorer
+  - discordium
+  - studioverse
+  - mediavault
+  - D-D
+  - PO-GO-DEX
+  - linkendin-resume
+  - my-resume
+  - diy-stream-deck
+  - wsmqtt-monitor
+  - guideline-checker
+  infra:
+  - catalog
+  - server
+  - github-actions
+  - shared-standards
+  - dotfiles
+  - project-init
+  - agent-config
+  - claude-config
+  - projects-claude-config
+  - chrysa-claude-template
+  lib:
+  - chrysa-lib
+  - django-app-forge
+  - django-autoload
+  - django-pytest
+  - django-query-optimizer
+  - django-traceid
+  - django-migration-analyzer
+  - epub-sorter
+  - fastapi-autoload
+  - fastapi-pytest
+  - fastapi-query-optimizer
+  - fastapi-traceid
+  - guideline-checker
+  - pre-commit-hooks-changelog
+  - pre-commit-tools
+  - project-init
+repos:
+- name: agent-config
+  public: false
+  runtime: exempt:config
+  status: dev
+- name: ai-aggregator
+  public: false
+  runtime: container
+  status: dev
+- name: audit-platform
+  public: false
+  runtime: container
+  status: dev
+- name: automations
+  public: false
+  runtime: exempt:native
+  status: dev
+- name: catalog
+  public: false
+  runtime: exempt:config
+  status: dev
+- name: cdn-explorer
+  public: true
+  runtime: container
+  status: dev
+- name: chrysa-knowledge
+  public: false
+  runtime: exempt:config
+  status: archived
+- name: chrysa-lib
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: chrysa-portfolio-viz
+  public: false
+  runtime: container
+  status: dev
+- name: chrysa-skills
+  public: false
+  runtime: exempt:config
+  status: dev
+- name: claude-config
+  public: false
+  runtime: exempt:config
+  status: dev
+- name: coach
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: container-webview
+  public: true
+  runtime: container
+  status: dev
+- name: D-D
+  public: false
+  runtime: container
+  status: dev
+- name: dev-nexus
+  public: false
+  runtime: container
+  status: dev
+- name: devtool
+  public: false
+  runtime: container
+  status: dev
+- name: discord-bot-back
+  public: false
+  runtime: container
+  status: dev
+- name: discordium
+  public: false
+  runtime: container
+  status: dev
+- name: diy-stream-deck
+  public: true
+  runtime: exempt:native
+  status: dev
+- name: django-app-forge
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: django-autoload
+  public: true
+  runtime: exempt:lib
+  status: dev
+- name: django-pytest
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: django-query-optimizer
+  public: true
+  runtime: exempt:lib
+  status: dev
+- name: django-query-optimizer-vscode
+  public: true
+  runtime: exempt:native
+  status: dev
+- name: django-traceid
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: doc-gen
+  public: false
+  runtime: container
+  status: dev
+- name: dotfiles
+  public: false
+  runtime: exempt:config
+  status: non-dev
+- name: epub-sorter
+  public: true
+  runtime: exempt:lib
+  status: dev
+- name: fastapi-autoload
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: fastapi-pytest
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: fastapi-query-optimizer
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: fastapi-traceid
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: feedback-gateway
+  public: false
+  runtime: container
+  status: dev
+- name: floating-agent
+  public: true
+  runtime: exempt:native
+  status: dev
+- name: game-solver-platform
+  public: false
+  runtime: exempt:config
+  status: archived
+- name: gaming-os
+  public: false
+  runtime: container
+  status: dev
+- name: genealogy-validator
+  public: false
+  runtime: container
+  status: dev
+- name: gestureOS
+  public: true
+  runtime: exempt:native
+  status: dev
+- name: github-actions
+  public: true
+  runtime: exempt:config
+  status: dev
+- name: guideline-checker
+  public: true
+  runtime: exempt:lib
+  status: dev
+- name: homeassistant-config
+  public: false
+  runtime: exempt:config
+  status: non-dev
+- name: lifeos
+  public: true
+  runtime: exempt:native
+  status: dev
+- name: linkendin-resume
+  public: true
+  runtime: container
+  status: dev
+- name: link-reader-bot
+  public: false
+  runtime: container
+  status: dev
+- name: mediavault
+  public: false
+  runtime: exempt:config
+  status: dev
+- name: mirrador
+  public: false
+  runtime: container
+  status: dev
+- alias_of: lifeos
+  name: my-assistant
+  public: false
+  runtime: exempt:native
+  status: alias
+- name: my-resume
+  public: false
+  runtime: container
+  status: archived
+- name: orchestrator
+  public: false
+  runtime: exempt:config
+  status: archived
+- name: paperclip
+  public: false
+  runtime: exempt:config
+  status: archived
+- name: PO-GO-DEX
+  public: false
+  runtime: container
+  status: dev
+- name: pre-commit-hooks-changelog
+  public: true
+  runtime: exempt:lib
+  status: dev
+- name: pre-commit-tools
+  public: true
+  runtime: exempt:lib
+  status: dev
+- name: project-init
+  public: true
+  runtime: exempt:lib
+  status: dev
+- name: quality-gatekeeper
+  public: false
+  runtime: pending
+  status: dev
+- name: satisfactory-automated_calculator
+  public: true
+  runtime: exempt:native
+  status: archived
+- name: satisfactory-factory-manager
+  public: false
+  runtime: container
+  status: dev
+- name: server
+  public: false
+  runtime: exempt:native
+  status: dev
+- name: shared-standards
+  public: true
+  runtime: exempt:config
+  status: dev
+- name: sport-intelligence-hub
+  public: false
+  runtime: container
+  status: dev
+- name: studioverse
+  public: false
+  runtime: container
+  status: dev
+- name: usefull-containers
+  public: true
+  runtime: exempt:config
+  status: dev
+- name: workstation-os
+  public: false
+  runtime: exempt:native
+  status: dev
+- name: windows-docker-state-notification
+  public: false
+  runtime: exempt:native
+  status: dev
+- name: debian-guardian
+  public: false
+  runtime: exempt:native
+  status: dev
+- name: django-migration-analyzer
+  public: false
+  runtime: exempt:lib
+  status: dev
+- name: windows-guardian
+  public: false
+  runtime: exempt:native
+  status: dev
+- name: wsmqtt-monitor
+  public: false
+  runtime: container
+  status: dev

--- a/scripts/clone-profile.sh
+++ b/scripts/clone-profile.sh
@@ -50,46 +50,39 @@ done
 
 [ -f "$REPOS_YML" ] || die "repos.yml not found: $REPOS_YML"
 
-# Extract the `profiles:` block members for a profile name.
-# Block shape in repos.yml:
+# Extract the `profiles:` block members for a profile name. The block is stored in the
+# yaml-sorter canonical shape (block sequences, keys sorted), e.g.:
 #   profiles:
-#     front: [dashboard, my-resume, ...]
-#     back:  [ai-aggregator, ...]
+#     ai:
+#     - ai-aggregator
+#     - mirrador
+#     back:
+#     - audit-platform
+# A profile header is a 2-space-indented `name:`; members are `- value` lines beneath it,
+# until the next header or the end of the block (`repos:` / any unindented key).
 profile_members() {
   awk -v want="$1" '
-    /^profiles:/ { inblk=1; next }
-    inblk && /^[a-zA-Z]/ { inblk=0 }          # left the block (next top-level key)
+    $0 ~ /^profiles:[[:space:]]*$/ { inblk=1; next }
+    inblk && /^[^[:space:]]/ { inblk=0 }        # unindented key (e.g. repos:) → block ended
     inblk {
-      line=$0
-      sub(/^[[:space:]]+/, "", line)
-      if (line ~ /^#/ || line == "") next     # skip comments / blank lines
-      # match "name: [ ... ]" or "name:" continued — we only support inline lists here
-      if (line ~ "^" want ":") {
-        sub("^" want ":[[:space:]]*", "", line)
-        gsub(/[][]/, "", line)
-        gsub(/,/, " ", line)
-        print line
-      }
+      if ($1 ~ /^[A-Za-z0-9_-]+:$/) { cur=$1; sub(/:$/, "", cur); next }  # profile header
+      if ($1 == "-" && cur == want) { print $2 }                          # member line
     }
   ' "$REPOS_YML"
 }
 
 profile_names() {
   awk '
-    /^profiles:/ { inblk=1; next }
-    inblk && /^[a-zA-Z]/ { inblk=0 }
-    inblk {
-      line=$0; sub(/^[[:space:]]+/, "", line)
-      if (line ~ /^#/ || line == "") next
-      if (line ~ /:/) { sub(/:.*/, "", line); print line }
-    }
+    $0 ~ /^profiles:[[:space:]]*$/ { inblk=1; next }
+    inblk && /^[^[:space:]]/ { inblk=0 }
+    inblk && $1 ~ /^[A-Za-z0-9_-]+:$/ { n=$1; sub(/:$/, "", n); print n }
   ' "$REPOS_YML"
 }
 
 if [ "$LIST" -eq 1 ]; then
   printf '\n  Profiles (from %s):\n\n' "$REPOS_YML"
   for p in $(profile_names); do
-    printf '  \033[36m%-8s\033[0m %s\n' "$p" "$(profile_members "$p")"
+    printf '  \033[36m%-8s\033[0m %s\n' "$p" "$(profile_members "$p" | tr '\n' ' ')"
   done
   printf '\n'
   exit 0

--- a/scripts/sync-claude-hook.sh
+++ b/scripts/sync-claude-hook.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# sync-claude-hook.sh — install/refresh ONE transverse Claude hook into a target repo.
+#
+# distribute-standards.sh fans out the CLAUDE.md block + skills + agents + workflows, but
+# NOT `.claude/hooks/`. This script fills that gap for a single hook, idempotently: it copies
+# the hook file from shared-standards and wires it into the repo's settings.json under the
+# right lifecycle event, without disturbing the repo's other hooks or settings.
+#
+# Scope kept to one hook on purpose — a blocking commit hook is fanned out canary-first, not
+# in a fleet-wide sweep. Once validated it can be called per-repo by the distribute Action.
+#
+# Usage:
+#   sync-claude-hook.sh <repo_path> [--hook NAME] [--event EVENT] [--matcher M] [--dry-run]
+#
+#   defaults: --hook check-no-env-files  --event PreToolUse  --matcher Bash
+#
+# Exit: 0 ok / no change · 1 error · 2 repo or hook source missing
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STD_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_SRC="$STD_ROOT/.claude/hooks"
+
+REPO=""
+HOOK="check-no-env-files"
+EVENT="PreToolUse"
+MATCHER="Bash"
+DRY=0
+
+die() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit "${2:-1}"; }
+info() { printf '\033[36m•\033[0m %s\n' "$*"; }
+ok() { printf '\033[32m✓\033[0m %s\n' "$*"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --hook) shift; HOOK="${1:?}" ;;
+    --event) shift; EVENT="${1:?}" ;;
+    --matcher) shift; MATCHER="${1:?}" ;;
+    --dry-run) DRY=1 ;;
+    -h|--help) sed -n '2,16p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    -*) die "unknown flag: $1" 2 ;;
+    *) REPO="$1" ;;
+  esac
+  shift
+done
+
+[ -n "$REPO" ] || die "missing <repo_path>" 2
+[ -d "$REPO/.git" ] || die "not a git repo: $REPO" 2
+command -v jq >/dev/null || die "jq required" 1
+
+SRC="$HOOKS_SRC/$HOOK.cjs"
+[ -f "$SRC" ] || die "hook source not found: $SRC" 2
+
+SETTINGS="$REPO/.claude/settings.json"
+[ -f "$SETTINGS" ] || die "no settings.json in $REPO/.claude (bootstrap the repo first)" 2
+
+DEST="$REPO/.claude/hooks/$HOOK.cjs"
+CMD="sh -c 'f=\"\$CLAUDE_PROJECT_DIR/.claude/hooks/$HOOK.cjs\"; [ ! -f \"\$f\" ] || node \"\$f\"'"
+
+info "repo=$REPO  hook=$HOOK  event=$EVENT  matcher=$MATCHER  dry-run=$DRY"
+
+# 1) hook file — copy if absent or changed.
+file_action="up-to-date"
+if [ ! -f "$DEST" ] || ! cmp -s "$SRC" "$DEST"; then
+  file_action="copy"
+fi
+
+# 2) settings.json — is the hook already wired under EVENT/MATCHER?
+already_wired=$(jq --arg e "$EVENT" --arg m "$MATCHER" --arg n "$HOOK" '
+  [.hooks[$e][]? | select(.matcher==$m) | .hooks[]? | select(.name==$n)] | length > 0
+' "$SETTINGS")
+
+settings_action="present"
+[ "$already_wired" = "true" ] || settings_action="add-entry"
+
+# Guard: the target event/matcher block must exist to append into.
+block_exists=$(jq --arg e "$EVENT" --arg m "$MATCHER" '
+  [.hooks[$e][]? | select(.matcher==$m)] | length > 0
+' "$SETTINGS")
+if [ "$settings_action" = "add-entry" ] && [ "$block_exists" != "true" ]; then
+  die "no $EVENT block with matcher=$MATCHER in $SETTINGS — repo settings shape differs, wire manually" 1
+fi
+
+info "plan: hook-file=$file_action  settings=$settings_action"
+
+if [ "$DRY" -eq 1 ]; then
+  ok "dry-run — nothing written"
+  exit 0
+fi
+
+# Apply file.
+if [ "$file_action" = "copy" ]; then
+  mkdir -p "$REPO/.claude/hooks"
+  cp "$SRC" "$DEST"
+  ok "hook file synced: $DEST"
+fi
+
+# Apply settings (idempotent append into the matching block).
+if [ "$settings_action" = "add-entry" ]; then
+  tmp="$(mktemp)"
+  jq --arg e "$EVENT" --arg m "$MATCHER" --arg n "$HOOK" --arg cmd "$CMD" '
+    .hooks[$e] |= (map(
+      if .matcher==$m
+      then .hooks += [{command:$cmd, name:$n, timeout:5000, type:"command"}]
+      else . end
+    ))
+  ' "$SETTINGS" > "$tmp" && mv "$tmp" "$SETTINGS"
+  ok "settings.json wired: $EVENT/$MATCHER += $HOOK"
+fi
+
+ok "done: $REPO"


### PR DESCRIPTION
Follow-up to #393. The `sort yaml files` hook rewrote the `profiles:` block to canonical block sequences (and hoisted it above `repos:`), which broke the inline-only awk parser and left #393 un-sorted (pre-commit red).

**Fix:** parser reads the canonical block format (`profile_members`/`profile_names`); repos.yml committed already-sorted so the gate passes.

**Verified:** `--list` clean, `front`=16, `full`=59, `sort yaml files` Passed locally.

Closes #394