### PR TITLE
feat(standards): external servers via env + reactive real-time frontends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,20 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   (`role="alert"` / `role="status"`) and its behaviour is tested against a network error and a
   503. A frontend Definition of Done includes its **API-down state**. Detail: annexe
   `FRONTEND.md` FE-050.
+- **The frontend is reactive and real-time by default.** A human-facing surface reflects the
+  true state of the system as soon as it changes — the user never stares at stale data and never
+  reaches for a manual refresh to find out what happened. Server state is owned by the cache layer
+  (TanStack Query) and kept fresh: a mutation invalidates or optimistically updates the queries it
+  affects, and data that a *different* actor (another user, a job, a device) can change is
+  **pushed, not polled** — a live transport (WebSocket / SSE) updates the UI in place, with polling
+  as a bounded fallback only where a push channel is genuinely unavailable. The interface reacts
+  immediately to input (optimistic UI, debounced derived state, no blocking spinner for a
+  sub-second action) and reconciles with the server result, rolling back visibly on failure. Live
+  updates propagate across the app's own tabs and on refocus (see *UI state survives reload &
+  focus*). Real-time is **layered over a correct offline/degraded state**, not a substitute for it:
+  losing the live channel degrades to the last known state with the API-down banner (FE-050), never
+  to a frozen or lying screen. A surface that shows data a refresh would change is a defect. Detail:
+  annexe `FRONTEND.md` FE-080.
 - **Every repo declares its profile and DDD level** (`project_profile`, `ddd_level`,
   `bounded_context`, `standards_version`) — architecture is proportionate to business
   complexity, and small tools are not over-architected. Detail: annexe `ARCHITECTURE-DDD.md`.
@@ -576,6 +590,21 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   particular machine, user account, or local directory layout. The test is mechanical: a fresh
   clone on an unknown machine, with git + Docker + pre-commit, must reach a green
   `make ci` — if it needs a manual step that only the owner knows, that is a defect.
+- **Every external server the service talks to is addressed through the environment — never
+  hardcoded.** The location and credentials of anything the service does not itself own — a
+  database, cache, broker, object store, another chrysa service's API, a third-party endpoint, an
+  SSO/OIDC issuer, an LLM or inference host — arrive as **environment variables** (host, port, URL,
+  DSN, region, secret), read once through the typed config loader (Pydantic Settings on the
+  backend, the generated typed env module on the frontend), with a committed `.env.example`
+  documenting every key and safe local defaults. A hostname, IP, port, or connection string of an
+  external server written as a literal in code, a compose file, or a manifest is a defect: it pins
+  the build to one environment and breaks *build once, promote the artefact* — the same image can
+  no longer travel from local to CI to prod, because its endpoints are baked in. This is the
+  transport-level twin of *no hardcoded constants* and of the *adaptation layer*: the endpoint is
+  configuration, the client wrapping it is an adapter, and between two chrysa projects the endpoint
+  still resolves to a versioned contract, not a private address (*projects talk through versioned
+  contracts only*). Secrets travel by env or a secrets manager, never committed (see the `.env`
+  rules) — the variable holds the value, the repo holds only the documented key.
 - **External dependencies are installed in containers, never on the host.** A project's
   runtime dependencies — language packages (pip/npm/cargo/nuget), databases, brokers, caches,
   system libraries, compilers, CLIs a service shells out to — are declared in the image
@@ -1305,9 +1334,19 @@ those rules must satisfy, and certification is a governance program on top, not 
 Five non-negotiables hold across every chrysa project, whatever the stack. Breaking one
 requires an ADR with a kill-test, not a shrug.
 
