### PR TITLE
fix(ci): repair size-label 403 + exempt release promotion from issue-link

### DIFF
--- a/.github/workflows/enforce-issue-link.yml
+++ b/.github/workflows/enforce-issue-link.yml
@@ -8,6 +8,8 @@
 # Exemptions (skip the check):
 #   - Dependabot PRs
 #   - PRs labeled: hotfix, standards-sync, automated
+#   - Release promotion PRs (base main, head develop) — the documented develop→main
+#     promotion carries accumulated work, not a single issue.
 #
 # Make it required: Settings → Branches → branch protection → require "Issue link".
 
@@ -35,6 +37,8 @@ jobs:
             && !contains(github.event.pull_request.labels.*.name, 'hotfix')
             && !contains(github.event.pull_request.labels.*.name, 'standards-sync')
             && !contains(github.event.pull_request.labels.*.name, 'automated')
+            && !(github.event.pull_request.base.ref == 'main'
+                 && github.event.pull_request.head.ref == 'develop')
         steps:
             - name: Require an issue reference in the PR body
               shell: bash

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -1,17 +1,20 @@
 "on": pull_request_target
+name: Label Pull Request Size
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   size-label:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    name: Label PR by size
     steps:
-    - env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      name: Label pull request by size
-      uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        fail_if_xl: false
-        l_max_size: 800
-        m_max_size: 200
-        s_max_size: 50
-        xs_max_size: 20
+      - name: Label pull request by size
+        uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: 20
+          s_max_size: 50
+          m_max_size: 200
+          l_max_size: 800
+          fail_if_xl: false

--- a/templates/workflows-process/pull-request-size.yml
+++ b/templates/workflows-process/pull-request-size.yml
@@ -1,20 +1,20 @@
 "on": pull_request_target
-jobs:
-  size-label:
-    runs-on: ubuntu-latest
-    steps:
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: Label pull request by size
-        uses: pascalgn/size-label-action@56b489b027932ec0cf60438a1a5f1a19c8fc71ff
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          fail_if_xl: false
-          l_max_size: 800
-          m_max_size: 200
-          s_max_size: 50
-          xs_max_size: 20
 name: Label Pull Request Size
 permissions:
   contents: read
   pull-requests: write
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Label PR by size
+    steps:
+      - name: Label pull request by size
+        uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: 20
+          s_max_size: 50
+          m_max_size: 200
+          l_max_size: 800
+          fail_if_xl: false

--- a/workflows/enforce-issue-link.yml
+++ b/workflows/enforce-issue-link.yml
@@ -8,6 +8,8 @@
 # Exemptions (skip the check):
 #   - Dependabot PRs
 #   - PRs labeled: hotfix, standards-sync, automated
+#   - Release promotion PRs (base main, head develop) — the documented develop→main
+#     promotion carries accumulated work, not a single issue.
 #
 # Make it required: Settings → Branches → branch protection → require "Issue link".
 
@@ -30,6 +32,8 @@ jobs:
             && !contains(github.event.pull_request.labels.*.name, 'hotfix')
             && !contains(github.event.pull_request.labels.*.name, 'standards-sync')
             && !contains(github.event.pull_request.labels.*.name, 'automated')
+            && !(github.event.pull_request.base.ref == 'main'
+                 && github.event.pull_request.head.ref == 'develop')
         steps:
             - name: Require an issue reference in the PR body
               shell: bash


### PR DESCRIPTION
Repairs two CI-gate defects (repo + distributed templates).

1. **size-label** — swap mis-configured pascalgn/size-label-action (invalid inputs, no permissions → 403 on label POST) for codelytv/pr-size-labeler + `permissions: pull-requests: write`.
2. **enforce-issue-link** — exempt the documented develop→main release-promotion PR (base main, head develop).

Sonar red on promotion #400 is separate backlog, out of scope.

Closes #401