-1. **LLM-provider independence** — no vendor SDK in business code; inference goes through a
-   local port with **≥2 real, tested adapters** (e.g. Claude + a local model). A prompt that
-   only works on one vendor is a bug, not a feature.
+1. **LLM-provider independence & local-first routing** — no vendor SDK in business code;
+   inference goes through a local port with **≥2 real, tested adapters** (e.g. a local model
+   + Claude). A prompt that only works on one vendor is a bug, not a feature. Beyond mere
+   independence, every AI-using project is **multi-model by construction** and ships a
+   **local model as the default provider** — the product must run useful with zero cloud
+   credentials and no network to any vendor (tested with the network disabled, like the
+   offline-game rule). Cloud providers are an **opt-in upgrade**, never a hard dependency.
+   Provider selection goes through a **configurable multi-LLM routing layer** (config/env,
+   not code): the operator can route per task, cost, latency, context size, and data
+   sensitivity, add or reorder providers, and set fallback order — all without a redeploy.
+   Sending data to an external model is off by default and requires a documented
+   authorisation (see annexe AG, rule AG-011). Shipping an AI feature that is single-model,
+   cloud-only, or whose provider/routing is hard-coded is a pillar-1 breach needing an ADR.
 2. **GAFAM independence** — every managed-cloud dependency has a documented self-hosted exit
    path; the cloud SDK stays confined to an adapter (`BlobStore`, not `S3Client`).
 3. **Portable personalisation data** — all user/personal data is exportable to an open format

--- a/standards/STANDARDS.chrysa.md
+++ b/standards/STANDARDS.chrysa.md
@@ -143,6 +143,20 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   (`role="alert"` / `role="status"`) and its behaviour is tested against a network error and a
   503. A frontend Definition of Done includes its **API-down state**. Detail: annexe
   `FRONTEND.md` FE-050.
+- **The frontend is reactive and real-time by default.** A human-facing surface reflects the
+  true state of the system as soon as it changes — the user never stares at stale data and never
+  reaches for a manual refresh to find out what happened. Server state is owned by the cache layer
+  (TanStack Query) and kept fresh: a mutation invalidates or optimistically updates the queries it
+  affects, and data that a *different* actor (another user, a job, a device) can change is
+  **pushed, not polled** — a live transport (WebSocket / SSE) updates the UI in place, with polling
+  as a bounded fallback only where a push channel is genuinely unavailable. The interface reacts
+  immediately to input (optimistic UI, debounced derived state, no blocking spinner for a
+  sub-second action) and reconciles with the server result, rolling back visibly on failure. Live
+  updates propagate across the app's own tabs and on refocus (see *UI state survives reload &
+  focus*). Real-time is **layered over a correct offline/degraded state**, not a substitute for it:
+  losing the live channel degrades to the last known state with the API-down banner (FE-050), never
+  to a frozen or lying screen. A surface that shows data a refresh would change is a defect. Detail:
+  annexe `FRONTEND.md` FE-080.
 - **Every repo declares its profile and DDD level** (`project_profile`, `ddd_level`,
   `bounded_context`, `standards_version`) — architecture is proportionate to business
   complexity, and small tools are not over-architected. Detail: annexe `ARCHITECTURE-DDD.md`.
@@ -432,6 +446,21 @@ deprecated and archived — nothing is added to it, nothing reads from it.
   particular machine, user account, or local directory layout. The test is mechanical: a fresh
   clone on an unknown machine, with git + Docker + pre-commit, must reach a green
   `make ci` — if it needs a manual step that only the owner knows, that is a defect.
+- **Every external server the service talks to is addressed through the environment — never
+  hardcoded.** The location and credentials of anything the service does not itself own — a
+  database, cache, broker, object store, another chrysa service's API, a third-party endpoint, an
+  SSO/OIDC issuer, an LLM or inference host — arrive as **environment variables** (host, port, URL,
+  DSN, region, secret), read once through the typed config loader (Pydantic Settings on the
+  backend, the generated typed env module on the frontend), with a committed `.env.example`
+  documenting every key and safe local defaults. A hostname, IP, port, or connection string of an
+  external server written as a literal in code, a compose file, or a manifest is a defect: it pins
+  the build to one environment and breaks *build once, promote the artefact* — the same image can
+  no longer travel from local to CI to prod, because its endpoints are baked in. This is the
+  transport-level twin of *no hardcoded constants* and of the *adaptation layer*: the endpoint is
+  configuration, the client wrapping it is an adapter, and between two chrysa projects the endpoint
+  still resolves to a versioned contract, not a private address (*projects talk through versioned
+  contracts only*). Secrets travel by env or a secrets manager, never committed (see the `.env`
+  rules) — the variable holds the value, the repo holds only the documented key.
 - **External dependencies are installed in containers, never on the host.** A project's
   runtime dependencies — language packages (pip/npm/cargo/nuget), databases, brokers, caches,
   system libraries, compilers, CLIs a service shells out to — are declared in the image

--- a/standards/annexes/FRONTEND.md
+++ b/standards/annexes/FRONTEND.md
@@ -257,6 +257,38 @@ reading empty boxes.
 
 ______________________________________________________________________
 
+## 8. Reactivity & real-time
+
+### FE-080 — Reactive, real-time-first UI
+
+A surface reflects the current state of the system without a manual refresh. The rules:
+
+- **Server state lives in the cache library** (FE-032), never mirrored into component state. A
+  mutation **invalidates or optimistically updates** the queries it affects, so the view that
+  triggered a change and every other view reading the same data converge without a reload.
+- **Push over poll.** Data a *different* actor (another user, a job, a device) can change is
+  delivered over a live transport — **WebSocket or SSE** through a single client in the service
+  layer (FE-031) — and applied to the cache in place. Polling is a **bounded fallback** (fixed
+  interval, backoff, paused when the tab is hidden) used only where no push channel exists; an
+  unbounded or always-on poll against the backend is a defect.
+- **Immediate input feedback.** An action whose result is predictable updates the UI
+  **optimistically** and reconciles with the server response, rolling back visibly on error;
+  derived state recomputes reactively (memoised, debounced for high-frequency input) rather than
+  behind a blocking spinner. Sub-second work never shows a full-screen loader.
+- **Live, but honest.** The real-time layer sits **on top of** the loading/error/empty triad
+  (FE-037) and the API-down contract (FE-050): when the live channel drops, the UI shows the last
+  known state plus the reconnection banner and refetches on recovery — it does not freeze, and it
+  does not present stale data as current.
+- **Cross-tab & focus.** Live updates and cache invalidation propagate across the app's own
+  tabs/windows and on refocus (the socle *UI state survives reload & focus* rule), so a background
+  tab is never left showing a superseded view.
+
+The transport, reconnection, and backpressure details are a realtime concern shared with the
+backend contract; the frontend rule is that the **default posture is reactive** — a screen that
+needs a manual refresh to be correct has a bug, not a missing feature.
+
+______________________________________________________________________
+
 ## Deferred (not canon yet)
 
 Listed so they are not silently lost — these need an arbitration before becoming rules:


### PR DESCRIPTION
## What

Two new normative socle rules (canonical source `standards/STANDARDS.chrysa.md`), plus detail annexe, plus regenerated inline block in this repo's `CLAUDE.md`.

### 1. External servers addressed through the environment
The location + credentials of any server the service does **not** own (DB, cache, broker, object store, sibling chrysa API, SSO/OIDC issuer, LLM/inference host) come from **env vars** read through the typed config loader (Pydantic Settings / generated typed env module), with a committed `.env.example`. A literal host/IP/port/DSN in code, compose, or a manifest is a defect — it pins the build to one environment and breaks *build once, promote the artefact*. Positioned as the transport-level twin of *no hardcoded constants* + *adaptation layer* + *projects talk through versioned contracts only*.

### 2. Reactive, real-time-first frontends
A human-facing surface reflects true system state without a manual refresh: server state owned by the cache layer, mutations invalidate/optimistically update, **push over poll** (WebSocket/SSE, bounded-poll fallback), immediate optimistic input feedback, cross-tab/focus propagation — **layered over** the offline/degraded API-down contract (FE-050), never a frozen or lying screen. Detail: new annexe **FRONTEND.md FE-080**.

## Files
- `standards/STANDARDS.chrysa.md` — two socle bullets
- `standards/annexes/FRONTEND.md` — new §8 / FE-080
- `CLAUDE.md` — inline standards block regenerated from source

## Distribution
After merge + release (or manual `distribute-standards` dispatch), the fleet picks these up via the per-repo PR fan-out.